### PR TITLE
Sanitize directory changes

### DIFF
--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -25,6 +25,7 @@ import ray
 from collections import OrderedDict
 import subprocess
 import time
+import atexit
 
 from isofit.core import common
 from isofit.configs import Config
@@ -45,14 +46,7 @@ def spawn_rt(cmd, local_dir=None):
     # starting simultaneously
     time.sleep(float(np.random.random(1))*2)
 
-    if local_dir is not None:
-        cwd = os.getcwd()
-        os.chdir(local_dir)
-
-    subprocess.call(cmd, shell=True)
-
-    if local_dir is not None:
-        os.chdir(cwd)
+    subprocess.call(cmd, shell=True, cwd=local_dir)
 
 ### Classes ###
 
@@ -199,6 +193,8 @@ class TabularRT:
                 os.mkdir(self.lut_dir)
 
             # migrate to the appropriate directory and spool up runs
+            cwd = os.getcwd()
+            atexit.register(os.chdir, cwd)
             os.chdir(self.lut_dir)
 
             # Make the LUT calls (in parallel if specified)

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -297,15 +297,13 @@ class ModtranRT(TabularRT):
                     cmd = self.rebuild_cmd(point, filebase)
 
                     # Run MODTRAN for up to 10 seconds - this should be plenty of time
-                    cwd = os.getcwd()
                     if os.path.isdir(self.lut_dir) is False:
                         os.mkdir(self.lut_dir)
-                    os.chdir(self.lut_dir)
                     try:
-                        subprocess.call(cmd, shell=True, timeout=10)
+                        subprocess.call(cmd, shell=True, timeout=10,
+                                        cwd=self.lut_dir)
                     except:
                         pass
-                    os.chdir(cwd)
 
 
                     max_water = None

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -607,14 +607,11 @@ def calc_modtran_max_water(paths: Pathnames) -> float:
     with open(filebase + '.json', 'w') as fout:
         fout.write(json.dumps(bound_test_config, cls=SerialEncoder, indent=4, sort_keys=True))
 
-    cwd = os.getcwd()
-    os.chdir(paths.lut_h2o_directory)
     cmd = os.path.join(paths.modtran_path, 'bin', xdir[platform], 'mod6c_cons ' + filebase + '.json')
     try:
-        subprocess.call(cmd, shell=True, timeout=10)
+        subprocess.call(cmd, shell=True, timeout=10, cwd=paths.lut_h2o_directory)
     except:
         pass
-    os.chdir(cwd)
 
     with open(filebase + '.tp6', errors='ignore') as tp6file:
         for count, line in enumerate(tp6file):


### PR DESCRIPTION
In some cases, Isofit changes directories in unexpected ways, which can
cause relative paths to fail when they really shouldn't. Ideally, the
Isofit executable should respect its current working directory as much
as possible. These changes try to more reliably undo working directory
changes when they happen:

- In two instances, we change directory just to execute a
`subprocess.call`. In these situations, we can just pass the `cwd`
argument to `subprocess.call` to achieve the exact same effect, but in a
way that is more robust to crashes midway through the command.

- In one other place, the directory change is more complicated, so I
added a call to `atexit.register(os.chdir, cwd)`. This basically tells
Python to run the `os.chdir(cwd)` command as soon as the function call
exits for _any_ reason that Python can pick up (basically, any error
that isn't at the system/memory level). `atexit` is a part of the Python
standard library, so this doesn't introduce any new dependencies.