### PR TITLE
Thermal only

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -195,12 +195,6 @@ def invert_simple(forward, meas, geom):
         rfl_hi = forward.upsample(forward.surface.wl, rfl_est)
         rhoatm, sphalb, transm, solar_irr, coszen, transup = coeffs
 
-        if vswir_present:
-            _, sphalb, _, _, _, transup = coeffs
-        else:
-            sphalb = 0. * np.ones(len(forward.surface.wl))
-            transup = 0.9 * np.ones(len(forward.surface.wl))
-
         L_atm = RT.get_L_atm(x_RT, geom)
         L_down_transmitted = RT.get_L_down_transmitted(x_RT, geom)
         L_total_without_surface_emission = \


### PR DESCRIPTION
This PR adds the capability to do TIR-only retrievals. The change requires only a modification to the initialization in inverse_simple. When doing TIR, if VSWIR is present then use the VSWIR init to get an initial TIR reflectivity estimate. If VSWIR is not present, then simply assume a flat TIR emissivity spectrum of 0.97.