### PR TITLE
Permitting RH>100%

### DIFF
--- a/examples/20171108_Pasadena/configs/ang20171108t184227_modtran.json
+++ b/examples/20171108_Pasadena/configs/ang20171108t184227_modtran.json
@@ -20,6 +20,7 @@
           "CO2MX": 450.0,
           "H2OSTR": 0.64,
           "H2OUNIT": "g",
+          "H2OOPT": "+",
           "O3STR": 0.3,
           "O3UNIT": "a"
         },


### PR DESCRIPTION
This allows atmospheres exceeding 100% RH.
Without this, if the h2o level is set to a value resulting with RH>100%, no prompt is given from MODTRAN and the output is of the h2o level resulting with 100% RH.