### PR TITLE
New thermal surface and t init

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -434,7 +434,7 @@ def conditional_gaussian(mu, C, window, remain, x):
     C12 = np.array([C[i,window] for i in remain])
     C21 = np.array([C[i,remain] for i in window])
     C22 = np.array([C[i,window] for i in window])
-    Cinv = scipy.linalg.inv(C11)
+    Cinv = svd_inv(C11)
     conditional_mean = mu[window] + C21 @ Cinv @ (x-mu[remain]) 
     conditional_Cov = C22 - C21 @ Cinv @ C12
     return conditional_mean, conditional_Cov

--- a/isofit/core/inverse_grid.py
+++ b/isofit/core/inverse_grid.py
@@ -149,7 +149,6 @@ class GridInversion(Inversion):
 
 
         for combo in combos(self.integration_grid.values()):
-           print(combo)
 
            self.x_fixed = combo.copy()
            trajectory = []
@@ -231,8 +230,6 @@ class GridInversion(Inversion):
                it = len(trajectory)
                rs = sum(pow(total_resid, 2))
                sm = self.fm.summarize(x, geom)
-               print('Iteration: %02i  Residual: %12.2f %s' %
-                            (it, rs, sm))
                logging.debug('Iteration: %02i  Residual: %12.2f %s' %
                              (it, rs, sm))
            


### PR DESCRIPTION
Two main changes here to the thermal parts:

1. Switch from using the conditional mean for the TIR surface reflectivity initialization to using the cluster mean. The cluster is chosen based on the initial, heuristic inversion of the VSWIR.

2. Make the surface temperature prior variance a config parameter instead of being hard coded. Also make the emissivity assumed for the initial temperature estimate a config parameter too. Both parameters are also given default values that seem to work ok.