### PR TITLE
Modtran h2o bounds

### DIFF
--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -33,6 +33,7 @@ from .fileio import IO
 import multiprocessing
 from isofit import configs
 from isofit.configs import configs
+import numpy as np
 
 
 class Isofit:
@@ -100,29 +101,30 @@ class Isofit:
         self.fm = None
         self.iv = None
 
-    def _run_single_spectrum(self, index):
+    def _run_set_of_spectra(self, index_start, index_stop):
         self._init_nonpicklable_objects()
         io = IO(self.config, self.fm, self.iv, self.rows, self.cols)
-        success, row, col, meas, geom, configs = io.get_components_at_index(
-            index)
-        # Only run through the inversion if we got some data
-        if success:
-            if meas is not None and all(meas < -49.0):
-                # Bad data flags
-                self.states = []
-            else:
-                # The inversion returns a list of states, which are
-                # intepreted either as samples from the posterior (MCMC case)
-                # or as a gradient descent trajectory (standard case). For
-                # a trajectory, the last spectrum is the converged solution.
-                self.states = self.iv.invert(meas, geom)
+        for index in range(index_start, index_stop):
+            success, row, col, meas, geom, configs = io.get_components_at_index(
+                index)
+            # Only run through the inversion if we got some data
+            if success:
+                if meas is not None and all(meas < -49.0):
+                    # Bad data flags
+                    self.states = []
+                else:
+                    # The inversion returns a list of states, which are
+                    # intepreted either as samples from the posterior (MCMC case)
+                    # or as a gradient descent trajectory (standard case). For
+                    # a trajectory, the last spectrum is the converged solution.
+                    self.states = self.iv.invert(meas, geom)
 
