### PR TITLE
CI testing with GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,12 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.python-version == 3.5 }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         os: [windows-latest, macos-latest, ubuntu-latest]
-        experimental: [false]
-        include:
-          - python-version: 3.5
-            experimental: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Isofit
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version}}
+      - name: Install self
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        experimental: [false]
+        include:
+          - python-version: 3.5
+            experimental: true
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds some simple Continuous Integration tests. Basically, they just try to install Isofit and run the `pytest` tests on every push and pull request. Here's what the results look like: https://github.com/ashiklom/isofit/actions

I currently have these configured to run on a matrix of Python 3.5-3.8 x latest [Windows, Mac, Ubuntu]. We can expand on this list as appropriate. Because tests are currently failing for Python 3.5, I've made them optional to the overall workflow success -- all other versions work swimmingly.

We can add more here as appropriate, but these provide an extra check to make sure our development doesn't break the basic functionality.