### PR TITLE
Generalized RTM

### DIFF
--- a/examples/20171108_Pasadena/configs/ang20171108t173546_darklot.json
+++ b/examples/20171108_Pasadena/configs/ang20171108t173546_darklot.json
@@ -33,7 +33,7 @@
     },
 
     "radiative_transfer": {
-      "modtran_visnir": {
+      "modtran_vswir": {
         "wavelength_file": "../remote/20170320_ang20170228_wavelength_fit.txt",
         "lut_path":"../lut/",
         "modtran_template_file":"ang20171108t184227_modtran.json",

--- a/examples/20171108_Pasadena/configs/ang20171108t173546_darklot.json
+++ b/examples/20171108_Pasadena/configs/ang20171108t173546_darklot.json
@@ -32,33 +32,35 @@
       "surface_file": "../remote/ang20170228_surface_model.mat"
     },
 
-    "modtran_radiative_transfer": {
-      "wavelength_file": "../remote/20170320_ang20170228_wavelength_fit.txt",
-      "lut_path":"../lut/",
-      "modtran_template_file":"ang20171108t184227_modtran.json",
-      "domain": {"start": 350, "end": 2520, "step": 0.1},
-      "statevector": {
-        "H2OSTR": {
-          "bounds": [1.5, 2.0],
-          "scale": 0.01,
-          "prior_mean": 1.75,
-          "prior_sigma":0.5,
-          "init": 1.75
+    "radiative_transfer": {
+      "modtran_visnir": {
+        "wavelength_file": "../remote/20170320_ang20170228_wavelength_fit.txt",
+        "lut_path":"../lut/",
+        "modtran_template_file":"ang20171108t184227_modtran.json",
+        "domain": {"start": 350, "end": 2520, "step": 0.1},
+        "statevector": {
+          "H2OSTR": {
+            "bounds": [1.5, 2.0],
+            "scale": 0.01,
+            "prior_mean": 1.75,
+            "prior_sigma":0.5,
+            "init": 1.75
+          },
+          "AOT550": {
+            "bounds": [0.01, 0.1],
+            "scale": 0.01,
+            "prior_mean": 0.05,
+            "prior_sigma":0.2,
+            "init": 0.05
+          }
         },
-        "AOT550": {
-          "bounds": [0.01, 0.1],
-          "scale": 0.01,
-          "prior_mean": 0.05,
-          "prior_sigma":0.2,
-          "init": 0.05
+        "lut_grid": {
+          "H2OSTR": [1.5, 2.0],
+          "AOT550": [0.01, 0.1]
+        },
+        "unknowns": {
+          "H2O_ABSCO": 0.01
         }
-      },
-      "lut_grid": {
-        "H2OSTR": [1.5, 2.0],
-        "AOT550": [0.01, 0.1]
-      },
-      "unknowns": {
-        "H2O_ABSCO": 0.01
       }
     }
   },

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -48,7 +48,8 @@ surface_models = [('surface', 'surface.surface', 'Surface'),
                   ('cat_surface', 'surf_cat', 'CATSurface'),
                   ('glint_surface', 'surface.surface_glint', 'GlintSurface'),
                   ('iop_surface', 'surface.surface_iop', 'IOPSurface'),
-                  ('poly_surface', 'surf_poly', 'PolySurface')]
+                  ('poly_surface', 'surf_poly', 'PolySurface'),
+                  ('thermal_surface', 'surface.surface_thermal', 'ThermalSurface')]
 
 
 ### Classes ###

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -26,6 +26,7 @@ from scipy.interpolate import interp1d
 
 from .common import recursive_replace, eps
 from .instrument import Instrument
+from ..radiative_transfer.radiative_transfer import RadiativeTransfer
 
 
 ### Variables ###
@@ -65,13 +66,7 @@ class ForwardModel:
         self.n_meas = self.instrument.n_chan
 
         # Build the radiative transfer model
-        self.RT = None
-        for key, module, cname in RT_models:
-            module = "isofit." + module
-            if key in config:
-                self.RT = getattr(import_module(module), cname)(config[key])
-        if self.RT is None:
-            raise ValueError('Must specify a valid radiative transfer model')
+        self.RT = RadiativeTransfer(config['radiative_transfer'])
 
         # Build the surface model
         self.surface = None

--- a/isofit/core/inverse_simple.py
+++ b/isofit/core/inverse_simple.py
@@ -63,10 +63,11 @@ def heuristic_atmosphere(RT, instrument, x_RT, x_instrument,  meas, geom):
             # Get Atmospheric terms at high spectral resolution
             x_RT_2 = x_RT.copy()
             x_RT_2[ind_sv] = h2o
-            rhoatm_hi, sphalb_hi, transm_hi, transup_hi = RT.get(x_RT_2, geom)
-            rhoatm = instrument.sample(x_instrument, RT.wl, rhoatm_hi)
-            transm = instrument.sample(x_instrument, RT.wl, transm_hi)
-            sphalb = instrument.sample(x_instrument, RT.wl, sphalb_hi)
+            #rhoatm_hi, sphalb_hi, transm_hi, transup_hi = RT.get(x_RT_2, geom)
+            rhi = RT.get(x_RT_2, geom)
+            rhoatm = instrument.sample(x_instrument, RT.wl, rhi['rhoatm']) #_hi)
+            transm = instrument.sample(x_instrument, RT.wl, rhi['transm']) #_hi)
+            sphalb = instrument.sample(x_instrument, RT.wl, rhi['sphalb']) #_hi)
             solar_irr = instrument.sample(x_instrument, RT.wl, RT.solar_irr)
 
             # Assume no surface emission.  "Correct" the at-sensor radiance
@@ -92,13 +93,14 @@ def invert_algebraic(surface, RT, instrument, x_surface, x_RT, x_instrument, mea
 
     # Get atmospheric optical parameters (possibly at high
     # spectral resolution) and resample them if needed.
-    rhoatm_hi, sphalb_hi, transm_hi, transup_hi = RT.get(x_RT, geom)
+    #rhoatm_hi, sphalb_hi, transm_hi, transup_hi = RT.get(x_RT, geom)
+    rhi = RT.get(x_RT, geom)
     wl, fwhm = instrument.calibration(x_instrument)
-    rhoatm = instrument.sample(x_instrument, RT.wl, rhoatm_hi)
-    transm = instrument.sample(x_instrument, RT.wl, transm_hi)
+    rhoatm = instrument.sample(x_instrument, RT.wl, rhi['rhoatm']) #_hi)
+    transm = instrument.sample(x_instrument, RT.wl, rhi['transm']) #_hi)
     solar_irr = instrument.sample(x_instrument, RT.wl, RT.solar_irr)
-    sphalb = instrument.sample(x_instrument, RT.wl, sphalb_hi)
-    transup = instrument.sample(x_instrument, RT.wl, transup_hi)
+    sphalb = instrument.sample(x_instrument, RT.wl, rhi['sphalb']) #_hi)
+    transup = instrument.sample(x_instrument, RT.wl, rhi['transup']) #_hi)
     coszen = RT.coszen
 
     # Calculate the initial emission and subtract from the measurement.

--- a/isofit/core/inverse_simple.py
+++ b/isofit/core/inverse_simple.py
@@ -46,12 +46,11 @@ def heuristic_atmosphere(RT, instrument, x_RT, x_instrument,  meas, geom):
             continue
 
         # ignore unused names
-        if h2oname not in RT.RTs['modtran_visnir'].lut_names:
+        if h2oname not in RT.RTs['modtran_vswir'].lut_names:
             continue
 
         # find the index in the lookup table associated with water vapor
-        #lut_names = RT.RTs['modtran_visnir'].lut_names
-        ind_lut = RT.RTs['modtran_visnir'].lut_names.index(h2oname)
+        ind_lut = RT.RTs['modtran_vswir'].lut_names.index(h2oname)
         ind_sv = RT.unique_statevec.index(h2oname)
         h2os, ratios = [], []
 
@@ -59,7 +58,7 @@ def heuristic_atmosphere(RT, instrument, x_RT, x_instrument,  meas, geom):
         # calculating the band ratio that we would see if this were the
         # atmospheric H2O content.  It assumes that defaults for all other
         # atmospheric parameters (such as aerosol, if it is there).
-        for h2o in RT.RTs['modtran_visnir'].lut_grids[ind_lut]:
+        for h2o in RT.RTs['modtran_vswir'].lut_grids[ind_lut]:
 
             # Get Atmospheric terms at high spectral resolution
             x_RT_2 = x_RT.copy()

--- a/isofit/core/inverse_simple.py
+++ b/isofit/core/inverse_simple.py
@@ -63,7 +63,6 @@ def heuristic_atmosphere(RT, instrument, x_RT, x_instrument,  meas, geom):
             # Get Atmospheric terms at high spectral resolution
             x_RT_2 = x_RT.copy()
             x_RT_2[ind_sv] = h2o
-            #rhoatm_hi, sphalb_hi, transm_hi, transup_hi = RT.get(x_RT_2, geom)
             rhi = RT.get(x_RT_2, geom)
             rhoatm = instrument.sample(x_instrument, RT.wl, rhi['rhoatm']) #_hi)
             transm = instrument.sample(x_instrument, RT.wl, rhi['transm']) #_hi)
@@ -93,14 +92,13 @@ def invert_algebraic(surface, RT, instrument, x_surface, x_RT, x_instrument, mea
 
     # Get atmospheric optical parameters (possibly at high
     # spectral resolution) and resample them if needed.
-    #rhoatm_hi, sphalb_hi, transm_hi, transup_hi = RT.get(x_RT, geom)
     rhi = RT.get(x_RT, geom)
     wl, fwhm = instrument.calibration(x_instrument)
-    rhoatm = instrument.sample(x_instrument, RT.wl, rhi['rhoatm']) #_hi)
-    transm = instrument.sample(x_instrument, RT.wl, rhi['transm']) #_hi)
+    rhoatm = instrument.sample(x_instrument, RT.wl, rhi['rhoatm'])
+    transm = instrument.sample(x_instrument, RT.wl, rhi['transm'])
     solar_irr = instrument.sample(x_instrument, RT.wl, RT.solar_irr)
-    sphalb = instrument.sample(x_instrument, RT.wl, rhi['sphalb']) #_hi)
-    transup = instrument.sample(x_instrument, RT.wl, rhi['transup']) #_hi)
+    sphalb = instrument.sample(x_instrument, RT.wl, rhi['sphalb'])
+    transup = instrument.sample(x_instrument, RT.wl, rhi['transup'])
     coszen = RT.coszen
 
     # Calculate the initial emission and subtract from the measurement.

--- a/isofit/core/inverse_simple.py
+++ b/isofit/core/inverse_simple.py
@@ -46,19 +46,20 @@ def heuristic_atmosphere(RT, instrument, x_RT, x_instrument,  meas, geom):
             continue
 
         # ignore unused names
-        if h2oname not in RT.lut_names:
+        if h2oname not in RT.RTs['modtran_visnir'].lut_names:
             continue
 
         # find the index in the lookup table associated with water vapor
-        ind_lut = RT.lut_names.index(h2oname)
-        ind_sv = RT.statevec.index(h2oname)
+        #lut_names = RT.RTs['modtran_visnir'].lut_names
+        ind_lut = RT.RTs['modtran_visnir'].lut_names.index(h2oname)
+        ind_sv = RT.unique_statevec.index(h2oname)
         h2os, ratios = [], []
 
         # We iterate through every possible grid point in the lookup table,
         # calculating the band ratio that we would see if this were the
         # atmospheric H2O content.  It assumes that defaults for all other
         # atmospheric parameters (such as aerosol, if it is there).
-        for h2o in RT.lut_grids[ind_lut]:
+        for h2o in RT.RTs['modtran_visnir'].lut_grids[ind_lut]:
 
             # Get Atmospheric terms at high spectral resolution
             x_RT_2 = x_RT.copy()

--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -91,18 +91,6 @@ class TabularRT:
         self.prior_sigma = s.array(self.prior_sigma)
         self.bval = s.array([config['unknowns'][k] for k in self.bvec])
 
-    def xa(self):
-        """Mean of prior distribution, calculated at state x. This is the
-           Mean of our LUT grid (why not)."""
-        return self.prior_mean.copy()
-
-    def Sa(self):
-        """Covariance of prior distribution. Our state vector covariance 
-           is diagonal with very loose constraints."""
-        if self.n_state == 0:
-            return s.zeros((0, 0), dtype=float)
-        return s.diagflat(pow(self.prior_sigma, 2))
-
     def build_lut(self, rebuild=False):
         """Each LUT is associated with a source directory.  We build a lookup table by: 
               (1) defining the LUT dimensions, state vector names, and the grid 

--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -164,9 +164,6 @@ class TabularRT:
         if Ls is None:
             Ls = s.zeros(rfl.shape)
 
-        #rhoatm, sphalb, transm, transup = self.get(x_RT, geom)
-        #rho = rhoatm + transm * rfl / (1.0 - sphalb * rfl)
-        #rdn = rho/s.pi*(self.solar_irr*self.coszen) + (Ls * transup)
         r = self.get(x_RT, geom)
         rho = r['rhoatm'] + r['transm'] * rfl / (1.0 - r['sphalb'] * rfl)
         rdn = rho/s.pi*(self.solar_irr*self.coszen) + (Ls * r['transup'])
@@ -177,7 +174,6 @@ class TabularRT:
         """Jacobian of radiance with respect to RT and surface state vectors."""
 
         # first the rdn at the current state vector
-        #rhoatm, sphalb, transm, transup = self.get(x_RT, geom)
         r = self.get(x_RT, geom)
         rho = r['rhoatm'] + r['transm'] * rfl / (1.0 - r['sphalb'] * rfl)
         rdn = rho/s.pi*(self.solar_irr*self.coszen) + (Ls * r['transup'])
@@ -187,7 +183,6 @@ class TabularRT:
         for i in range(len(x_RT)):
             x_RT_perturb = x_RT.copy()
             x_RT_perturb[i] = x_RT[i] + eps
-            #rhoatme, sphalbe, transme, transupe = self.get(x_RT_perturb, geom)
             re = self.get(x_RT_perturb, geom)
             rhoe = re['rhoatm'] + re['transm'] * rfl / (1.0 - re['sphalb'] * rfl)
             rdne = rhoe/s.pi*(self.solar_irr*self.coszen) + (Ls * re['transup'])
@@ -216,9 +211,7 @@ class TabularRT:
 
         else:
             # first the radiance at the current state vector
-            #rhoatm, sphalb, transm, transup = self.get(x_RT, geom)
             r = self.get(x_RT, geom)
-            #rho = rhoatm + transm * rfl / (1.0 - sphalb * rfl)
             rho = r['rhoatm'] + r['transm'] * rfl / (1.0 - r['sphalb'] * rfl)
             rdn = rho/s.pi*(self.solar_irr*self.coszen) + (Ls * r['transup'])
 
@@ -234,19 +227,15 @@ class TabularRT:
 
                 elif unknown == 'H2O_ABSCO' and 'H2OSTR' in self.statevec:
                     # first the radiance at the current state vector
-                    #rhoatm, sphalb, transm, transup = self.get(x_RT, geom)
                     r = self.get(x_RT, geom)
-                    #rho = rhoatm + transm * rfl / (1.0 - sphalb * rfl)
                     rho = r['rhoatm'] + r['transm'] * rfl / (1.0 - r['sphalb'] * rfl)
                     rdn = rho/s.pi*(self.solar_irr*self.coszen) + (Ls *
                                                                    r['transup'])
                     i = self.statevec.index('H2OSTR')
                     x_RT_perturb = x_RT.copy()
                     x_RT_perturb[i] = x_RT[i] * perturb
-                    #rhoatme, sphalbe, transme, transupe = self.get(
                     re = self.get(x_RT_perturb, geom)
                     rhoe = re['rhoatm'] + re['transm'] * rfl / (1.0 - re['sphalb'] * rfl)
-                    #rhoe = rhoatme + transme * rfl / (1.0 - sphalbe * rfl)
                     rdne = rhoe/s.pi*(self.solar_irr*self.coszen) + (Ls *
                                                                      re['transup'])
                     Kb_RT.append((rdne-rdn) / eps)

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -390,22 +390,13 @@ class ModtranRT(TabularRT):
             raise NotImplementedError
 
     def get_L_down_vswir(self, x_RT, geom):
-        #r = self.get(x_RT, geom)
-        #rho = r['transm']
-        #rdn = rho/s.pi*(self.solar_irr*self.coszen)
         rdn = (self.solar_irr*self.coszen) / s.pi
         return rdn
 
-    def get_L_up(self, x_RT, Ls, geom):
-        if self.band_mode_string.lower() == 'modtran_vswir':
-            return self.get_L_up_vswir(x_RT, Ls, geom)
-        else:
-            raise NotImplementedError
-
-    def get_L_up_vswir(self, x_RT, Ls, geom):
-        r = self.get(x_RT, geom)
-        rdn = (Ls * r['transup'])
-        return rdn
+    def get_L_up(self, x_RT, geom):
+        """Thermal emission from the ground is provided by the thermal model, so
+        this function is a placeholder for future upgrades."""
+        return 0
 
     def wl2flt(self, wls, fwhms, outfile):
         """Helper function to generate Gaussian distributions around the center wavelengths."""

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -235,6 +235,7 @@ class ModtranRT(TabularRT):
         for point, fn in zip(self.points, self.files):
             chnfile = self.lut_dir+'/'+fn+'.chn'
             mod_outputs.append(self.load_rt(point, fn))
+
         self.wl = mod_outputs[0]['wl']
         self.solar_irr = mod_outputs[0]['sol']
         self.coszen = s.cos(mod_outputs[0]['solzen'] * s.pi / 180.0)
@@ -314,14 +315,14 @@ class ModtranRT(TabularRT):
         tp6file = self.lut_dir+'/'+fn+'.tp6'
         solzen = self.load_tp6(tp6file)
         coszen = s.cos(solzen * s.pi / 180.0)
+
         chnfile = self.lut_dir+'/'+fn+'.chn'
-        #wl, sol, rhoatm, transm, sphalb, transup = self.load_chn(
         params = self.load_chn(chnfile, coszen)
+
         names = ['wl', 'sol', 'rhoatm', 'transm', 'sphalb', 'transup']
         results_dict = {name:param for name, param in zip(names,params)}
         results_dict['solzen'] = solzen
         results_dict['coszen'] = coszen
-        #return wl, sol, solzen, rhoatm, transm, sphalb, transup
         return results_dict
 
     def lookup_lut(self, point):

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -39,14 +39,19 @@ from ..core.common import combos, VectorInterpolatorJIT, eps, load_wavelen
 
 eps = 1e-5  # used for finite difference derivative calculations
 
+modtran_bands_available = ['modtran_visnir']
 
 ### Classes ###
 
 class ModtranRT(TabularRT):
     """A model of photon transport including the atmosphere."""
 
-    def __init__(self, config):
+    def __init__(self, band_mode_string, config):
         """."""
+
+        self.band_mode_string = band_mode_string
+        if self.band_mode_string not in modtran_bands_available:
+            raise NotImplementedError
 
         TabularRT.__init__(self, config)
 
@@ -75,8 +80,7 @@ class ModtranRT(TabularRT):
             self.aer_extc = s.array(aer_extc)
             self.aer_asym = s.array(aer_asym)
         
-        self.band_mode_string = 'visnir'
-        if self.band_mode_string.lower() == 'visnir':
+        if self.band_mode_string.lower() == 'modtran_visnir':
             self.modtran_lut_names = ['rhoatm', 'transm', 'sphalb', 'transup']
 
         # Build the lookup table
@@ -376,7 +380,7 @@ class ModtranRT(TabularRT):
 
         r = self.get(x_RT, geom)
 
-        if self.band_mode_string.lower() == 'visnir':
+        if self.band_mode_string.lower() == 'modtran_visnir':
             return self.calc_rdn_visnir(r, rfl)
         else:
             raise NotImplementedError
@@ -392,7 +396,7 @@ class ModtranRT(TabularRT):
     def drdn_dRT(self, x_RT, x_surface, rfl, drfl_dsurface, Ls, dLs_dsurface,
                  geom):
         
-        if self.band_mode_string.lower() == 'visnir':
+        if self.band_mode_string.lower() == 'modtran_visnir':
             return self.drdn_dRT_visnir(x_RT, x_surface, rfl, drfl_dsurface, 
                                    Ls, dLs_dsurface, geom)
         else:
@@ -431,7 +435,7 @@ class ModtranRT(TabularRT):
 
     def drdn_dRTb(self, x_RT, rfl, Ls, geom):
 
-        if self.band_mode_string.lower() == 'visnir':
+        if self.band_mode_string.lower() == 'modtran_visnir':
             return self.drdn_dRTb_visnir(x_RT, rfl, Ls, geom)
         else:
             raise NotImplementedError

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -254,7 +254,6 @@ class ModtranRT(TabularRT):
 
             self.luts[key] = VectorInterpolatorJIT(self.lut_grids, temp)
 
-
     def rebuild_cmd(self, point, fn):
         """."""
 
@@ -372,106 +371,41 @@ class ModtranRT(TabularRT):
                 point[point_ind] = x_RT[x_RT_ind]
             return self.lookup_lut(point)
 
-    def calc_rdn(self, x_RT, rfl, Ls, geom):
-        """Calculate radiance at aperature for a radiative transfer state vector.
-
-        rfl is the reflectance at surface. 
-        Ls is the  emissive radiance at surface."""
-
-        r = self.get(x_RT, geom)
-
+    def get_L_atm(self, x_RT, geom):
         if self.band_mode_string.lower() == 'modtran_vswir':
-            return self.calc_rdn_vswir(r, rfl)
+            return self.get_L_atm_vswir(x_RT, geom)
         else:
             raise NotImplementedError
 
-    def calc_rdn_vswir(self, r, rfl, perturb = 1.):
-
-        Ls = s.zeros(rfl.shape)
-
-        rho = r['rhoatm'] + r['transm'] * rfl / (1.0 - r['sphalb'] * rfl * perturb)
-        rdn = rho/s.pi*(self.solar_irr*self.coszen) + (Ls * r['transup'])
+    def get_L_atm_vswir(self, x_RT, geom):
+        r = self.get(x_RT, geom)
+        rho = r['rhoatm']
+        rdn = rho/s.pi*(self.solar_irr*self.coszen)
         return rdn
-    
-    def drdn_dRT(self, x_RT, x_surface, rfl, drfl_dsurface, Ls, dLs_dsurface,
-                 geom):
-        
+
+    def get_L_down(self, x_RT, geom):
         if self.band_mode_string.lower() == 'modtran_vswir':
-            return self.drdn_dRT_vswir(x_RT, x_surface, rfl, drfl_dsurface, 
-                                   Ls, dLs_dsurface, geom)
+            return self.get_L_down_vswir(x_RT, geom)
         else:
             raise NotImplementedError
 
-    def drdn_dRT_vswir(self, x_RT, x_surface, rfl, drfl_dsurface, Ls, dLs_dsurface,
-                 geom):
-        """Jacobian of radiance with respect to RT and surface state vectors."""
+    def get_L_down_vswir(self, x_RT, geom):
+        #r = self.get(x_RT, geom)
+        #rho = r['transm']
+        #rdn = rho/s.pi*(self.solar_irr*self.coszen)
+        rdn = (self.solar_irr*self.coszen) / s.pi
+        return rdn
 
-        # first the rdn at the current state vector
+    def get_L_up(self, x_RT, Ls, geom):
+        if self.band_mode_string.lower() == 'modtran_vswir':
+            return self.get_L_up_vswir(x_RT, Ls, geom)
+        else:
+            raise NotImplementedError
+
+    def get_L_up_vswir(self, x_RT, Ls, geom):
         r = self.get(x_RT, geom)
-        rdn = self.calc_rdn_vswir(r, rfl)
-
-        # perturb each element of the RT state vector (finite difference)
-        K_RT = []
-        x_RTs_perturb = x_RT + s.eye(len(x_RT))*eps
-        for x_RT_perturb in list(x_RTs_perturb): 
-            re = self.get(x_RT_perturb, geom)
-            rdne = self.calc_rdn_vswir(re, rfl)
-            K_RT.append((rdne-rdn) / eps)
-        K_RT = s.array(K_RT).T
-
-        # analytical jacobians for surface model state vector, via chain rule
-        K_surface = []
-        for i in range(len(x_surface)):
-            drho_drfl = \
-                (r['transm']/(1-r['sphalb']*rfl) -
-                 (r['sphalb']*r['transm']*rfl)/pow(1-r['sphalb']*rfl, 2))
-            drdn_drfl = drho_drfl/s.pi*(self.solar_irr*self.coszen)
-            drdn_dLs = r['transup']
-            K_surface.append(drdn_drfl * drfl_dsurface[:, i] +
-                             drdn_dLs * dLs_dsurface[:, i])
-        K_surface = s.array(K_surface).T
-
-        return K_RT, K_surface
-
-    def drdn_dRTb(self, x_RT, rfl, Ls, geom):
-
-        if self.band_mode_string.lower() == 'modtran_vswir':
-            return self.drdn_dRTb_vswir(x_RT, rfl, Ls, geom)
-        else:
-            raise NotImplementedError
-
-    def drdn_dRTb_vswir(self, x_RT, rfl, Ls, geom):
-        """Jacobian of radiance with respect to NOT RETRIEVED RT and surface 
-           state.  Right now, this is just the sky view factor."""
-
-        if len(self.bvec) == 0:
-            Kb_RT = s.zeros((0, len(self.wl.shape)))
-
-        else:
-            # first the radiance at the current state vector
-            r = self.get(x_RT, geom)
-            rdn = self.calc_rdn_vswir(r, rfl)
-
-            # perturb the sky view
-            Kb_RT = []
-            perturb = (1.0+eps)
-            for unknown in self.bvec:
-
-                if unknown == 'Skyview':
-                    rdne = self.calc_rdn_vswir(r, rfl, perturb = perturb)
-                    Kb_RT.append((rdne-rdn) / eps)
-
-                elif unknown == 'H2O_ABSCO' and 'H2OSTR' in self.statevec:
-                    # first the radiance at the current state vector
-                    i = self.statevec.index('H2OSTR')
-                    x_RT_perturb = x_RT.copy()
-                    x_RT_perturb[i] = x_RT[i] * perturb
-                    re = self.get(x_RT_perturb, geom)
-                    rdne = self.calc_rdn_vswir(re, rfl)
-                    Kb_RT.append((rdne-rdn) / eps)
-
-        Kb_RT = s.array(Kb_RT).T
-        return Kb_RT
+        rdn = (Ls * r['transup'])
+        return rdn
 
     def wl2flt(self, wls, fwhms, outfile):
         """Helper function to generate Gaussian distributions around the center wavelengths."""

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -197,22 +197,8 @@ class RadiativeTransfer():
         # Get K_surface
         r = self.get(x_RT, geom) 
         L_down = self.get_L_down(x_RT, geom)
-
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        # These two lines are correct, but commented out to allow comparison
-        # with the master branch. When ready, uncomment these two and remove
-        # the next four lines.
-        #drho_drfl = r['transm'] / (1 - r['sphalb']*rfl)**2
-        #drdn_drfl = drho_drfl * L_down
-
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        # This stretch has the sign error for testing
-        drho_drfl = \
-            (r['transm']/(1-r['sphalb']*rfl) -
-                (r['sphalb']*r['transm']*rfl)/pow(1-r['sphalb']*rfl, 2))
-        drdn_drfl = drho_drfl/s.pi*(self.solar_irr*self.coszen)
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+        drho_drfl = r['transm'] / (1 - r['sphalb']*rfl)**2
+        drdn_drfl = drho_drfl * L_down
         drdn_dLs = r['transup']
         K_surface = drdn_drfl[:, s.newaxis] * drfl_dsurface + \
                     drdn_dLs[:, s.newaxis] * dLs_dsurface

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -22,17 +22,40 @@ import scipy as s
 import logging
 from copy import deepcopy
 from collections import OrderedDict
+import pdb
 
 from ..core.common import json_load_ascii
 from ..radiative_transfer.modtran import modtran_bands_available, ModtranRT
 
 class RadiativeTransfer():
+    """This class controls the radiative transfer component of the forward
+    model. An ordered dict is maintained of individual RTMs (like MODTRAN,
+    for example). The dict is looped over and the radiation and derivatives
+    from each RTM and band are put together.
+
+    In general, some of the state vector components will be shared between
+    RTMs and bands. For example, H20STR is shared between both VISNIR and TIR.
+    The element unique_statevec contains the unique state vector elements from
+    each RTM component. For example, assume there are two RTMs: VISNIR and TIR.
+    There will be three RT state vector elements: H20, AOT, and surface
+    temperature. The VISNIR RTM's statevec will have H20 and AOT and the TIR
+    RTM's statevec will have H20 and surface temperature.
+
+    Maintaining the order of the inputs and outputs here is a bit tricky. The
+    individual RTMs will maintain their own order for their state vector. This
+    class will provide them in that order using the function make_statevec().
+    The order of the output radiation (output from calc_rdn, for example) will
+    be in whatever order the RTs ordered dict is filled, which is determined by
+    the random order of the radiative_transfer elements in the json input. This
+    means that there is no sorting with respect to wavelength of the different
+    RTM bands.
+    """
 
     def __init__(self, config):
         """."""
 
         # Maintain order when looping for indexing convenience
-        self.RTs = OrderedDict() 
+        self.RTs = OrderedDict()
 
         for key, local_config in config.items():
             if key in modtran_bands_available:
@@ -47,17 +70,42 @@ class RadiativeTransfer():
         # only want a single H20STR value in the statevector as it is shared.
         all_statevec = [s for RT in self.RTs.values() for s in RT.statevec] # Flatten a list of lists
         self.unique_statevec = list(set(all_statevec)) # Get unique elements
+        self.unique_statevec.sort()
         self.len_statevecs = [RT.n_state for RT in self.RTs.values()]
 
 
-        self.statevec = self.RTs['modtran_visnir'].statevec
-        self.bounds = self.RTs['modtran_visnir'].bounds
-        self.scale = self.RTs['modtran_visnir'].scale
-        self.init = self.RTs['modtran_visnir'].init
+        #self.statevec = self.RTs['modtran_visnir'].statevec
+        self.statevec = self.unique_statevec
+
+        #self.bounds = self.RTs['modtran_visnir'].bounds
+        #self.scale = self.RTs['modtran_visnir'].scale
+        #self.init = self.RTs['modtran_visnir'].init
+        bounds = []
+        scale = []
+        init = []
+        print(self.unique_statevec, self.RTs['modtran_visnir'].statevec)
+        for key in self.unique_statevec:
+            if key in self.RTs['modtran_visnir'].statevec:
+                RT_temp = self.RTs['modtran_visnir']
+                bounds.append(RT_temp.bounds[RT_temp.statevec.index(key)])
+                scale.append(RT_temp.scale[RT_temp.statevec.index(key)])
+                init.append(RT_temp.init[RT_temp.statevec.index(key)])
+        self.bounds = bounds
+        self.scale = scale
+        self.init = init
+
         self.bvec = self.RTs['modtran_visnir'].bvec
         self.bval = self.RTs['modtran_visnir'].bval
-        self.lut_names = self.RTs['modtran_visnir'].lut_names
-        self.lut_grids = self.RTs['modtran_visnir'].lut_grids
+        #self.lut_names = self.RTs['modtran_visnir'].lut_names
+        #self.lut_names = self.unique_statevec
+
+        #lut_grids = []
+        #print(self.unique_statevec, self.RTs['modtran_visnir'].statevec)
+        #for key in self.unique_statevec:
+        #    if key in self.RTs['modtran_visnir'].statevec:
+        #        RT_temp = self.RTs['modtran_visnir']
+        #        lut_grids.append(RT_temp.lut_grids[RT_temp.statevec.index(key)])
+        #self.lut_grids = lut_grids
         self.solar_irr = self.RTs['modtran_visnir'].solar_irr
         self.coszen = self.RTs['modtran_visnir'].coszen
 
@@ -71,66 +119,163 @@ class RadiativeTransfer():
         #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
         #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
         #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-    
+
     def xa(self):
-        #TODO: fix for multiple bands
-        return self.RTs['modtran_visnir'].xa()
-        return self.RTs['modtran_visnir'].get(x_RT, geom)
-    
+        #xa = self.RTs['modtran_visnir'].xa()
+        prior_means = []
+        # We want to get the prior mean for each unique_statevec
+        # element in its order. For state vector elements that are
+        # shared between multiple RTMs, assume that the user
+        # correctly entered the priors as being the same.
+        # TODO: check that the user correctly entered the priors
+        # TODO: the same for each radiative_transfer entry in the json input
+
+        prior_means = []
+        # List of tuples of all RTs: (statevec_name, prior_mean)
+        # For example: 
+        for key, RT in self.RTs.items():
+            prior_means = prior_means + \
+                          [(statevec, prior_mean) for statevec, prior_mean in zip(RT.statevec, RT.prior_mean)]
+        
+        prior_means = list(set(prior_means)) # Keep only unique entries
+
+        # Unless the user entered different priors for the same state vector elements
+        # in different 'radiative_tranfer' json entries, these should be the same size.
+        if len(prior_means) != len(self.unique_statevec):
+            raise AssertionError
+
+        prior_means.sort()  # Sort them into the same order as self.unique_statevec
+        prior_means = [prior_mean for _, prior_mean in prior_means] # Pull out prior value
+        return s.array(prior_means)
+
     def Sa(self):
-        #TODO: fix for multiple bands
-        return self.RTs['modtran_visnir'].Sa()
-    
+
+        prior_sigmas = []
+        # List of tuples of all RTs: (statevec_name, prior_sigma)
+        # For example: 
+        for key, RT in self.RTs.items():
+            prior_sigmas = prior_sigmas + \
+                           [(statevec, prior_sigma) for statevec, prior_sigma in zip(RT.statevec, RT.prior_sigma)]
+        
+        prior_sigmas = list(set(prior_sigmas)) # Keep only unique entries
+
+        # Unless the user entered different priors for the same state vector elements
+        # in different 'radiative_tranfer' json entries, these should be the same size.
+        if len(prior_sigmas) != len(self.unique_statevec):
+            raise AssertionError
+
+        prior_sigmas.sort()  # Sort them into the same order as self.unique_statevec
+        prior_sigmas = [prior_sigmas for _, prior_sigmas in prior_sigmas] # Pull out prior value
+
+        ret = s.diagflat(pow(s.array(prior_sigmas), 2))
+        #temp = self.RTs['modtran_visnir'].Sa()
+        return ret
+
     def get(self, x_RT, geom):
 
         x_RT_dict = self.make_statevecs(x_RT)
         ret = []
         for key, RT in self.RTs.items():
             ret.append(self.RTs[key].get(x_RT_dict[key], geom))
-        
+        #pdb.set_trace()
         return self.pack_arrays(ret)
-    
+
     def calc_rdn(self, x_RT, rfl, Ls, geom):
-        #TODO: fix for multiple bands
-        return self.RTs['modtran_visnir'].calc_rdn(x_RT, rfl, Ls, geom)
-    
-    def drdn_dRT(self, x_RT, x_surface, rfl, drfl_dsurface, Ls, 
+        x_RT_dict = self.make_statevecs(x_RT)
+        ret = []
+        for key, RT in self.RTs.items():
+            #TODO: take rfl out of here and move it elsewhere
+            ret.append(self.RTs[key].calc_rdn(x_RT_dict[key], rfl, Ls, geom))
+        #pdb.set_trace()
+        return s.hstack(ret)
+        #return self.RTs['modtran_visnir'].calc_rdn(x_RT, rfl, Ls, geom)
+
+    def drdn_dRT(self, x_RT, x_surface, rfl, drfl_dsurface, Ls,
                  dLs_dsurface, geom):
-        #TODO: fix for multiple bands
-        return self.RTs['modtran_visnir'].drdn_dRT(x_RT, x_surface, rfl, drfl_dsurface, 
-                                    Ls, dLs_dsurface, geom)
-    
+        x_RT_dict = self.make_statevecs(x_RT)
+        ret_K_RTs, ret_K_surfaces = [], []
+        for key, RT in self.RTs.items():
+            #TODO: take rfl out of here and move it elsewhere
+            K_RT_temp, K_surface_temp = \
+                self.RTs[key].drdn_dRT(x_RT_dict[key], x_surface, rfl, drfl_dsurface,
+                                       Ls, dLs_dsurface, geom)
+            ret_K_RTs.append(K_RT_temp)
+            ret_K_surfaces.append(K_surface_temp)
+
+        nxs = [x.shape[0] for x in ret_K_RTs]
+        init_offsets = s.cumsum([0] + nxs)
+        K_RT = s.zeros((sum(nxs), len(self.unique_statevec)))
+        for RT, ret_K_RT, init_offset in zip(self.RTs.values(), ret_K_RTs, init_offsets[:-1]):
+            tT = ret_K_RT.T
+            for state_component, ret_K_RT_line in zip(RT.statevec, tT):
+                st_ind = self.unique_statevec.index(state_component)
+                sl = slice(init_offset, init_offset + len(ret_K_RT_line))
+                K_RT[sl, st_ind] = ret_K_RT_line
+
+        nxs = [x.shape[0] for x in ret_K_surfaces]
+        nys = [x.shape[1] for x in ret_K_surfaces]
+        init_x_offsets = s.cumsum([0] + nxs)
+        init_y_offsets = s.cumsum([0] + nys)
+        K_surface = s.zeros((sum(nxs), sum(nys)))
+        for init_x_offset, init_y_offset, ret_K_surface in \
+                zip(init_x_offsets[:-1], init_y_offsets[:-1], ret_K_surfaces):
+            slx = slice(init_x_offset, init_x_offset + ret_K_surface.shape[0])
+            sly = slice(init_y_offset, init_y_offset + ret_K_surface.shape[1])
+            K_surface[slx, sly] = ret_K_surface
+
+        #pdb.set_trace()
+
+        return K_RT, K_surface
+        #return self.RTs['modtran_visnir'].drdn_dRT(x_RT, x_surface, rfl, drfl_dsurface,
+        #                            Ls, dLs_dsurface, geom)
+
     def drdn_dRTb(self, x_RT, rfl, Ls, geom):
-        #TODO: fix for multiple bands
-        return self.RTs['modtran_visnir'].drdn_dRTb(x_RT, rfl, Ls, geom)
-    
+        x_RT_dict = self.make_statevecs(x_RT)
+        ret = []
+        for key, RT in self.RTs.items():
+            #TODO: take rfl out of here and move it elsewhere
+            temp = self.RTs[key].drdn_dRTb(x_RT_dict[key], rfl, Ls, geom)
+            ret.append(s.squeeze(temp))
+        #pdb.set_trace()
+        return s.hstack(ret)[:,s.newaxis]
+        #return self.RTs['modtran_visnir'].drdn_dRTb(x_RT, rfl, Ls, geom)
+
     def summarize(self, x_RT, geom):
         #TODO: fix for multiple bands
         return self.RTs['modtran_visnir'].summarize(x_RT, geom)
-    
+
     def reconfigure(self, config_rt):
         #TODO: fix for multiple bands
         return self.RTs['modtran_visnir'].reconfigure(config_rt)
-    
+
     def make_statevecs(self, x_RT):
+        """Take the input state vector, whose elements are in the order
+        of unique_statevec and create a dict of individual state vectors
+        ready to be input to the individual RTMS in the RTs dict.
+        """
+
         x_RT_dict = {}
         for key, RT in self.RTs.items():
             val = []
-            #for state_component in RT.statevec:
-            for state_component in self.unique_statevec:
-                if state_component in RT.statevec:
-                    val.append(x_RT[self.unique_statevec.index(state_component)])
+            # Go in order of unique_statevec
+            #for state_component in self.unique_statevec:
+                #if state_component in RT.statevec:
+            for state_component in RT.statevec:
+                val.append(x_RT[self.unique_statevec.index(state_component)])
 
             x_RT_dict[key] = s.squeeze(s.array(val))
-        
+
         return x_RT_dict
-    
-    def pack_arrays(self, r_dict):
-        r_full = {}
-        for key in r_dict[0].keys():
-            temp = [x[key] for x in r_dict]
-            r_full[key] = s.hstack(temp)
-        return r_full
+
+    def pack_arrays(self, list_of_r_dicts):
+        """Take the list of dict outputs from each RTM (in order of RTs) and
+        stack their internal arrays in the same order.
+        """
+        r_stacked = {}
+        for key in list_of_r_dicts[0].keys():
+            temp = [x[key] for x in list_of_r_dicts]
+            r_stacked[key] = s.hstack(temp)
+        return r_stacked
 
 
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -22,7 +22,6 @@ import scipy as s
 import logging
 from copy import deepcopy
 from collections import OrderedDict
-import pdb
 
 from ..core.common import json_load_ascii
 from ..radiative_transfer.modtran import modtran_bands_available, ModtranRT
@@ -63,113 +62,77 @@ class RadiativeTransfer():
             else:
                 raise NotImplementedError
 
-        #TODO: fix for multiple bands
         self.wl = s.squeeze(s.array([RT.wl for RT in self.RTs.values()]))
+
         # The state vector is made of up unique elements of the individual RTs.
         # The idea is that each RT LUT may need H20STR, for example, but we
         # only want a single H20STR value in the statevector as it is shared.
         all_statevec = [s for RT in self.RTs.values() for s in RT.statevec] # Flatten a list of lists
         self.unique_statevec = list(set(all_statevec)) # Get unique elements
         self.unique_statevec.sort()
-        self.len_statevecs = [RT.n_state for RT in self.RTs.values()]
 
-
-        #self.statevec = self.RTs['modtran_visnir'].statevec
         self.statevec = self.unique_statevec
 
-        #self.bounds = self.RTs['modtran_visnir'].bounds
-        #self.scale = self.RTs['modtran_visnir'].scale
-        #self.init = self.RTs['modtran_visnir'].init
-        bounds = []
-        scale = []
-        init = []
-        print(self.unique_statevec, self.RTs['modtran_visnir'].statevec)
-        for key in self.unique_statevec:
-            if key in self.RTs['modtran_visnir'].statevec:
-                RT_temp = self.RTs['modtran_visnir']
-                bounds.append(RT_temp.bounds[RT_temp.statevec.index(key)])
-                scale.append(RT_temp.scale[RT_temp.statevec.index(key)])
-                init.append(RT_temp.init[RT_temp.statevec.index(key)])
-        self.bounds = bounds
-        self.scale = scale
-        self.init = init
+        statevec_temp, bounds, scales, inits = [], [], [], []
+        for RT in self.RTs.values():
+            statevec_temp = statevec_temp + [statevec for statevec in RT.statevec]
+            bounds = bounds + [bound for bound in RT.bounds]
+            scales = scales + [scale for scale in RT.scale]
+            inits = inits + [init for init in RT.init]
+        
+        self.bounds, self.scale, self.init = [], [], []
+        for unique_statevec_component in self.unique_statevec:
+            self.bounds.append(bounds[statevec_temp.index(unique_statevec_component)])
+            self.scale.append(scales[statevec_temp.index(unique_statevec_component)])
+            self.init.append(inits[statevec_temp.index(unique_statevec_component)])
+        
+        self.bvec = [bvec for bvec in RT.bvec for RT in self.RTs.values()]
+        self.bval = s.hstack([RT.bval for RT in self.RTs.values()])
+        # Not quite sure what to do with this right now. This check is to ensure
+        # that future updates correctly handle additions to bvec and bval
+        if len(self.bvec) != 1:
+            raise NotImplementedError
 
-        self.bvec = self.RTs['modtran_visnir'].bvec
-        self.bval = self.RTs['modtran_visnir'].bval
-        #self.lut_names = self.RTs['modtran_visnir'].lut_names
-        #self.lut_names = self.unique_statevec
-
-        #lut_grids = []
-        #print(self.unique_statevec, self.RTs['modtran_visnir'].statevec)
-        #for key in self.unique_statevec:
-        #    if key in self.RTs['modtran_visnir'].statevec:
-        #        RT_temp = self.RTs['modtran_visnir']
-        #        lut_grids.append(RT_temp.lut_grids[RT_temp.statevec.index(key)])
-        #self.lut_grids = lut_grids
-        self.solar_irr = self.RTs['modtran_visnir'].solar_irr
-        self.coszen = self.RTs['modtran_visnir'].coszen
-
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
-        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        self.solar_irr = s.squeeze(s.array([RT.solar_irr for RT in self.RTs.values()]))
+        self.coszen = s.squeeze(s.array([RT.coszen for RT in self.RTs.values()]))
 
     def xa(self):
-        #xa = self.RTs['modtran_visnir'].xa()
+        """Pull the priors from each of the individual RTs and order them
+        in the same order as unique_statevec.
+        TODO: check that the user correctly entered the priors
+        TODO: the same for each radiative_transfer entry in the json input
+        """
         prior_means = []
-        # We want to get the prior mean for each unique_statevec
-        # element in its order. For state vector elements that are
-        # shared between multiple RTMs, assume that the user
-        # correctly entered the priors as being the same.
-        # TODO: check that the user correctly entered the priors
-        # TODO: the same for each radiative_transfer entry in the json input
 
-        prior_means = []
-        # List of tuples of all RTs: (statevec_name, prior_mean)
-        # For example: 
-        for key, RT in self.RTs.items():
-            prior_means = prior_means + \
-                          [(statevec, prior_mean) for statevec, prior_mean in zip(RT.statevec, RT.prior_mean)]
+        statevec_temp, all_prior_means = [], []
+        for RT in self.RTs.values():
+            statevec_temp = statevec_temp + [statevec for statevec in RT.statevec]
+            all_prior_means = all_prior_means + [prior_mean for prior_mean in RT.prior_mean]
+
+        prior_mean = []
+        for unique_statevec_component in self.unique_statevec:
+            prior_mean.append(all_prior_means[statevec_temp.index(unique_statevec_component)])
         
-        prior_means = list(set(prior_means)) # Keep only unique entries
-
-        # Unless the user entered different priors for the same state vector elements
-        # in different 'radiative_tranfer' json entries, these should be the same size.
-        if len(prior_means) != len(self.unique_statevec):
-            raise AssertionError
-
-        prior_means.sort()  # Sort them into the same order as self.unique_statevec
-        prior_means = [prior_mean for _, prior_mean in prior_means] # Pull out prior value
-        return s.array(prior_means)
+        return s.array(prior_mean)
 
     def Sa(self):
+        """Pull the priors from each of the individual RTs and order them
+        in the same order as unique_statevec.
+        TODO: check that the user correctly entered the priors
+        TODO: the same for each radiative_transfer entry in the json input
+        """
 
         prior_sigmas = []
-        # List of tuples of all RTs: (statevec_name, prior_sigma)
-        # For example: 
-        for key, RT in self.RTs.items():
-            prior_sigmas = prior_sigmas + \
-                           [(statevec, prior_sigma) for statevec, prior_sigma in zip(RT.statevec, RT.prior_sigma)]
-        
-        prior_sigmas = list(set(prior_sigmas)) # Keep only unique entries
+        statevec_temp, all_prior_sigmas = [], []
+        for RT in self.RTs.values():
+            statevec_temp = statevec_temp + [statevec for statevec in RT.statevec]
+            all_prior_sigmas = all_prior_sigmas + [prior_mean for prior_mean in RT.prior_sigma]
 
-        # Unless the user entered different priors for the same state vector elements
-        # in different 'radiative_tranfer' json entries, these should be the same size.
-        if len(prior_sigmas) != len(self.unique_statevec):
-            raise AssertionError
+        prior_sigmas = []
+        for unique_statevec_component in self.unique_statevec:
+            prior_sigmas.append(all_prior_sigmas[statevec_temp.index(unique_statevec_component)])
 
-        prior_sigmas.sort()  # Sort them into the same order as self.unique_statevec
-        prior_sigmas = [prior_sigmas for _, prior_sigmas in prior_sigmas] # Pull out prior value
-
-        ret = s.diagflat(pow(s.array(prior_sigmas), 2))
-        #temp = self.RTs['modtran_visnir'].Sa()
-        return ret
+        return s.diagflat(pow(s.array(prior_sigmas), 2))
 
     def get(self, x_RT, geom):
 
@@ -177,7 +140,7 @@ class RadiativeTransfer():
         ret = []
         for key, RT in self.RTs.items():
             ret.append(self.RTs[key].get(x_RT_dict[key], geom))
-        #pdb.set_trace()
+
         return self.pack_arrays(ret)
 
     def calc_rdn(self, x_RT, rfl, Ls, geom):
@@ -186,9 +149,7 @@ class RadiativeTransfer():
         for key, RT in self.RTs.items():
             #TODO: take rfl out of here and move it elsewhere
             ret.append(self.RTs[key].calc_rdn(x_RT_dict[key], rfl, Ls, geom))
-        #pdb.set_trace()
         return s.hstack(ret)
-        #return self.RTs['modtran_visnir'].calc_rdn(x_RT, rfl, Ls, geom)
 
     def drdn_dRT(self, x_RT, x_surface, rfl, drfl_dsurface, Ls,
                  dLs_dsurface, geom):
@@ -223,11 +184,7 @@ class RadiativeTransfer():
             sly = slice(init_y_offset, init_y_offset + ret_K_surface.shape[1])
             K_surface[slx, sly] = ret_K_surface
 
-        #pdb.set_trace()
-
         return K_RT, K_surface
-        #return self.RTs['modtran_visnir'].drdn_dRT(x_RT, x_surface, rfl, drfl_dsurface,
-        #                            Ls, dLs_dsurface, geom)
 
     def drdn_dRTb(self, x_RT, rfl, Ls, geom):
         x_RT_dict = self.make_statevecs(x_RT)
@@ -236,17 +193,20 @@ class RadiativeTransfer():
             #TODO: take rfl out of here and move it elsewhere
             temp = self.RTs[key].drdn_dRTb(x_RT_dict[key], rfl, Ls, geom)
             ret.append(s.squeeze(temp))
-        #pdb.set_trace()
+
         return s.hstack(ret)[:,s.newaxis]
-        #return self.RTs['modtran_visnir'].drdn_dRTb(x_RT, rfl, Ls, geom)
 
     def summarize(self, x_RT, geom):
-        #TODO: fix for multiple bands
-        return self.RTs['modtran_visnir'].summarize(x_RT, geom)
+        ret = []
+        for RT in self.RTs.values():
+            ret.append(RT.summarize(x_RT, geom))
+        ret = '\n'.join(ret)
+        return ret
 
     def reconfigure(self, config_rt):
-        #TODO: fix for multiple bands
-        return self.RTs['modtran_visnir'].reconfigure(config_rt)
+        for RT in self.RTs.values():
+            RT.reconfigure(config_rt)
+        return 
 
     def make_statevecs(self, x_RT):
         """Take the input state vector, whose elements are in the order

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -148,10 +148,9 @@ class RadiativeTransfer():
         L_atm = self.get_L_atm(x_RT, geom)
         L_down = self.get_L_down(x_RT, geom)
 
-        #TODO: Ls should not be here!
-        L_up = self.get_L_up(x_RT, Ls, geom)
+        L_up = self.get_L_up(x_RT, geom)
+        L_up = L_up + Ls * r['transm']
 
-        #ret = L_atm + \
         ret = L_atm + \
               L_down * rfl * r['transm'] / (1.0 - r['sphalb'] * rfl) + \
               L_up
@@ -172,11 +171,11 @@ class RadiativeTransfer():
             L_downs.append(RT.get_L_down(x_RT_dict[key], geom))
         return s.hstack(L_downs)
 
-    def get_L_up(self, x_RT, Ls, geom):
+    def get_L_up(self, x_RT, geom):
         x_RT_dict = self.make_statevecs(x_RT)
         L_ups = []
         for key, RT in self.RTs.items():
-            L_ups.append(RT.get_L_up(x_RT_dict[key], Ls, geom))
+            L_ups.append(RT.get_L_up(x_RT_dict[key], geom))
         return s.hstack(L_ups)
 
     def drdn_dRT(self, x_RT, x_surface, rfl, drfl_dsurface, Ls,

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -1,0 +1,139 @@
+#! /usr/bin/env python3
+#
+#  Copyright 2018 California Institute of Technology
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ISOFIT: Imaging Spectrometer Optimal FITting
+# Author: Jay E. Fahlen, jay.e.fahlen@jpl.nasa.gov
+#
+
+import scipy as s
+import logging
+from copy import deepcopy
+from collections import OrderedDict
+
+from ..core.common import json_load_ascii
+from ..radiative_transfer.modtran import modtran_bands_available, ModtranRT
+
+class RadiativeTransfer():
+
+    def __init__(self, config):
+        """."""
+
+        # Maintain order when looping for indexing convenience
+        self.RTs = OrderedDict() 
+
+        for key, local_config in config.items():
+            if key in modtran_bands_available:
+                self.RTs[key] = ModtranRT(key, local_config)
+            else:
+                raise NotImplementedError
+
+        #TODO: fix for multiple bands
+        self.wl = s.squeeze(s.array([RT.wl for RT in self.RTs.values()]))
+        # The state vector is made of up unique elements of the individual RTs.
+        # The idea is that each RT LUT may need H20STR, for example, but we
+        # only want a single H20STR value in the statevector as it is shared.
+        all_statevec = [s for RT in self.RTs.values() for s in RT.statevec] # Flatten a list of lists
+        self.unique_statevec = list(set(all_statevec)) # Get unique elements
+        self.len_statevecs = [RT.n_state for RT in self.RTs.values()]
+
+
+        self.statevec = self.RTs['modtran_visnir'].statevec
+        self.bounds = self.RTs['modtran_visnir'].bounds
+        self.scale = self.RTs['modtran_visnir'].scale
+        self.init = self.RTs['modtran_visnir'].init
+        self.bvec = self.RTs['modtran_visnir'].bvec
+        self.bval = self.RTs['modtran_visnir'].bval
+        self.lut_names = self.RTs['modtran_visnir'].lut_names
+        self.lut_grids = self.RTs['modtran_visnir'].lut_grids
+        self.solar_irr = self.RTs['modtran_visnir'].solar_irr
+        self.coszen = self.RTs['modtran_visnir'].coszen
+
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+        #self. = s.squeeze(s.array([RT. for RT in self.RTs.values()]))
+    
+    def xa(self):
+        #TODO: fix for multiple bands
+        return self.RTs['modtran_visnir'].xa()
+        return self.RTs['modtran_visnir'].get(x_RT, geom)
+    
+    def Sa(self):
+        #TODO: fix for multiple bands
+        return self.RTs['modtran_visnir'].Sa()
+    
+    def get(self, x_RT, geom):
+
+        x_RT_dict = self.make_statevecs(x_RT)
+        ret = []
+        for key, RT in self.RTs.items():
+            ret.append(self.RTs[key].get(x_RT_dict[key], geom))
+        
+        return self.pack_arrays(ret)
+    
+    def calc_rdn(self, x_RT, rfl, Ls, geom):
+        #TODO: fix for multiple bands
+        return self.RTs['modtran_visnir'].calc_rdn(x_RT, rfl, Ls, geom)
+    
+    def drdn_dRT(self, x_RT, x_surface, rfl, drfl_dsurface, Ls, 
+                 dLs_dsurface, geom):
+        #TODO: fix for multiple bands
+        return self.RTs['modtran_visnir'].drdn_dRT(x_RT, x_surface, rfl, drfl_dsurface, 
+                                    Ls, dLs_dsurface, geom)
+    
+    def drdn_dRTb(self, x_RT, rfl, Ls, geom):
+        #TODO: fix for multiple bands
+        return self.RTs['modtran_visnir'].drdn_dRTb(x_RT, rfl, Ls, geom)
+    
+    def summarize(self, x_RT, geom):
+        #TODO: fix for multiple bands
+        return self.RTs['modtran_visnir'].summarize(x_RT, geom)
+    
+    def reconfigure(self, config_rt):
+        #TODO: fix for multiple bands
+        return self.RTs['modtran_visnir'].reconfigure(config_rt)
+    
+    def make_statevecs(self, x_RT):
+        x_RT_dict = {}
+        for key, RT in self.RTs.items():
+            val = []
+            #for state_component in RT.statevec:
+            for state_component in self.unique_statevec:
+                if state_component in RT.statevec:
+                    val.append(x_RT[self.unique_statevec.index(state_component)])
+
+            x_RT_dict[key] = s.squeeze(s.array(val))
+        
+        return x_RT_dict
+    
+    def pack_arrays(self, r_dict):
+        r_full = {}
+        for key in r_dict[0].keys():
+            temp = [x[key] for x in r_dict]
+            r_full[key] = s.hstack(temp)
+        return r_full
+
+
+
+
+
+

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -1,0 +1,158 @@
+#! /usr/bin/env python3
+#
+#  Copyright 2018 California Institute of Technology
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ISOFIT: Imaging Spectrometer Optimal FITting
+# Author: David R Thompson, david.r.thompson@jpl.nasa.gov
+#
+
+import scipy as s
+from scipy.linalg import inv
+from scipy.optimize import minimize
+
+from ..core.common import emissive_radiance, eps
+from .surface_multicomp import MultiComponentSurface
+
+
+class ThermalSurface(MultiComponentSurface):
+    """A model of the surface based on a Mixture of a hot Black Body and 
+        Multicomponent cold surfaces."""
+
+    def __init__(self, config):
+        """."""
+
+        MultiComponentSurface.__init__(self, config)
+        # Handle additional state vector elements
+        self.statevec.extend(['SURF_TEMP_K'])
+        self.init.extend([293.0]) # Room temperature
+        self.scale.extend([100.0])
+        self.bounds.extend([[250.0, 400.0]])
+        self.surf_temp_ind = len(self.statevec)-1
+        # Treat emissive surfaces as a fractional blackbody
+        self.emissive = True
+        self.n_state = len(self.init)
+
+    def xa(self, x_surface, geom):
+        """Mean of prior distribution, calculated at state x.  We find
+        the covariance in a normalized space (normalizing by z) and then un-
+        normalize the result for the calling function."""
+
+        mu = MultiComponentSurface.xa(self, x_surface, geom)
+        mu[self.surf_temp_ind] = self.init[self.surf_temp_ind]
+        return mu
+
+    def Sa(self, x_surface, geom):
+        """Covariance of prior distribution, calculated at state x."""
+
+        Cov = MultiComponentSurface.Sa(self, x_surface, geom)
+        t = s.array([[(10.0 * self.scale[self.surf_temp_ind])**2]])
+        Cov[self.surf_temp_ind, self.surf_temp_ind] = t
+        return Cov
+
+    def fit_params(self, rfl_meas, Ls, geom):
+        """Given a reflectance estimate and one or more emissive parameters, 
+          fit a state vector."""
+
+        def err(z):
+            T = z
+            print(T)
+            emissivity = s.ones(self.n_wl, dtype=float)
+            Ls_est, d = emissive_radiance(emissivity, T, self.wl)
+            resid = Ls_est - Ls
+            return sum(resid**2)
+
+        x_surface = MultiComponentSurface.fit_params(self, rfl_meas, Ls, geom)
+        T = minimize(err, s.array([self.init[self.surf_temp_ind]])).x
+        T = max(self.bounds[self.surf_temp_ind][0]+eps, 
+                min(T, self.bounds[self.surf_temp_ind][1]-eps))
+        x_surface[self.surf_temp_ind] = T
+        return x_surface
+
+    def conditional_solrfl(self, rfl_est, geom):
+        """Conditions the reflectance on solar-reflected channels."""
+
+        sol_inds = s.logical_and(self.wl > 450, self.wl < 1250)
+        if sum(sol_inds) < 1:
+            return rfl_est
+        x = s.zeros(len(self.statevec))
+        x[self.idx_lamb] = rfl_est
+        c = self.components[self.component(x, geom)]
+        mu_sol = c[0][sol_inds]
+        Cov_sol = s.array([c[1][i, sol_inds] for i in s.where(sol_inds)[0]])
+        Cinv = inv(Cov_sol)
+        diff = rfl_est[sol_inds] - mu_sol
+        full = c[0] + c[1][:, sol_inds].dot(Cinv.dot(diff))
+        return full
+
+    def calc_rfl(self, x_surface, geom):
+        """Reflectance."""
+
+        return self.calc_lamb(x_surface, geom)
+
+    def drfl_dsurface(self, x_surface, geom):
+        """Partial derivative of reflectance with respect to state vector, 
+        calculated at x_surface."""
+
+        return self.dlamb_dsurface(x_surface, geom)
+
+    def calc_lamb(self, x_surface, geom):
+        """Lambertian Reflectance."""
+
+        return MultiComponentSurface.calc_lamb(self, x_surface, geom)
+
+    def dlamb_dsurface(self, x_surface, geom):
+        """Partial derivative of Lambertian reflectance with respect to state 
+        vector, calculated at x_surface."""
+
+        dlamb = MultiComponentSurface.dlamb_dsurface(self, x_surface, geom)
+        dlamb[:, self.surf_temp_ind] = 0
+        return dlamb
+
+    def calc_Ls(self, x_surface, geom):
+        """Emission of surface, as a radiance."""
+
+        T = x_surface[self.surf_temp_ind]
+        #emissivity = s.ones(self.n_wl, dtype=float)
+        rfl = self.calc_rfl(x_surface, geom)
+        emissivity = 1 - rfl
+        Ls, dLs_dT = emissive_radiance(emissivity, T, self.wl)
+        return Ls
+
+    def dLs_dsurface(self, x_surface, geom):
+        """Partial derivative of surface emission with respect to state vector, 
+        calculated at x_surface."""
+
+        #dLs_dsurface = MultiComponentSurface.dLs_dsurface(self, x_surface,
+        #                                                  geom)
+        T = x_surface[self.surf_temp_ind]
+        rfl = self.calc_rfl(x_surface, geom)
+        emissivity = 1 - rfl
+        Ls, dLs_dT = emissive_radiance(emissivity, T, self.wl)
+        dLs_drfl = s.diag(Ls)
+                                                        
+        #frac = x_surface[self.bb_frac_ind]
+        #emissivity = s.ones(self.n_wl, dtype=float)
+        #dLs_dsurface[:, self.surf_temp_ind] = dLs_dT * 
+
+        dLs_dsurface = s.vstack([dLs_drfl, dLs_dT]).T
+
+        return dLs_dsurface
+
+    def summarize(self, x_surface, geom):
+        """Summary of state vector."""
+
+        mcm = MultiComponentSurface.summarize(self, x_surface, geom)
+        msg = ' Kelvins: %5.1f ' % tuple(x_surface[-1:])
+        return msg+mcm


### PR DESCRIPTION
This branch generalizes the RTM handling code. The idea is to move the radiative transfer equations out of the RTM classes (ModtranRT, for example) and out of look_up_tables.py. The generalization allows for multiple RTMs to be used, like a VSWIR and a separate TIR RTM. There are also a few minor input config file changes.

The code reproduces the Pasadena darklot example's reflectivity outputs exactly, but I have not tested it comprehensively against other examples.

Additionally, I have not actually tested having multiple RTMs yet. The point of this pull request is to alert others of the substantial changes contained here so that maybe we can avoid giant merge conflicts in the future. Of course, I'd be happy to see this in the main branch too should the group decide it's worthwhile.

The reason that this won't automatically merge is that, for testing purposes, my local master branch includes the changes described in Pull Request #63. The code in the current pull request no longer includes the lines changed in #63.