### PR TITLE
Use ray instead of multiprocess in empirical_line

### DIFF
--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -54,7 +54,7 @@ def _write_bil_chunk(dat: np.array, outfile: str, line: int, shape: tuple, dtype
 
 def _run_chunk(start_line: int, stop_line: int, reference_radiance_file: str, reference_reflectance_file: str,
                reference_uncertainty_file: str, reference_locations_file: str, input_radiance_file: str,
-               input_locations_file: str, segmentation_file: str, isofit_config: dict, output_reflectance_file: str,
+               input_locations_file: str, segmentation_file: str, isofit_config: str, output_reflectance_file: str,
                output_uncertainty_file: str, radiance_factors: np.array, nneighbors: int,
                nodata_value: float) -> None:
     """
@@ -68,7 +68,7 @@ def _run_chunk(start_line: int, stop_line: int, reference_radiance_file: str, re
         input_radiance_file: input radiance file (interpolate over this)
         input_locations_file: input location file (interpolate over this)
         segmentation_file: input file noting the per-pixel segmentation used
-        isofit_config: dictionary-stype isofit configuration
+        isofit_config: path to isofit configuration JSON file
         output_reflectance_file: location to write output reflectance to
         output_uncertainty_file: location to write output uncertainty to
         radiance_factors: radiance adjustment factors
@@ -280,7 +280,7 @@ def empirical_line(reference_radiance_file: str, reference_reflectance_file: str
                    reference_locations_file: str, segmentation_file: str, input_radiance_file: str,
                    input_locations_file: str, output_reflectance_file: str, output_uncertainty_file: str,
                    nneighbors: int = 15, nodata_value: float = -9999.0, level: str = 'INFO',
-                   radiance_factors: np.array = None, isofit_config: dict = None, n_cores: int = -1) -> None:
+                   radiance_factors: np.array = None, isofit_config: str = None, n_cores: int = -1) -> None:
     """
     Perform an empirical line interpolation for reflectance and uncertainty extrapolation
     Args:
@@ -298,7 +298,7 @@ def empirical_line(reference_radiance_file: str, reference_reflectance_file: str
         nodata_value: nodata value of input and output
         level: logging level
         radiance_factors: radiance adjustment factors
-        isofit_config: dictionary-stype isofit configuration
+        isofit_config: path to isofit configuration JSON file
         n_cores: number of cores to run on
     Returns:
         None


### PR DESCRIPTION
See #161.

Ray is configured identically to `isofit.py` -- i.e., the relevant options from the `implementation` config are passed to ray in the same way. The one exception is that the `n_cores` argument, if set to something other than `-1`, overwrites whatever is in the implementation config. This is intended to match the current behavior.

Also, I think the `isofit_config` argument documentation is inconsistent with how it's actually used (the function says it expects a dict, but the call in `apply_oe` passes a path, so I took the liberty of revising that too.

Feedback welcome!