### PR TITLE
Fix transm bug and rename l down

### DIFF
--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -574,7 +574,7 @@ class IO:
             rhoatm, sphalb, transm, solar_irr, coszen, transup = coeffs
 
             L_atm = self.fm.RT.get_L_atm(x_RT, geom)
-            L_down = self.fm.RT.get_L_down(x_RT, geom)
+            L_down_times_multiscattering_transmission = self.fm.RT.get_L_down_times_multiscattering_transmission(x_RT, geom)
             L_up = self.fm.RT.get_L_up(x_RT, geom)
 
             atm = s.column_stack(list(coeffs[:4]) +
@@ -689,7 +689,7 @@ class IO:
                 'transup': transup,
                 'solar_irr': solar_irr,
                 'L_atm': L_atm,
-                'L_down': L_down,
+                'L_down_times_multiscattering_transmission': L_down_times_multiscattering_transmission,
                 'L_up': L_up
             }
             s.io.savemat(self.output['data_dump_file'], mdict)

--- a/isofit/core/inverse_simple.py
+++ b/isofit/core/inverse_simple.py
@@ -129,19 +129,6 @@ def invert_algebraic(surface, RT, instrument, x_surface, x_RT, x_instrument, mea
     return rfl_est, Ls, coeffs
 
 
-def estimate_Ls(coeffs, rfl, rdn, geom):
-    """Estimate the surface emission for a given state vector and 
-    reflectance/radiance pair. This is determined by the residual
-    between the upward-welling radiance due to surface and 
-    scattering, and the measured radiance. We account for 
-    atmospheric transmission on the upward path."""
-
-    rhoatm, sphalb, transm, solar_irr, coszen, transup = coeffs
-    rho = rhoatm + transm * rfl / (1.0 - sphalb * rfl)
-    Ls = (rdn - rho/s.pi*(solar_irr*coszen)) / transup
-    return Ls
-
-
 def invert_simple(forward, meas, geom):
     """Find an initial guess at the state vector. This currently uses
     traditional (non-iterative, heuristic) atmospheric correction."""
@@ -187,9 +174,9 @@ def invert_simple(forward, meas, geom):
     # Estimate the total radiance at sensor, leaving out the surface emission
     rhoatm, sphalb, transm, solar_irr, coszen, transup = coeffs
     L_atm = RT.get_L_atm(x_RT, geom)
-    L_down = RT.get_L_down(x_RT, geom)
+    L_down_times_multiscattering_transmission = RT.get_L_down_times_multiscattering_transmission(x_RT, geom)
     L_total_without_surface_emission = \
-            L_atm + L_down * rfl_est * transm / (1. - sphalb * rfl_est)
+            L_atm + L_down_times_multiscattering_transmission * rfl_est / (1. - sphalb * rfl_est)
     
     # These tend to have high transmission factors and the emissivity of most
     # materials is nearly 1 for these bands, so they are good for initializing the 

--- a/isofit/radiative_transfer/libradtran.py
+++ b/isofit/radiative_transfer/libradtran.py
@@ -291,8 +291,9 @@ class LibRadTranRT(TabularRT):
         rdn = rho / s.pi*(self.solar_irr * self.coszen)
         return rdn
 
-    def get_L_down(self, x_RT, geom):
-        rdn = (self.solar_irr * self.coszen) / s.pi
+    def get_L_down_times_multiscattering_transmission(self, x_RT, geom):
+        r = self.get(x_RT, geom)
+        rdn = (self.solar_irr * self.coszen) / s.pi * r['transm']
         return rdn
 
     def get_L_up(self, x_RT, geom):

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -187,7 +187,7 @@ class ModtranRT(TabularRT):
                 thermal_upwelling = (thermal_emission + thermal_scatter) / wid * 1e6  # uW/nm/sr/cm2
 
                 # Be careful with these! See note in function comments above
-                grnd_rflt = float(toks[16])
+                grnd_rflt = float(toks[16]) # Already includes ground-to-sensor transmission
                 thermal_downwelling = grnd_rflt / wid * 1e6  # uW/nm/sr/cm2
 
                 sols.append(solar_irr)
@@ -434,19 +434,23 @@ class ModtranRT(TabularRT):
         r = self.get(x_RT, geom)
         return r['thermal_upwelling']
 
-    def get_L_down(self, x_RT, geom):
+    def get_L_down_times_multiscattering_transmission(self, x_RT, geom):
         if self.band_mode_string.lower() == 'modtran_vswir':
-            return self.get_L_down_vswir(x_RT, geom)
+            return self.get_L_down_times_multiscattering_transmission_vswir(x_RT, geom)
         elif self.band_mode_string.lower() == 'modtran_tir':
-            return self.get_L_down_tir(x_RT, geom)
+            return self.get_L_down_times_multiscattering_transmission_tir(x_RT, geom)
         else:
             raise NotImplementedError
 
-    def get_L_down_vswir(self, x_RT, geom):
-        rdn = (self.solar_irr*self.coszen) / s.pi
+    def get_L_down_times_multiscattering_transmission_vswir(self, x_RT, geom):
+        r = self.get(x_RT, geom)
+        rdn = (self.solar_irr*self.coszen) / s.pi * r['transm']
         return rdn
 
-    def get_L_down_tir(self, x_RT, geom):
+    def get_L_down_times_multiscattering_transmission_tir(self, x_RT, geom):
+        """thermal_downwelling already includes the transmission factor. Also
+        assume there is no multiple scattering for TIR.
+        """
         r = self.get(x_RT, geom)
         return r['thermal_downwelling']
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -189,8 +189,14 @@ class RadiativeTransfer():
         # Get K_surface
         r = self.get(x_RT, geom)
         L_down_times_multiscattering_transmission = self.get_L_down_times_multiscattering_transmission(x_RT, geom)
-        drho_drfl = 1. / (1 - r['sphalb']*rfl)**2
-        drdn_drfl = drho_drfl * L_down_times_multiscattering_transmission
+
+        # The reflected downwelling light is:
+        # L_down_times_multiscattering_transmission * rfl / (1.0 - r['sphalb'] * rfl), or 
+        # L_down_times_multiscattering_transmission * rho_scaled_for_multiscattering
+        # This term is the derivative of rho_scaled_for_multiscattering
+        drho_scaled_for_multiscattering_drfl = 1. / (1 - r['sphalb']*rfl)**2
+
+        drdn_drfl = L_down_times_multiscattering_transmission * drho_scaled_for_multiscattering_drfl
         drdn_dLs = r['transup']
         K_surface = drdn_drfl[:, s.newaxis] * drfl_dsurface + \
             drdn_dLs[:, s.newaxis] * dLs_dsurface

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -139,13 +139,13 @@ class RadiativeTransfer():
     def calc_rdn(self, x_RT, rfl, Ls, geom):
         r = self.get(x_RT, geom)
         L_atm = self.get_L_atm(x_RT, geom)
-        L_down = self.get_L_down(x_RT, geom)
+        L_down_times_multiscattering_transmission = self.get_L_down_times_multiscattering_transmission(x_RT, geom)
 
         L_up = self.get_L_up(x_RT, geom)
         L_up = L_up + Ls * r['transup']
 
         ret = L_atm + \
-            L_down * rfl * r['transm'] / (1.0 - r['sphalb'] * rfl) + \
+            L_down_times_multiscattering_transmission * rfl / (1.0 - r['sphalb'] * rfl) + \
             L_up
 
         return ret
@@ -156,10 +156,10 @@ class RadiativeTransfer():
             L_atms.append(RT.get_L_atm(x_RT, geom))
         return s.hstack(L_atms)
 
-    def get_L_down(self, x_RT, geom):
+    def get_L_down_times_multiscattering_transmission(self, x_RT, geom):
         L_downs = []
         for key, RT in self.RTs.items():
-            L_downs.append(RT.get_L_down(x_RT, geom))
+            L_downs.append(RT.get_L_down_times_multiscattering_transmission(x_RT, geom))
         return s.hstack(L_downs)
 
     def get_L_up(self, x_RT, geom):
@@ -188,9 +188,9 @@ class RadiativeTransfer():
 
         # Get K_surface
         r = self.get(x_RT, geom)
-        L_down = self.get_L_down(x_RT, geom)
-        drho_drfl = r['transm'] / (1 - r['sphalb']*rfl)**2
-        drdn_drfl = drho_drfl * L_down
+        L_down_times_multiscattering_transmission = self.get_L_down_times_multiscattering_transmission(x_RT, geom)
+        drho_drfl = 1. / (1 - r['sphalb']*rfl)**2
+        drdn_drfl = drho_drfl * L_down_times_multiscattering_transmission
         drdn_dLs = r['transup']
         K_surface = drdn_drfl[:, s.newaxis] * drfl_dsurface + \
             drdn_dLs[:, s.newaxis] * dLs_dsurface

--- a/isofit/radiative_transfer/six_s.py
+++ b/isofit/radiative_transfer/six_s.py
@@ -278,8 +278,9 @@ class SixSRT(TabularRT):
         rdn = rho / s.pi*(self.solar_irr * self.coszen)
         return rdn
 
-    def get_L_down(self, x_RT, geom):
-        rdn = (self.solar_irr * self.coszen) / s.pi
+    def get_L_down_times_multiscattering_transmission(self, x_RT, geom):
+        r = self.get(x_RT, geom)
+        rdn = (self.solar_irr * self.coszen) / s.pi * r['transm']
         return rdn
 
     def get_L_up(self, x_RT, geom):


### PR DESCRIPTION
This PR fixes an oversight in the TIR RTM that used the transm quantity in the L_down component of the radiance model. It should be one. In fixing this bug, it renames a few quantities and functions in order to be a bit clearer.