### PR TITLE
Separate out CLI programs into bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,14 @@
 *.swp
 
 # Ignore files with these names
-.DS_Store 
+.DS_Store
 .idea
 .buildinfo
 .nojekyll
+
+# Ignore folders and their contents with these names
+.vscode
+__pycache__
 
 # Ignore dynamic contents of example directories
 examples/*/*lut/*
@@ -22,7 +26,6 @@ isofit.egg-info/
 .pytest_cache/
 tests/output/*.txt
 
-# Ignore docs files
+# Ignore documentation files
 docs/_build/
 docs/html/_sources/
-

--- a/isofit/.gitignore
+++ b/isofit/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.vscode

--- a/isofit/common.py
+++ b/isofit/common.py
@@ -239,28 +239,29 @@ def get_absorption(wl, absfile):
     return water_abscf_intrp, ice_abscf_intrp
 
 
-def json_load_ascii(filename, shell_replace=True):
+def recursive_reincode(j, shell_replace=True):
+    if isinstance(j, dict):
+        for key, value in j.items():
+            j[key] = recursive_reincode(value)
+        return j
+    elif isinstance(j, list):
+        for i, k in enumerate(j):
+            j[i] = recursive_reincode(k)
+        return j
+    elif isinstance(j, tuple):
+        return tuple([recursive_reincode(k) for k in j])
+    else:
+        if shell_replace and type(j) is str:
+            try:
+                j = expandvars(j)
+            except IndexError:
+                pass
+        return j
+
+
+def json_load_ascii(filename):
     """Load a hierarchical structure, convert all unicode to ASCII and
     expand environment variables"""
-
-    def recursive_reincode(j):
-        if isinstance(j, dict):
-            for key, value in j.items():
-                j[key] = recursive_reincode(value)
-            return j
-        elif isinstance(j, list):
-            for i, k in enumerate(j):
-                j[i] = recursive_reincode(k)
-            return j
-        elif isinstance(j, tuple):
-            return tuple([recursive_reincode(k) for k in j])
-        else:
-            if shell_replace and type(j) is str:
-                try:
-                    j = expandvars(j)
-                except IndexError:
-                    pass
-            return j
 
     with open(filename, 'r') as fin:
         j = json.load(fin)

--- a/isofit/fileio.py
+++ b/isofit/fileio.py
@@ -24,12 +24,12 @@ import scipy as s
 import pylab as plt
 from scipy.linalg import inv, norm, sqrtm, det
 from scipy.io import savemat
-from inverse_simple import invert_simple, invert_algebraic
+from .inverse_simple import invert_simple, invert_algebraic
 from spectral.io import envi
-from common import load_spectrum, eps, resample_spectrum, expand_all_paths
+from .common import load_spectrum, eps, resample_spectrum, expand_all_paths
 import logging
 from collections import OrderedDict
-from geometry import Geometry
+from .geometry import Geometry
 
 
 # Constants related to file I/O

--- a/isofit/forward.py
+++ b/isofit/forward.py
@@ -19,12 +19,12 @@
 #
 
 import scipy as s
-from common import recursive_replace, eps
+from .common import recursive_replace, eps
 from copy import deepcopy
 from scipy.linalg import det, norm, pinv, sqrtm, inv, block_diag
 from importlib import import_module
 from scipy.interpolate import interp1d
-from instrument import Instrument
+from .instrument import Instrument
 
 
 # Supported RT modules, filenames, and class names
@@ -61,6 +61,7 @@ class ForwardModel:
         # Build the radiative transfer model
         self.RT = None
         for key, module, cname in RT_models:
+            module = "isofit." + module
             if key in config:
                 self.RT = getattr(import_module(module), cname)(config[key])
         if self.RT is None:
@@ -69,6 +70,7 @@ class ForwardModel:
         # Build the surface model
         self.surface = None
         for key, module, cname in surface_models:
+            module = "isofit." + module
             if key in config:
                 self.surface = getattr(
                     import_module(module), cname)(config[key])

--- a/isofit/geometry.py
+++ b/isofit/geometry.py
@@ -20,7 +20,7 @@
 
 import scipy as s
 import logging
-from sunposition import sunpos
+from .sunposition import sunpos
 from datetime import datetime
 
 

--- a/isofit/instrument.py
+++ b/isofit/instrument.py
@@ -23,7 +23,7 @@ import logging
 from scipy.io import loadmat, savemat
 from scipy.interpolate import interp1d
 from scipy.signal import convolve
-from common import eps, srf, load_wavelen, resample_spectrum
+from .common import eps, srf, load_wavelen, resample_spectrum
 from numpy.random import multivariate_normal as mvn
 from numba import jit
 

--- a/isofit/inverse.py
+++ b/isofit/inverse.py
@@ -20,11 +20,11 @@
 
 import sys
 import scipy as s
-from common import svd_inv, svd_inv_sqrt, eps
+from .common import svd_inv, svd_inv_sqrt, eps
 from collections import OrderedDict
 from scipy.optimize import least_squares
 import xxhash
-from inverse_simple import invert_simple
+from .inverse_simple import invert_simple
 from scipy.linalg import inv, norm, det, cholesky, qr, svd
 from scipy.linalg import LinAlgError
 from hashlib import md5

--- a/isofit/inverse_mcmc.py
+++ b/isofit/inverse_mcmc.py
@@ -20,8 +20,8 @@
 
 import sys
 import scipy as s
-from common import chol_inv, eps
-from inverse import Inversion
+from .common import chol_inv, eps
+from .inverse import Inversion
 import scipy.optimize
 from scipy.linalg import inv, norm, sqrtm, det, cholesky, qr, svd
 from scipy.stats import multivariate_normal

--- a/isofit/isofit.py
+++ b/isofit/isofit.py
@@ -25,12 +25,12 @@ import argparse
 import scipy as s
 from spectral.io import envi
 from scipy.io import savemat
-from common import load_config, expand_all_paths, load_spectrum
-from forward import ForwardModel
-from inverse import Inversion
-from inverse_mcmc import MCMCInversion
-from geometry import Geometry
-from fileio import IO
+from .common import load_config, expand_all_paths, load_spectrum
+from .forward import ForwardModel
+from .inverse import Inversion
+from .inverse_mcmc import MCMCInversion
+from .geometry import Geometry
+from .fileio import IO
 import cProfile
 import logging
 

--- a/isofit/rt_6s.py
+++ b/isofit/rt_6s.py
@@ -26,8 +26,8 @@ import logging
 import scipy as s
 from spectral.io import envi
 from scipy.io import loadmat, savemat
-from common import json_load_ascii, combos, VectorInterpolator
-from common import recursive_replace, eps
+from .common import json_load_ascii, combos, VectorInterpolator
+from .common import recursive_replace, eps
 from copy import deepcopy
 from scipy.linalg import block_diag, det, norm, pinv, sqrtm, inv
 from scipy.signal import convolve, gaussian, medfilt
@@ -38,9 +38,9 @@ import pylab as plt
 import multiprocessing
 import subprocess
 from datetime import datetime
-from rt_lut import TabularRT, FileExistsError, spawn_rt
-from common import resample_spectrum, load_wavelen
-from geometry import Geometry
+from .rt_lut import TabularRT, FileExistsError, spawn_rt
+from .common import resample_spectrum, load_wavelen
+from .geometry import Geometry
 
 eps = 1e-5  # used for finite difference derivative calculations
 

--- a/isofit/rt_libradtran.py
+++ b/isofit/rt_libradtran.py
@@ -26,8 +26,8 @@ import logging
 import scipy as s
 from spectral.io import envi
 from scipy.io import loadmat, savemat
-from common import json_load_ascii, combos, VectorInterpolator
-from common import recursive_replace
+from .common import json_load_ascii, combos, VectorInterpolator
+from .common import recursive_replace
 from copy import deepcopy
 from scipy.linalg import block_diag, det, norm, pinv, sqrtm, inv
 from scipy.signal import convolve, gaussian, medfilt
@@ -37,8 +37,8 @@ from scipy.stats import multivariate_normal as mvn
 import pylab as plt
 import multiprocessing
 import subprocess
-from rt_lut import TabularRT, FileExistsError, spawn_rt
-from common import resample_spectrum
+from .rt_lut import TabularRT, FileExistsError, spawn_rt
+from .common import resample_spectrum
 
 eps = 1e-5  # used for finite difference derivative calculations
 

--- a/isofit/rt_lut.py
+++ b/isofit/rt_lut.py
@@ -22,9 +22,9 @@ import os
 import sys
 import scipy as s
 import logging
-from common import json_load_ascii, combos
-from common import VectorInterpolator, VectorInterpolatorJIT
-from common import recursive_replace, eps, load_wavelen
+from .common import json_load_ascii, combos
+from .common import VectorInterpolator, VectorInterpolatorJIT
+from .common import recursive_replace, eps, load_wavelen
 from scipy.interpolate import interp1d
 from scipy.optimize import minimize_scalar as min1d
 

--- a/isofit/rt_modtran.py
+++ b/isofit/rt_modtran.py
@@ -24,12 +24,12 @@ import os
 from os.path import split
 import re
 import scipy as s
-from common import json_load_ascii, combos, VectorInterpolator
-from common import recursive_replace
+from .common import json_load_ascii, combos, VectorInterpolator
+from .common import recursive_replace
 from copy import deepcopy
 from scipy.stats import norm as normal
 from scipy.interpolate import interp1d
-from rt_lut import TabularRT, FileExistsError
+from .rt_lut import TabularRT, FileExistsError
 
 eps = 1e-5  # used for finite difference derivative calculations
 

--- a/isofit/surf.py
+++ b/isofit/surf.py
@@ -19,7 +19,7 @@
 #
 
 import scipy as s
-from common import load_spectrum, load_wavelen
+from .common import load_spectrum, load_wavelen
 from scipy.interpolate import interp1d
 
 

--- a/isofit/surf_emissive.py
+++ b/isofit/surf_emissive.py
@@ -19,10 +19,10 @@
 #
 
 import scipy as s
-from common import recursive_replace, emissive_radiance, chol_inv, eps
+from .common import recursive_replace, emissive_radiance, chol_inv, eps
 from scipy.linalg import det, norm, pinv, sqrtm, inv, cholesky
 from scipy.optimize import minimize
-from surf_multicomp import MultiComponentSurface
+from .surf_multicomp import MultiComponentSurface
 
 
 class MixBBSurface(MultiComponentSurface):

--- a/isofit/surf_glint.py
+++ b/isofit/surf_glint.py
@@ -19,8 +19,8 @@
 #
 
 import scipy as s
-from common import recursive_replace, emissive_radiance, chol_inv, eps
-from surf_multicomp import MultiComponentSurface
+from .common import recursive_replace, emissive_radiance, chol_inv, eps
+from .surf_multicomp import MultiComponentSurface
 
 
 class GlintSurface(MultiComponentSurface):

--- a/isofit/surf_iop.py
+++ b/isofit/surf_iop.py
@@ -20,10 +20,10 @@
 
 import scipy as s
 from scipy.io import loadmat, savemat
-from common import recursive_replace, load_wavelen, chol_inv, eps, srf
+from .common import recursive_replace, load_wavelen, chol_inv, eps, srf
 from scipy.linalg import block_diag, det, norm, pinv, sqrtm, inv, cholesky
 from scipy.interpolate import interp1d
-from surf import Surface
+from .surf import Surface
 
 
 class IOPSurface(Surface):

--- a/isofit/surf_multicomp.py
+++ b/isofit/surf_multicomp.py
@@ -20,9 +20,9 @@
 
 import scipy as s
 from scipy.io import loadmat, savemat
-from common import recursive_replace, svd_inv, eps
+from .common import recursive_replace, svd_inv, eps
 from scipy.linalg import block_diag, det, norm, pinv, sqrtm, inv
-from surf import Surface
+from .surf import Surface
 
 
 class MultiComponentSurface(Surface):


### PR DESCRIPTION
This fixes import issues in the CLI scripts by moving programs to the bin directory. Utilities are still available separately in their respective directory for infrequent use.