### PR TITLE
Avoiding codec error when reading tp6 file in water vapor bound test

### DIFF
--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -306,7 +306,7 @@ class ModtranRT(TabularRT):
 
 
                     max_water = None
-                    with open(os.path.join(self.lut_dir,filebase + '.tp6')) as tp6file:
+                    with open(os.path.join(self.lut_dir,filebase + '.tp6'), errors='ignore') as tp6file:
                         for count, line in enumerate(tp6file):
                             if 'The water column is being set to the maximum' in line:
                                 max_water = line.split(',')[1].strip()

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -183,7 +183,7 @@ def main():
         os.chdir(cwd)
 
         max_water = None
-        with open(filebase + '.tp6') as tp6file:
+        with open(filebase + '.tp6', errors='ignore') as tp6file:
             for count, line in enumerate(tp6file):
                 if 'The water column is being set to the maximum' in line:
                     max_water = line.split(',')[1].strip()


### PR DESCRIPTION
This fixes a problem which occurred when running MODTRAN on macOS 10.14.6 for the H2O bound test. Reading the tp6 file fails with a codec error. @pgbrodrick  