### PR TITLE
Stability upgrades

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -52,7 +52,7 @@ class SurfaceConfig(BaseConfigSection):
         The state is preserved in the geometry object so that this object stays stateless"""
 
         self._selection_metric_type = str
-        self.selection_metric = 'Mahalanobis'
+        self.selection_metric = 'Euclidean'
 
         # Surface Thermal
         self._emissivity_for_surface_T_init_type = float

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -84,7 +84,7 @@ class Inversion:
                        self.fm.bounds[1][self.inds_free] - eps),
             'x_scale': self.fm.scale[self.inds_free],
             'xtol': 1e-4,
-            'ftol': 1e-4,
+            'ftol': 1e-8,
             'gtol': 1e-4,
             'tr_solver': 'exact'
         }

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -84,7 +84,7 @@ class Inversion:
                        self.fm.bounds[1][self.inds_free] - eps),
             'x_scale': self.fm.scale[self.inds_free],
             'xtol': 1e-4,
-            'ftol': 1e-8,
+            'ftol': 1e-4,
             'gtol': 1e-4,
             'tr_solver': 'exact'
         }


### PR DESCRIPTION
I think that a few minor changes might improve stability, particularly for new users.

1) Make the "Euclidean" distance metric for component selection the default choice in our multicomponent surface models.   I can't remember a time when it made a blatantly unreasonable choice.  In contrast, the Mahalanobis methods can occasionally be tricked (by near-singular covariances?) into selecting an unrealistic model.  This results in very strange and difficult-to-diagnose error conditions - the spectrum converges, but to an answer which is obviously wrong.  Switching to Euclidean selection immediately solves the problem.

2) Increase the precision tolerance for optimization convergence, at the suggestion of Jay Fahlen.

3) Artificially broaden the range of H2O vapor resulting from apply_oe.py's initial pre-solve.  Since the pre-solve doesn't include aerosols, its answer could be biased high or low.

4) In apply_oe.py, set the instrument "number of integrations" to match the number of spectra which are averaged for each inversion.  This was the original intent of the parameter.  I typically use a value of unity.  If we are operating on superpixel average spectra, it can be set to the number of spectra in the superpixel.  This will modify the instrument noise assumptions to reflect the "averaging down" of variability.