### PR TITLE
interleave update

### DIFF
--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -121,12 +121,9 @@ class SpectrumFile:
                     logging.error('Could not find %s' % (self.fname+'.hdr'))
                     raise IOError('Could not find %s' % (self.fname+'.hdr'))
 
-                # open file and copy metadata, checking interleave format
+                # open file and copy metadata
                 self.file = envi.open(self.fname + '.hdr', fname)
                 self.meta = self.file.metadata.copy()
-                if self.meta['interleave'] not in ['bil', 'bip']:
-                    logging.error('Unsupported interleave format.')
-                    raise IOError('Unsupported interleave format.')
 
                 self.n_rows = int(self.meta['lines'])
                 self.n_cols = int(self.meta['samples'])
@@ -179,7 +176,7 @@ class SpectrumFile:
 
         self.memmap = None
         for attempt in range(10):
-            self.memmap = self.file.open_memmap(interleave='source',
+            self.memmap = self.file.open_memmap(interleave='bip',
                                                 writable=self.write)
             if self.memmap is not None:
                 return
@@ -195,8 +192,6 @@ class SpectrumFile:
         if row not in self.frames:
             if not self.write:
                 d = self.memmap[row, :, :]
-                if self.file.metadata['interleave'] == 'bil':
-                    d = d.T
                 self.frames[row] = d.copy()
             else:
                 self.frames[row] = np.nan * np.zeros((self.n_cols, self.n_bands))
@@ -243,10 +238,7 @@ class SpectrumFile:
             if self.write:
                 for row, frame in self.frames.items():
                     valid = np.logical_not(np.isnan(frame[:, 0]))
-                    if self.file.metadata['interleave'] == 'bil':
-                        self.memmap[row, :, valid] = frame[valid, :].T
-                    else:
-                        self.memmap[row, valid, :] = frame[valid, :]
+                    self.memmap[row, valid, :] = frame[valid, :]
             self.frames = OrderedDict()
             del self.file
             self.file = envi.open(self.fname+'.hdr', self.fname)

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -111,16 +111,16 @@ def _run_chunk(start_line: int, stop_line: int, reference_radiance_file: str, re
     n_output_uncertainty_bands = int(output_uncertainty_img.metadata['bands'])
 
     # Load reference data
-    reference_locations_mm = reference_locations_img.open_memmap(interleave='source', writable=False)
+    reference_locations_mm = reference_locations_img.open_memmap(interleave='bip', writable=False)
     reference_locations = np.array(reference_locations_mm[:, :, :]).reshape((n_reference_lines, n_location_bands))
 
-    reference_radiance_mm = reference_radiance_img.open_memmap(interleave='source', writable=False)
+    reference_radiance_mm = reference_radiance_img.open_memmap(interleave='bip', writable=False)
     reference_radiance = np.array(reference_radiance_mm[:, :, :]).reshape((n_reference_lines, n_radiance_bands))
 
-    reference_reflectance_mm = reference_reflectance_img.open_memmap(interleave='source', writable=False)
+    reference_reflectance_mm = reference_reflectance_img.open_memmap(interleave='bip', writable=False)
     reference_reflectance = np.array(reference_reflectance_mm[:, :, :]).reshape((n_reference_lines, n_radiance_bands))
 
-    reference_uncertainty_mm = reference_uncertainty_img.open_memmap(interleave='source', writable=False)
+    reference_uncertainty_mm = reference_uncertainty_img.open_memmap(interleave='bip', writable=False)
     reference_uncertainty = np.array(reference_uncertainty_mm[:, :, :]).reshape((n_reference_lines,
                                                                                  n_reference_uncertainty_bands))
     reference_uncertainty = reference_uncertainty[:, :n_radiance_bands].reshape((n_reference_lines, n_radiance_bands))
@@ -162,17 +162,13 @@ def _run_chunk(start_line: int, stop_line: int, reference_radiance_file: str, re
 
         # Load inline input data
         input_radiance_mm = input_radiance_img.open_memmap(
-            interleave='source', writable=False)
+            interleave='bip', writable=False)
         input_radiance = np.array(input_radiance_mm[row, :, :])
-        if input_radiance_img.metadata['interleave'] == 'bil':
-            input_radiance = input_radiance.transpose((1, 0))
         input_radiance = input_radiance * radiance_adjustment
 
         input_locations_mm = input_locations_img.open_memmap(
-            interleave='source', writable=False)
+            interleave='bip', writable=False)
         input_locations = np.array(input_locations_mm[row, :, :])
-        if input_locations_img.metadata['interleave'] == 'bil':
-            input_locations = input_locations.transpose((1, 0))
 
         output_reflectance_row = np.zeros(input_radiance.shape) + nodata_value
         output_uncertainty_row = np.zeros(input_radiance.shape) + nodata_value

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -40,7 +40,7 @@ def extractions(inputfile, labels, output, chunksize, flag):
     meta = in_img.metadata
 
     nl, nb, ns = [int(meta[n]) for n in ('lines', 'bands', 'samples')]
-    img_mm = in_img.open_memmap(interleave='source', writable=False)
+    img_mm = in_img.open_memmap(interleave='bip', writable=False)
 
     lbl_img = envi.open(lbl_file+'.hdr', lbl_file)
     labels = lbl_img.read_band(0)
@@ -53,7 +53,7 @@ def extractions(inputfile, labels, output, chunksize, flag):
     for lstart in np.arange(0, nl, nchunk):
 
         del img_mm
-        img_mm = in_img.open_memmap(interleave='source', writable=False)
+        img_mm = in_img.open_memmap(interleave='bip', writable=False)
 
         # Which labels will we extract? ignore zero index
         lend = min(lstart+nchunk, nl)
@@ -70,8 +70,6 @@ def extractions(inputfile, labels, output, chunksize, flag):
         lend_adjust = max(active_locs[0])+1
 
         chunk_inp = np.array(img_mm[lstart_adjust:lend_adjust, :, :])
-        if meta['interleave'] == 'bil':
-            chunk_inp = chunk_inp.transpose((0, 2, 1))
         chunk_lbl = np.array(labels[lstart_adjust:lend_adjust, :])
 
         for i in active:

--- a/isofit/utils/instrument_model.py
+++ b/isofit/utils/instrument_model.py
@@ -51,9 +51,7 @@ def instrument_model(config):
 
     infile_hdr = infile + '.hdr'
     img = envi.open(infile_hdr, infile)
-    inmm = img.open_memmap(interleave='source', writable=False)
-    if img.interleave != 1:
-        raise ValueError("I need BIL interleave.")
+    inmm = img.open_memmap(interleave='bil', writable=False)
     X = np.array(inmm[:, :, :], dtype=np.float32)
     nr, nb, nc = X.shape
 

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -37,9 +37,7 @@ def segment(spectra, flag, npca, segsize, nchunk):
     in_img = envi.open(in_file+'.hdr', in_file)
     meta = in_img.metadata
     nl, nb, ns = [int(meta[n]) for n in ('lines', 'bands', 'samples')]
-    img_mm = in_img.open_memmap(interleave='source', writable=False)
-    if meta['interleave'] != 'bil':
-        raise ValueError('I need BIL interleave.')
+    img_mm = in_img.open_memmap(interleave='bip', writable=False)
 
     # Iterate through image "chunks," segmenting as we go
     next_label = 1
@@ -51,8 +49,7 @@ def segment(spectra, flag, npca, segsize, nchunk):
 
         # Extract data
         lend = min(lstart+nchunk, nl)
-        img_mm = in_img.open_memmap(interleave='source', writable=False)
-        x = np.array(img_mm[lstart:lend, :, :]).transpose((0, 2, 1))
+        img_mm = in_img.open_memmap(interleave='bip', writable=False)
         nc = x.shape[0]
         x = x.reshape((nc * ns, nb))
 

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -22,6 +22,7 @@ import numpy as np
 import scipy
 from sklearn.cluster import KMeans
 from spectral.io import envi
+import os
 
 from isofit.core.common import expand_path, json_load_ascii
 
@@ -129,11 +130,8 @@ def surface_model(config_file: str) -> None:
                 swl = swl * 1000.0
 
             # Load library and adjust interleave, if needed
-            rfl_mm = rfl.open_memmap(interleave='source', writable=False)
-            if rfl.metadata['interleave'] == 'bip':
-                x = np.array(rfl_mm[:, :, :])
-            if rfl.metadata['interleave'] == 'bil':
-                x = np.array(rfl_mm[:, :, :]).transpose((0, 2, 1))
+            rfl_mm = rfl.open_memmap(interleave='bip', writable=False)
+            x = np.array(rfl_mm[:, :, :])
             x = x.reshape(nl * ns, nb)
 
             # import spectra and resample
@@ -151,11 +149,8 @@ def surface_model(config_file: str) -> None:
                           for n in ('lines', 'bands', 'samples')]
 
                 # Load library and adjust interleave, if needed
-                attr_mm = attr.open_memmap(interleave='source', writable=False)
-                if attr.metadata['interleave'] == 'bip':
-                    x = np.array(attr_mm[:, :, :])
-                if attr.metadata['interleave'] == 'bil':
-                    x = np.array(attr_mm[:, :, :]).transpose((0, 2, 1))
+                attr_mm = attr.open_memmap(interleave='bip', writable=False)
+                x = np.array(attr_mm[:, :, :])
                 x = x.reshape(nla * nsa, nba)
                 model['attributes'] = attr.metadata['band names']
 


### PR DESCRIPTION
Addresses issue #163 by opening up input interleaves to be anything - does not address output interleave, though discussion indicated that was a lower priority providing the inputs were opened up.  Switches out transpose of BIL interleaves for forced bip-reads, which conveniently also runs (very slightly) faster based on a speed test.  

@davidraythompson, could you review when you get a chance?