### PR TITLE
Stability improvements for multicomponent surface model

### DIFF
--- a/isofit/inverse_simple.py
+++ b/isofit/inverse_simple.py
@@ -82,7 +82,7 @@ def heuristic_atmosphere(RT, instrument, x_RT, x_instrument,  meas, geom):
         bounds = (h2os[0]+0.001, h2os[-1]-0.001)
         best = min1d(lambda h: abs(1-p(h)), bounds=bounds, method='bounded')
         x_new[ind_sv] = best.x
-    return x_RT
+    return x_new
 
 
 def invert_algebraic(surface, RT, instrument, x_surface, x_RT, x_instrument,
@@ -166,4 +166,6 @@ def invert_simple(forward, meas, geom):
     # models, etc.)
 
     x[forward.idx_surface] = forward.surface.fit_params(rfl_est, Ls_est, geom)
+    geom.x_surf_init = x[forward.idx_surface]
+    geom.x_RT_init = x[forward.idx_RT]
     return x

--- a/isofit/surf_multicomp.py
+++ b/isofit/surf_multicomp.py
@@ -62,6 +62,16 @@ class MultiComponentSurface(Surface):
         except KeyError:
             self.selection_metric = 'Mahalanobis'
 
+        # This field, if present and set to true, forces us to use
+        # any initialization state and never change.  The state is 
+        # preserved in the geometry object so that this object stays
+        # stateless
+        try:
+            self.select_on_init = config['select_on_init']
+        except KeyError:
+            self.select_on_init = False
+
+
         # Reference values are used for normalizing the reflectances.
         # in the VSWIR regime, reflectances are normalized so that the model
         # is agnostic to absolute magnitude.
@@ -88,13 +98,22 @@ class MultiComponentSurface(Surface):
         self.idx_lamb = s.arange(self.n_wl)
         self.n_state = len(self.statevec)
 
-    def component(self, x_surface, geom):
+    def component(self, x, geom):
         """ We pick a surface model component using the Mahalanobis distance.
             This always uses the Lambertian (non-specular) version of the 
-            surface reflectance."""
+            surface reflectance. If the forward model initialize via heuristic
+            (i.e. algebraic inversion), the component is only calculated once
+            based on that first solution.  That state is preserved in the 
+            geometry object"""
 
         if self.n_comp <= 1:
             return 0
+        elif hasattr(geom,'surf_cmp_init'):
+            return geom.surf_cmp_init
+        elif self.select_on_init and hasattr(geom,'x_surf_init'):
+            x_surface = geom.x_surf_init
+        else:
+            x_surface = x
 
         # Get the (possibly normalized) reflectance
         lamb = self.calc_lamb(x_surface, geom)
@@ -112,6 +131,10 @@ class MultiComponentSurface(Surface):
                 md = sum(pow(lamb_ref - ref_mu, 2))
             mds.append(md)
         closest = s.argmin(mds)
+
+        if self.select_on_init and hasattr(geom,'x_surf_init') and \
+            (not hasattr(geom,'surf_cmp_init')):
+            geom.surf_cmp_init = closest
         return closest
 
     def xa(self, x_surface, geom):

--- a/isofit/surf_multicomp.py
+++ b/isofit/surf_multicomp.py
@@ -63,14 +63,13 @@ class MultiComponentSurface(Surface):
             self.selection_metric = 'Mahalanobis'
 
         # This field, if present and set to true, forces us to use
-        # any initialization state and never change.  The state is 
+        # any initialization state and never change.  The state is
         # preserved in the geometry object so that this object stays
         # stateless
         try:
             self.select_on_init = config['select_on_init']
         except KeyError:
             self.select_on_init = False
-
 
         # Reference values are used for normalizing the reflectances.
         # in the VSWIR regime, reflectances are normalized so that the model
@@ -108,9 +107,9 @@ class MultiComponentSurface(Surface):
 
         if self.n_comp <= 1:
             return 0
-        elif hasattr(geom,'surf_cmp_init'):
+        elif hasattr(geom, 'surf_cmp_init'):
             return geom.surf_cmp_init
-        elif self.select_on_init and hasattr(geom,'x_surf_init'):
+        elif self.select_on_init and hasattr(geom, 'x_surf_init'):
             x_surface = geom.x_surf_init
         else:
             x_surface = x
@@ -132,8 +131,8 @@ class MultiComponentSurface(Surface):
             mds.append(md)
         closest = s.argmin(mds)
 
-        if self.select_on_init and hasattr(geom,'x_surf_init') and \
-            (not hasattr(geom,'surf_cmp_init')):
+        if self.select_on_init and hasattr(geom, 'x_surf_init') and \
+                (not hasattr(geom, 'surf_cmp_init')):
             geom.surf_cmp_init = closest
         return closest
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open('README.rst', 'r') as f:
 lic = 'Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)'
 
 setup(name='isofit',
-    version='1.0.4',
+    version='1.0.5',
     url='http://github.com/davidraythompson/isofit/',
     license=lic,
     author='David R. Thompson, Winston Olson-Duvall, and Team',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open('README.rst', 'r') as f:
 lic = 'Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)'
 
 setup(name='isofit',
-    version='1.0.5',
+    version='1.0.6',
     url='http://github.com/davidraythompson/isofit/',
     license=lic,
     author='David R. Thompson, Winston Olson-Duvall, and Team',


### PR DESCRIPTION
This permits the multicomponent surface to avoid recalculating component memberships with each iteration.  Instead it uses the iteration-zero result for the entire retrieval.