### PR TITLE
Fix bugs in look_up_tables.py

### DIFF
--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -313,7 +313,7 @@ class TabularRT:
                         x_RT_perturb, geom)
                     rhoe = rhoatme + transme * rfl / (1.0 - sphalbe * rfl)
                     rdne = rhoe/s.pi*(self.solar_irr*self.coszen) + (Ls *
-                                                                     transup)
+                                                                     transupe)
                     Kb_RT.append((rdne-rdn) / eps)
 
         Kb_RT = s.array(Kb_RT).T

--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -182,7 +182,7 @@ class TabularRT:
         self.sphalb_interp = VectorInterpolatorJIT(self.lut_grids, self.sphalb)
         self.transm_interp = VectorInterpolatorJIT(self.lut_grids, self.transm)
         self.transup_interp = VectorInterpolatorJIT(
-            self.lut_grids, self.transm)
+            self.lut_grids, self.transup)
 
     def lookup_lut(self, point):
         """Multi-linear interpolation in the LUT."""


### PR DESCRIPTION
There are two bugs fixed here:

1. Correctly assign transup to the transup_interp variable (issue #60)
2. Correctly use transupe instead of transup