-            # Write the spectra to disk
-            io.write_spectrum(row, col, self.states, meas,
-                              geom, flush_immediately=True)
-            if index % 1000 == 0:
-                logging.info(
-                    'Completed inversion {}/{}'.format(index, len(io.iter_inds)))
+                # Write the spectra to disk
+                io.write_spectrum(row, col, self.states, meas,
+                                  geom, flush_immediately=True)
+                if index % 1000 == 0:
+                    logging.info(
+                        'Completed inversion {}/{}'.format(index, len(io.iter_inds)))
 
     def run(self, profile=False):
         """
@@ -156,6 +158,9 @@ class Isofit:
             else:
                 n_cores = self.config.implementation.n_cores
 
+            # Don't use more cores than needed
+            n_cores = min(n_cores, n_iter)
+
             if self.config.implementation.runtime_nice_level is None:
                 pool = multiprocessing.Pool(processes=n_cores)
             else:
@@ -166,11 +171,12 @@ class Isofit:
             logging.info('Beginning inversions using {} cores'.format(n_cores))
 
             results = []
-            for l in range(n_iter):
+            index_sets = np.linspace(0, n_iter, num=n_cores+1, dtype=int)
+            for l in range(len(index_sets)-1):
                 if n_cores == 1:
-                    self._run_single_spectrum(l)
+                    self._run_set_of_spectra(index_sets[0], index_sets[-1])
                 else:
-                    results.append(pool.apply_async(self._run_single_spectrum, args=(l,)))
+                    results.append(pool.apply_async(self._run_set_of_spectra, args=(index_sets[l], index_sets[l + 1])))
             results = [p.get() for p in results]
             pool.close()
             pool.join()

--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -178,11 +178,7 @@ class TabularRT:
         # "points" contains all combinations of grid points
         # We will have one filename prefix per point
         self.points = common.combos(self.lut_grids)
-        self.files = []
-        for point in self.points:
-            outf = '_'.join(['%s-%6.4f' % (n, x)
-                             for n, x in zip(self.lut_names, point)])
-            self.files.append(outf)
+        self.files = self.get_lut_filenames()
 
         # Build the list of radiative transfer run commands. This
         # rebuild_cmd() function will be overriden by the child class to
@@ -224,6 +220,14 @@ class TabularRT:
             r = pool.map_async(spawn_rt, rebuild_cmds)
             r.wait()
             os.chdir(cwd)
+
+    def get_lut_filenames(self):
+        files = []
+        for point in self.points:
+            outf = '_'.join(['%s-%6.4f' % (n, x)
+                             for n, x in zip(self.lut_names, point)])
+            files.append(outf)
+        return files
 
     def summarize(self, x_RT, geom):
         """Summary of state vector."""

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -277,47 +277,49 @@ class ModtranRT(TabularRT):
         # MODTRAN caps the value at 5x profile specified value or 100% RH, as
         # defined in PDF-page 52 of the MODTRAN user guide.
         if 'H2OSTR' in self.lut_names:
+            if 'H2OOPT' in self.template[0]['MODTRANINPUT']['ATMOSPHERE'].keys() and self.template[0]['MODTRANINPUT']['ATMOSPHERE']['H2OOPT'] == '+':
+                logging.info('H2OOPT found in MODTRAN template - ignoring H2O upper bound')
+            else:
+                # Only do this check if we don't have a LUT provided:
+                need_to_rebuild = np.any([not self.required_results_exist(x) for x in self.get_lut_filenames()])
+                if need_to_rebuild:
 
-            # Only do this check if we don't have a LUT provided:
-            need_to_rebuild = np.any([not self.required_results_exist(x) for x in self.get_lut_filenames()])
-            if need_to_rebuild:
+                    # Define a realistic point, based on lut grid
+                    point = np.array([x[-1] for x in self.lut_grids])
 
-                # Define a realistic point, based on lut grid
-                point = np.array([x[-1] for x in self.lut_grids])
+                    # Set the H2OSTR value as arbitrarily high - 50 g/cm2 in this case
+                    point[self.lut_names.index('H2OSTR')] = 50
 
-                # Set the H2OSTR value as arbitrarily high - 50 g/cm2 in this case
-                point[self.lut_names.index('H2OSTR')] = 50
+                    filebase = os.path.join(os.path.dirname(self.files[-1]), 'H2O_bound_test')
+                    cmd = self.rebuild_cmd(point, filebase)
 
-                filebase = os.path.join(os.path.dirname(self.files[-1]), 'H2O_bound_test')
-                cmd = self.rebuild_cmd(point, filebase)
-
-                # Run MODTRAN for up to 10 seconds - this should be plenty of time
-                cwd = os.getcwd()
-                if os.path.isdir(self.lut_dir) is False:
-                    os.mkdir(self.lut_dir)
-                os.chdir(self.lut_dir)
-                try:
-                    subprocess.call(cmd, shell=True, timeout=10)
-                except:
-                    pass
-                os.chdir(cwd)
+                    # Run MODTRAN for up to 10 seconds - this should be plenty of time
+                    cwd = os.getcwd()
+                    if os.path.isdir(self.lut_dir) is False:
+                        os.mkdir(self.lut_dir)
+                    os.chdir(self.lut_dir)
+                    try:
+                        subprocess.call(cmd, shell=True, timeout=10)
+                    except:
+                        pass
+                    os.chdir(cwd)
 
 
-                max_water = None
-                with open(os.path.join(self.lut_dir,filebase + '.tp6')) as tp6file:
-                    for count, line in enumerate(tp6file):
-                        if 'The water column is being set to the maximum' in line:
-                            max_water = line.split(',')[1].strip()
-                            max_water = float(max_water.split(' ')[0])
-                            break
+                    max_water = None
+                    with open(os.path.join(self.lut_dir,filebase + '.tp6')) as tp6file:
+                        for count, line in enumerate(tp6file):
+                            if 'The water column is being set to the maximum' in line:
+                                max_water = line.split(',')[1].strip()
+                                max_water = float(max_water.split(' ')[0])
+                                break
 
-                if max_water is None:
-                    logging.error('Could not find MODTRAN H2O upper bound in file {}'.format(filebase + '.tp6'))
-                    raise KeyError('Could not find MODTRAN H2O upper bound')
+                    if max_water is None:
+                        logging.error('Could not find MODTRAN H2O upper bound in file {}'.format(filebase + '.tp6'))
+                        raise KeyError('Could not find MODTRAN H2O upper bound')
 
-                if np.max(self.lut_grids[self.lut_names.index('H2OSTR')]) > max_water:
-                    logging.error('MODTRAN max H2OSTR with current profile is {}, while H2O lut_grid is {}.  Either adjust MODTRAN profile or lut_grid'.format(max_water, self.lut_grids[self.lut_names.index('H2OSTR')]))
-                    raise KeyError('MODTRAN H2O lut grid is invalid - see logs for details.')
+                    if np.max(self.lut_grids[self.lut_names.index('H2OSTR')]) > max_water:
+                        logging.error('MODTRAN max H2OSTR with current profile is {}, while H2O lut_grid is {}.  Either adjust MODTRAN profile or lut_grid.  To over-ride MODTRANs maximum allowable value, set H2OOPT to "+"'.format(max_water, self.lut_grids[self.lut_names.index('H2OSTR')]))
+                        raise KeyError('MODTRAN H2O lut grid is invalid - see logs for details.')
 
 
         TabularRT.build_lut(self, rebuild)
@@ -372,8 +374,7 @@ class ModtranRT(TabularRT):
                 current_config[0]['MODTRANINPUT']['SPECTRAL']['FILTNM'] = ''
                 modtran_config[0]['MODTRANINPUT']['SPECTRAL']['FILTNM'] = ''
                 current_str = json.dumps(current_config)
-                #TODO: check if current_config below is correct, or should be modtran_config
-                modtran_str = json.dumps(current_config)
+                modtran_str = json.dumps(modtran_config)
                 rebuild = (modtran_str.strip() != current_str.strip())
 
         if not rebuild:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -192,7 +192,7 @@ def main():
             raise KeyError('Could not find MODTRAN H2O upper bound')
 
         # Write the presolve connfiguration file
-        h2o_grid = np.linspace(0.01, max_water, 10).round(2)
+        h2o_grid = np.linspace(0.01, max_water - 0.01, 10).round(2)
         logging.info('Pre-solve H2O grid: {}'.format(h2o_grid))
         logging.info('Writing H2O pre-solve configuration file.')
         build_presolve_config(paths, h2o_grid, args.n_cores)

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -14,6 +14,8 @@ import json
 import gdal
 import numpy as np
 from sklearn import mixture
+import subprocess
+from sys import platform
 
 from isofit.utils import segment, extractions, empirical_line
 from isofit.core import isofit, common
@@ -99,7 +101,7 @@ def main():
         wl = np.array([float(w) for w in radiance_dataset.metadata['wavelength']])
         if 'fwhm' in radiance_dataset.metadata:
             fwhm = np.array([float(f) for f in radiance_dataset.metadata['fwhm']])
-        if 'FWHM' in radiance_dataset.metadata:
+        elif 'FWHM' in radiance_dataset.metadata:
             fwhm = np.array([float(f) for f in radiance_dataset.metadata['FWHM']])
         else:
             fwhm = np.ones(wl.shape) * (wl[1] - wl[0])
@@ -151,9 +153,39 @@ def main():
                                gmtime=gmtime, elevation_km=mean_elevation_km,
                                output_file=paths.h2o_template_path, ihaze_type='AER_NONE')
 
+        # TODO: this is effectively redundant from the radiative_transfer->modtran. Either devise a way
+        # to port in from there, or put in utils to reduce redundancy.
+        xdir = {
+            'linux': 'linux',
+            'darwin': 'macos',
+            'windows': 'windows'
+        }
+        filebase = os.path.join(paths.lut_h2o_directory, 'H2O_bound_test')
+        copyfile(paths.h2o_template_path, filebase + '.json')
+        cwd = os.getcwd()
+        os.chdir(paths.lut_h2o_directory)
+        cmd = os.path.join(paths.modtran_path, 'bin', xdir[platform], 'mod6c_cons ' + filebase + '.json')
+        try:
+            subprocess.call(cmd, shell=True, timeout=10)
+        except:
+            pass
+        os.chdir(cwd)
+
+        max_water = None
+        with open(filebase + '.tp6') as tp6file:
+            for count, line in enumerate(tp6file):
+                if 'The water column is being set to the maximum' in line:
+                    max_water = line.split(',')[1].strip()
+                    max_water = float(max_water.split(' ')[0])
+                    break
+
+        if max_water is None:
+            logging.error('Could not find MODTRAN H2O upper bound in file {}'.format(filebase + '.tp6'))
+            raise KeyError('Could not find MODTRAN H2O upper bound')
+
         # Write the presolve connfiguration file
         logging.info('Writing H2O pre-solve configuration file.')
-        build_presolve_config(paths, np.linspace(0.5, 5, 10), args.n_cores)
+        build_presolve_config(paths, np.linspace(0.01, max_water, 10).round(2), args.n_cores)
 
         # Run modtran retrieval
         logging.info('Run ISOFIT initial guess')

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -160,8 +160,16 @@ def main():
             'darwin': 'macos',
             'windows': 'windows'
         }
-        filebase = os.path.join(paths.lut_h2o_directory, 'H2O_bound_test')
-        copyfile(paths.h2o_template_path, filebase + '.json')
+        name = 'H2O_bound_test'
+        filebase = os.path.join(paths.lut_h2o_directory, name)
+        with open(paths.h2o_template_path, 'r') as f:
+            bound_test_config = json.load(f)
+
+        bound_test_config['MODTRAN'][0]['MODTRANINPUT']['NAME'] = name
+        bound_test_config['MODTRAN'][0]['MODTRANINPUT']['ATMOSPHERE']['H2OSTR'] = 50
+        with open(filebase + '.json', 'w') as fout:
+            fout.write(json.dumps(bound_test_config, cls=SerialEncoder, indent=4, sort_keys=True))
+
         cwd = os.getcwd()
         os.chdir(paths.lut_h2o_directory)
         cmd = os.path.join(paths.modtran_path, 'bin', xdir[platform], 'mod6c_cons ' + filebase + '.json')
@@ -184,8 +192,10 @@ def main():
             raise KeyError('Could not find MODTRAN H2O upper bound')
 
         # Write the presolve connfiguration file
+        h2o_grid = np.linspace(0.01, max_water, 10).round(2)
+        logging.info('Pre-solve H2O grid: {}'.format(h2o_grid))
         logging.info('Writing H2O pre-solve configuration file.')
-        build_presolve_config(paths, np.linspace(0.01, max_water, 10).round(2), args.n_cores)
+        build_presolve_config(paths, h2o_grid, args.n_cores)
 
         # Run modtran retrieval
         logging.info('Run ISOFIT initial guess')

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -217,9 +217,12 @@ def main():
                                    np.percentile(h2o_est[h2o_est > lut_params.h2o_min], 95),
                                    lut_params.num_h2o_lut_elements)
 
-        #TODO: adjust to better heuristic, (based on num_h2o_lut_elements perhaps)
-        if (np.abs(h2o_lut_grid[-1] - h2o_lut_grid[0]) < 0.1):
-            h2o_lut_grid = np.linspace(h2o_lut_grid[0] - 0.5, h2o_lut_grid[0] + 0.5, lut_params.num_h2o_lut_elements)
+        if (np.abs(h2o_lut_grid[-1] - h2o_lut_grid[0]) < 0.03):
+            new_h2o_lut_grid = np.linspace(h2o_lut_grid[0] - 0.1* np.ceil(lut_params.num_h2o_lut_elements/2.), 
+                                           h2o_lut_grid[0] + 0.1*np.ceil(lut_params.num_h2o_lut_elements/2.), 
+                                           lut_params.num_h2o_lut_elements)
+            logging.warning('Warning: h2o lut grid from presolve detected as {}-{}, which is very narrow.  Expanding to {}-{}.  Advised to check presolve solutions thoroughly.'.format(h2o_lut_grid[0],h2o_lut_grid[-1], new_h2o_lut_grid[0], new_h2o_lut_grid[-1]))
+            h2o_lut_grid = new_h2o_lut_grid
     else:
         h2o_lut_grid = np.linspace(lut_params.default_h2o_lut_range[0], lut_params.default_h2o_lut_range[1],
                                    lut_params.num_h2o_lut_elements)

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -144,7 +144,7 @@ def main():
                             output=outp, chunksize=CHUNKSIZE, flag=-9999)
 
 
-    if args.presolve == 1 and not exists(paths.h2o_subs_path + '.hdr') or not exists(paths.h2o_subs_path):
+    if args.presolve == 1 and (not exists(paths.h2o_subs_path + '.hdr') or not exists(paths.h2o_subs_path)):
         write_modtran_template(atmosphere_type='ATM_MIDLAT_SUMMER', fid=paths.fid, altitude_km=mean_altitude_km,
                                dayofyear=dayofyear, latitude=mean_latitude, longitude=mean_longitude,
                                to_sensor_azimuth=mean_to_sensor_azimuth, to_sensor_zenith=mean_to_sensor_zenith,


### PR DESCRIPTION
Patch fix to handle the case where the H2OSTR exceeds 100% RH or 5x the original value.  If a lut_grid is specified that exceeds what MODTRAN can model, an exception is thrown.  This is to safeguard against subsequent Jacobian miscalculations and ultimately bad inversions, for these cases.

If you intentionally want to override the H2OSTR maximum, you can either change to a custom, user profile, or set the ATMOSPHERE->H2OOPT option to '+'.

apply_oe has been updated to use the maximum atmospheric water value accepted by MODTRAN for running the presolve.