### PR TITLE
adds bibliography

### DIFF
--- a/docs/source/custom/bibliography.rst
+++ b/docs/source/custom/bibliography.rst
@@ -1,0 +1,64 @@
+Bibliography
+============
+
+Considerable effort by many individuals has gone into the development of optimal
+estimation for imaging spectroscopy, and *Isofit* specifically.  Below are a list
+of some of the key work.  If you use *Isofit* in your work, we would appreciate
+your consideration of the relevant contributions.
+
+Core developments
+-------------------
+
+D\. R. Thompson, V. Natraj, R. O. Green, M. Helmlinger, B.-C. Gao, and M. L. Eastwood.
+`Optimal Estimation for Imaging Spectrometer Atmospheric Correction.
+<https://doi.org/10.1016/j.rse.2018.07.003>`__
+*Remote Sensing of Environment* 216, p. 355-373, 2018. DOI: 10.1016/j.rse.2018.07.003.
+
+D\. R. Thompson, K.N. Babu, A. Braverman, M. Eastwood, R.O. Green,
+J. Hobbs, J.B. Jewell, M. Mishra, A. Mathur, V. Natraj, F. C. Seidel,
+P. Townsend, M. Turmon. `Optimal Estimation of Spectral Surface Reflectance
+in Challenging Atmospheres <https://doi.org/10.1016/j.rse.2019.111258>`__.
+Remote Sensing of Environment, 232, 111258, 2019.
+DOI: 10.1016/j.rse.2019.111258.
+
+
+D\. R. Thompson, K. Cawse-Nicholson, Z. Erickson, C. Fichot, C. Frankenberg,
+B-C. Gao, M. M. Gierach, R. O. Green, D. Jensen, V. Natraj, A. Thompson.
+`A unified approach to estimate land and water reflectances with uncertainties
+for coastal imaging spectroscopy. <https://doi.org/10.1016/j.rse.2019.05.017>`__
+*Remote Sensing of Environment*, 231, 111198, 2019.
+DOI: 10.1016/j.rse.2019.05.017.
+
+
+Uncertainty quantification
+--------------------------
+D\. R. Thompson, Alberto Candela, Nimrod Carmon, Roger N. Clark,
+David Connelly, Bethany Ehlmann, Robert O. Green, Raymond Kokaly,
+Nathalie Mahowald, Gregory Okin, Gregg A. Swayze, Michael Turmon,
+and David S. Wettergreen. `Quantifying Uncertainty for Remote
+Spectroscopy of Surface Composition. <https://doi.org/10.1016/j.rse.2020.111898>`__
+*Remote Sensing of Environment*,
+247:15, 111898, 2020.
+DOI: 10.1016/j.rse.2020.111898.
+
+N\. Carmon, D. R. Thompson, J. Susiluoto, N. Bohn, D. S. Connelly,
+M. J. Turmon, K. Cawse-Nicholson, R. O. Green, M. R Gunson.
+Uncertainty Quantification for Global Remote Spectroscopy of Surface Composition.
+*Remote Sensing of Environment*, in press, 2020.
+
+
+Extensions
+----------
+R\. Frouin, B.  Franz, A. Ibrahim, K. Knobelspiesse, Z. Ahmad, B. Cairns, J. Chowdhary,
+H. M. Dierssen, O. Dubovik, J. Tan, A. B. Davis, D. J. Diner, O. Kalashnikova,
+D. R. Thompson, L. R. Remer, E. Boss, O. Coddington, B-C Gao, L. Gross, O. Hasekamp,
+A. Omar, B. Pelletier, D. Ramon, P-W. Zhai. `Atmospheric correction of satellite
+ocean-color imagery during the PACE era. <https://doi.org/10.3389/feart.2019.00145>`__
+*Frontiers in Marine Science*, 7: 145, 2019.
+DOI: 10.3389/feart.2019.00145.
+
+
+B\. D. Bue, D. R. Thompson, S. Deshpande, M. Eastwood, C. Fichot, R. O. Green,
+T. Mullen, V. Natraj, and M. Parente. `Neural Network Radiative Transfer for
+Imaging Spectroscopy <Uncertainty Quantification for Global Remote Spectroscopy of Surface Composition>`__. *Atmospheric Measurement Techniques*, 12, 2567–2578,
+2019. DOI: 10.5194/amt-12-2567-2019.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,12 @@
    isofit.rst
 
 .. toctree::
+   :Caption: Bibliography
+   :maxdepth: 2
+
+   custom/bibliography.rst
+
+.. toctree::
    :Caption: Contributing
    :maxdepth: 2
 


### PR DESCRIPTION
Adds bibliography, broken out by topic, addressing #152.  I'm not in love with the heading 'Extensions' - neither of those really extend the codebase...they're somewhere between applications and expansions.  Updated headers or additional manuscripts would be great, but I think breaking out by topic is important.