### PR TITLE
Bug fix in radiative transfer

### DIFF
--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -211,10 +211,7 @@ class RadiativeTransferConfig(BaseConfigSection):
                 rt_model = RadiativeTransferEngineConfig(subconfig[key], name=key)
                 self.radiative_transfer_engines.append(rt_model)
 
-    def get_ordered_radiative_transfer_engines(self):
-
         self.radiative_transfer_engines.sort(key=lambda x: x.wavelength_range[0])
-        return self.radiative_transfer_engines
 
     def _check_config_validity(self) -> List[str]:
         errors = list()

--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -211,8 +211,6 @@ class RadiativeTransferConfig(BaseConfigSection):
                 rt_model = RadiativeTransferEngineConfig(subconfig[key], name=key)
                 self.radiative_transfer_engines.append(rt_model)
 
-        self.radiative_transfer_engines.sort(key=lambda x: x.wavelength_range[0])
-
     def _check_config_validity(self) -> List[str]:
         errors = list()
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -76,7 +76,7 @@ def heuristic_atmosphere(RT: RadiativeTransfer, instrument, x_RT, x_instrument, 
             # Get Atmospheric terms at high spectral resolution
             x_RT_2 = x_RT.copy()
             x_RT_2[ind_sv] = h2o
-            rhi = RT.get(x_RT_2, geom)
+            rhi = RT.get_shared_rtm_quantities(x_RT_2, geom)
             rhoatm = instrument.sample(x_instrument, RT.wl, rhi['rhoatm'])
             transm = instrument.sample(x_instrument, RT.wl, rhi['transm'])
             sphalb = instrument.sample(x_instrument, RT.wl, rhi['sphalb'])
@@ -107,7 +107,7 @@ def invert_algebraic(surface, RT: RadiativeTransfer, instrument, x_surface,
 
     # Get atmospheric optical parameters (possibly at high
     # spectral resolution) and resample them if needed.
-    rhi = RT.get(x_RT, geom)
+    rhi = RT.get_shared_rtm_quantities(x_RT, geom)
     wl, fwhm = instrument.calibration(x_instrument)
     rhoatm = instrument.sample(x_instrument, RT.wl, rhi['rhoatm'])
     transm = instrument.sample(x_instrument, RT.wl, rhi['transm'])

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -106,7 +106,10 @@ class RadiativeTransfer():
         """
         return np.diagflat(np.power(np.array(self.prior_sigma), 2))
 
-    def get(self, x_RT, geom):
+    def get_shared_rtm_quantities(self, x_RT, geom):
+        """Return only the set of RTM quantities (transup, sphalb, etc.) that are contained
+        in all RT engines.
+        """
 
         ret = []
         for RT in self.rt_engines:
@@ -115,7 +118,7 @@ class RadiativeTransfer():
         return self.pack_arrays(ret)
 
     def calc_rdn(self, x_RT, rfl, Ls, geom):
-        r = self.get(x_RT, geom)
+        r = self.get_shared_rtm_quantities(x_RT, geom)
         L_atm = self.get_L_atm(x_RT, geom)
         L_down_transmitted = self.get_L_down_transmitted(x_RT, geom)
         L_up = Ls * r['transup']
@@ -153,7 +156,7 @@ class RadiativeTransfer():
         K_RT = np.array(K_RT).T
 
         # Get K_surface
-        r = self.get(x_RT, geom)
+        r = self.get_shared_rtm_quantities(x_RT, geom)
         L_down_transmitted = self.get_L_down_transmitted(x_RT, geom)
 
         # The reflected downwelling light is:
@@ -176,7 +179,7 @@ class RadiativeTransfer():
 
         else:
             # first the radiance at the current state vector
-            r = self.get(x_RT, geom)
+            r = self.get_shared_rtm_quantities(x_RT, geom)
             rdn = self.calc_rdn(x_RT, rfl, Ls, geom)
 
             # unknown parameters modeled as random variables per
@@ -202,12 +205,22 @@ class RadiativeTransfer():
         ret = '\n'.join(ret)
         return ret
 
-    def pack_arrays(self, list_of_r_dicts):
-        """Take the list of dict outputs from each RTM (in order of RTs) and
-        stack their internal arrays in the same order.
+    def pack_arrays(self, rtm_quantities_from_RT_engines):
+        """Take the list of dict outputs from each RT engine and
+        stack their internal arrays in the same order. Keep only
+        those quantities that are common to all RT engines.
         """
-        r_stacked = {}
-        for key in list_of_r_dicts[0].keys():
-            temp = [x[key] for x in list_of_r_dicts]
-            r_stacked[key] = np.hstack(temp)
-        return r_stacked
+
+        # Get the intersection of the sets of keys from each of the rtm_quantities_from_RT_engines
+        shared_rtm_keys = set(rtm_quantities_from_RT_engines[0].keys())
+        if len(rtm_quantities_from_RT_engines) > 1:
+            for rtm_quantities_from_one_RT_engine in rtm_quantities_from_RT_engines[1:]:
+                shared_rtm_keys.intersection_update(rtm_quantities_from_one_RT_engine.keys())
+
+        # Concatenate the different band ranges
+        rtm_quantities_concatenated_over_RT_bands = {}
+        for key in shared_rtm_keys:
+            temp = [x[key] for x in rtm_quantities_from_RT_engines]
+            rtm_quantities_concatenated_over_RT_bands[key] = np.hstack(temp)
+
+        return rtm_quantities_concatenated_over_RT_bands

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -66,6 +66,10 @@ class RadiativeTransfer():
                     'Invalid radiative transfer engine name: {}'.format(rte_config.engine_name))
 
             self.rt_engines.append(rte)
+        
+        # The rest of the code relies on sorted order of the individual RT engines which cannot
+        # be guaranteed by the dict JSON or YAML input
+        self.rt_engines.sort(key=lambda x: x.wl[0])
 
         # Retrieved variables.  We establish scaling, bounds, and
         # initial guesses for each state vector element.  The state


### PR DESCRIPTION
Fixes two related problems. The first is that the code expects the radiative transfer engines to be in sorted wavelength order, but they weren't when the config input was not. This update puts them in order. The second is that the RadiativeTransfer.pack_arrays() function would attempt to look up nonexistent keys in the individual  RT engines's get() returns. This PR ensures that only those RTM quantities that are shared among all RT engines will be processed.