### PR TITLE
Multiprocessing rework

### DIFF
--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -172,7 +172,7 @@ class Isofit:
 
             results = []
             index_sets = np.linspace(0, n_iter, num=n_cores+1, dtype=int)
-            for l in range(n_iter):
+            for l in range(len(index_sets)-1):
                 if n_cores == 1:
                     self._run_set_of_spectra(index_sets[0], index_sets[-1])
                 else:


### PR DESCRIPTION
Rework multiprocessing workflow to minimize redundant pickling.  Test case using 100 spectra (426 band), and 10 cores:

Prior: 
Parallel inversions complete.  89.84578514099121 s total, 1.1130182661665675 spectra/s, 0.11130182661665675/spectra/core

After change:
Parallel inversions complete.  34.05124616622925 s total, 2.9367500828553013 spectra/s, 0.2936750082855301/spectra/core

Speedup factor: 2.64


