### PR TITLE
Adds simple speedups

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -419,10 +419,13 @@ def conditional_gaussian(mu, C, window, remain, x):
     contains all other indices, 
     such that len(window)+len(remain)=len(x)
     """
-    C11 = np.array([C[i, remain] for i in remain])
-    C12 = np.array([C[i, window] for i in remain])
-    C21 = np.array([C[i, remain] for i in window])
-    C22 = np.array([C[i, window] for i in window])
+    w = np.array(window)[:,np.newaxis]
+    r = np.array(remain)[:,np.newaxis]
+    C11 = C[r, r.T]
+    C12 = C[r, w.T]
+    C21 = C[w, r.T]
+    C22 = C[w, w.T]
+
     Cinv = svd_inv(C11)
     conditional_mean = mu[window] + C21 @ Cinv @ (x-mu[remain])
     conditional_Cov = C22 - C21 @ Cinv @ C12

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -305,6 +305,11 @@ class ForwardModel:
     def upsample(self, wl, q):
         """Linear interpolation to RT wavelengths."""
 
+        # In some cases, these differ only by a tiny amount,
+        # so no need to waste time interpolating
+        if s.allclose(wl, self.RT.wl):
+            return q
+
         if q.ndim > 1:
             q2 = []
             for qi in q:

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -91,6 +91,9 @@ class ModtranRT(TabularRT):
         self.angular_lut_keys_degrees = ['OBSZEN','TRUEAZ','viewzen','viewaz',
             'solzen','solaz']
 
+        self.last_point_looked_up = s.zeros(self.n_point)
+        self.last_point_lookup_values = s.zeros(self.n_point)
+
         # Build the lookup table
         self.build_lut()
 
@@ -388,11 +391,17 @@ class ModtranRT(TabularRT):
         return results_dict
 
     def _lookup_lut(self, point):
-        ret = {}
-        for key, lut in self.luts.items():
-            ret[key] = s.array(lut(point)).ravel()
 
-        return ret
+        if s.all(s.equal(point, self.last_point_looked_up)):
+            return self.last_point_lookup_values
+        else:
+            ret = {}
+            for key, lut in self.luts.items():
+                ret[key] = s.array(lut(point)).ravel()
+
+            self.last_point_looked_up = point
+            self.last_point_lookup_values = ret
+            return ret
 
     def get(self, x_RT, geom):
         point = s.zeros((self.n_point,))


### PR DESCRIPTION
Using a cProfile, I found a few simple changes that result in a speed up of approximately a factor of 2.

Here's a summary of the profiler output after these changes:

I ran 5 pixels in serial (debug mode). The test machine had higher usage from other users on the new run, but this would mean that the new runtime would be lower than reported here and hence more favorable.

Original run time: 74 s
New run time: 39.5 s

isofit.run_single_spectrum: 39.5
    inverse_grid.invert: 33.1
        inverse_grid least_squares: 31.1
            internal svd decomp: 20.3
            jac: 6.4
            err: 3.7

These results suggest that there is not much speedup to be had by optimizing the jac or err functions (and hence nearly all the python code) as the main time sink is the SVD decomposition apparently being done inside the least_squares call. Possibly a new numerical library (like MKL?) would speed this up. Taking fewer steps with a better initialization or more relaxed convergence constraints would also help.

For parallel runs, the __init__ functions are being called for each pixel, I think. Since the LUTs are the same for each pixel, a small improvement might be had by performing the initialization only once and passing the LUT to each parallel task.