### PR TITLE
Optimized vector interpolator

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -113,13 +113,13 @@ class VectorInterpolator:
 
     def __call__(self, points):
 
-        x = s.zeros((self.n,3))
-        x[:,0] = points[0]
-        x[:,1] = points[1]
+        x = s.zeros((self.n,len(points)+1))
+        for i in range(len(points)):
+            x[:,i] = points[i]
         # This last dimension is always an integer so no
         # interpolation is performed. This is done only
         # for performance reasons.
-        x[:,2] = s.arange(self.n)
+        x[:,-1] = s.arange(self.n)
         res = self.itp(x)
 
         return res

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -112,12 +112,17 @@ class VectorInterpolator:
         self.itp = RegularGridInterpolator(grid_aug, data)
 
     def __call__(self, points):
-        res = []
-        for v in s.arange(self.n):
-            p_aug = s.concatenate((points, s.array([v])), axis=0)
-            res.append(self.itp(p_aug))
-        return res
 
+        x = s.zeros((self.n,3))
+        x[:,0] = points[0]
+        x[:,1] = points[1]
+        # This last dimension is always an integer so no
+        # interpolation is performed. This is done only
+        # for performance reasons.
+        x[:,2] = s.arange(self.n)
+        res = self.itp(x)
+
+        return res
 
 class VectorInterpolatorJIT:
     """JIT implementation for VectorInterpolator class."""

--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -24,6 +24,8 @@ import scipy as s
 import logging
 
 from ..core.common import combos, VectorInterpolatorJIT, eps, load_wavelen
+from ..core.common import VectorInterpolator
+
 
 
 ### Functions ###
@@ -178,10 +180,10 @@ class TabularRT:
             self.transm[ind] = transm
             self.transup[ind] = transup
 
-        self.rhoatm_interp = VectorInterpolatorJIT(self.lut_grids, self.rhoatm)
-        self.sphalb_interp = VectorInterpolatorJIT(self.lut_grids, self.sphalb)
-        self.transm_interp = VectorInterpolatorJIT(self.lut_grids, self.transm)
-        self.transup_interp = VectorInterpolatorJIT(
+        self.rhoatm_interp = VectorInterpolator(self.lut_grids, self.rhoatm)
+        self.sphalb_interp = VectorInterpolator(self.lut_grids, self.sphalb)
+        self.transm_interp = VectorInterpolator(self.lut_grids, self.transm)
+        self.transup_interp = VectorInterpolator(
             self.lut_grids, self.transup)
 
     def lookup_lut(self, point):

--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -182,7 +182,7 @@ class TabularRT:
         self.sphalb_interp = VectorInterpolatorJIT(self.lut_grids, self.sphalb)
         self.transm_interp = VectorInterpolatorJIT(self.lut_grids, self.transm)
         self.transup_interp = VectorInterpolatorJIT(
-            self.lut_grids, self.transm)
+            self.lut_grids, self.transup)
 
     def lookup_lut(self, point):
         """Multi-linear interpolation in the LUT."""


### PR DESCRIPTION
This commit has a small change to the VectorInterpolator class that dramatically improves its performance (~15x). Removing the loop over the spectral dimension and allowing the scipy function to handle it makes the loop run at native speeds. This commit then uses VectorInterpolate instead of the JIT version as it is simpler to read and understand.

Based on the simple timings below, it seems like all of the JIT code could be removed for simplicity without any performance loss. I didn't do that here though.

The following are simple timings using %timeit on the Pasadena darklot example.

Original VectorInterpolatorJIT with jit_enabled = True: 6.8 s
Original VectorInterpolator with jit_enabled = False: 96 s
New VectorInterpolator with hit_enabled = False: 6.5 s