### PR TITLE
Hypertrace: Modtran support + logging

### DIFF
--- a/examples/py-hypertrace/.gitignore
+++ b/examples/py-hypertrace/.gitignore
@@ -13,6 +13,7 @@ output/*
 # JSON files that are NOT the config example
 *.json
 !config-example.json
+!config-example-modtran.json
 
 # Example look-up table directory
 /luts/

--- a/examples/py-hypertrace/config-example-modtran.json
+++ b/examples/py-hypertrace/config-example-modtran.json
@@ -1,9 +1,9 @@
 {
     "wavelength_file": "./hypertrace-data/priors/avirisc-wavelengths.txt",
     "reflectance_file": "./hypertrace-data/reflectance/reference/reference_reflectance",
-    "rtm_template_file": "./lrt-template.inp",
-    "lutdir": "./luts",
-    "outdir": "./output",
+    "rtm_template_file": "./modtran-template.json",
+    "lutdir": "./luts/modtran",
+    "outdir": "./output/modtran",
     "isofit": {
         "forward_model": {
             "instrument": {
@@ -15,8 +15,8 @@
             },
             "radiative_transfer": {
                 "lut_grid": {
-                    "AOT550": [0.001, 0.123, 0.6],
-                    "H2OSTR": [1.0, 2.5, 3.25]
+                    "AOT550": [0.001, 0.6],
+                    "H2OSTR": [0.543, 3.216]
                 },
                 "statevector": {
                     "AOT550": {
@@ -37,9 +37,8 @@
                 "unknowns": {"H2O_ABSCO": 0.01},
                 "radiative_transfer_engines": {
                     "vswir": {
-                        "engine_name": "libradtran",
-                        "engine_base_dir": "~/projects/models/libRadtran-2.0.3",
-                        "environment": "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib",
+                        "engine_name": "modtran",
+                        "engine_base_dir": "/dev/null",
                         "lut_names": ["H2OSTR", "AOT550"],
                         "statevector_names": ["H2OSTR", "AOT550"]
                     }
@@ -53,12 +52,12 @@
         }
     },
     "hypertrace": {
-        "atm_aod_h2o": [["midlatitude_winter", 0.2, 1.0], ["midlatitude_winter", 0.3, 2.0]],
-        "observer_zenith": [0.0, 20.0],
-        "inversion_mode": ["simple", "inversion"],
-        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt",
-                      "./hypertrace-data/noise/noise_coeff_sbg_cbe1.txt"],
-        "surface_file": ["./hypertrace-data/priors/uninformative.mat",
-                        "./hypertrace-data/priors/basemap_surface_model.mat"]
+        "lrt_atmosphere_type": ["ATM_MIDLAT_SUMMER"],
+        "aod": [0.2, 0.3],
+        "h2o": [1.0, 2.0],
+        "observer_zenith": [0, 22.5],
+        "inversion_mode": ["inversion"],
+        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt"],
+        "surface_file": ["./hypertrace-data/priors/uninformative.mat"]
     }
 }

--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -121,11 +121,11 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
         h2o = atm_aod_h2o[2]
 
     lrttag = f"atm_{lrt_atmosphere_type}__" +\
-        f"szen_{solar_zenith}__" +\
-        f"ozen_{observer_zenith}__" +\
-        f"saz_{solar_azimuth}__" +\
-        f"oaz_{observer_azimuth}"
-    atmtag = f"aod_{aod}__h2o_{h2o}"
+        f"szen_{solar_zenith:.2f}__" +\
+        f"ozen_{observer_zenith:.2f}__" +\
+        f"saz_{solar_azimuth:.2f}__" +\
+        f"oaz_{observer_azimuth:.2f}"
+    atmtag = f"aod_{aod:.3f}__h2o_{h2o:.3f}"
 
     if create_lut:
         lutdir = mkabs(lutdir)

--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -5,12 +5,14 @@
 import copy
 import pathlib
 import json
+import logging
 
 import numpy as np
 from scipy.io import loadmat
 
 from isofit.core.isofit import Isofit
 
+logger = logging.getLogger(__name__)
 
 def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
                   libradtran_template_file,

--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -170,12 +170,13 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
     outdir2.mkdir(parents=True, exist_ok=True)
 
     # Observation file, which describes the geometry
+    # Angles follow LibRadtran conventions
     obsfile = outdir2 / "obs.txt"
     geomvec = [
         -999,              # path length; not used
         observer_azimuth,  # Degrees 0-360; 0 = Sensor in N, looking S; 90 = Sensor in W, looking E
         observer_zenith,   # Degrees 0-90; 0 = directly overhead, 90 = horizon
-        solar_azimuth,     # Degrees 0-360; 0 = N, 90 = W, 180 = S, 270 = E
+        solar_azimuth,     # Degrees 0-360; 0 = Sun in S; 90 = Sun in W.
         solar_zenith,      # Same units as observer zenith
         180.0 - abs(observer_zenith),  # MODTRAN OBSZEN -- t
         observer_azimuth - solar_azimuth + 180.0,  # MODTRAN relative azimuth

--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -154,6 +154,9 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
             mod = fdict["MODTRAN"][0]["MODTRANINPUT"]
             for key in ['MODEL', 'M1', 'M2', 'M3', 'M4', 'M5', 'M6']:
                 mod['ATMOSPHERE'][key] = lrt_atmosphere_type
+            assert mod["GEOMETRY"]["IPARM"] == 12, \
+                "MODTRAN GEOMETRY IPARM must be set to 12, " +\
+                f"but is currently set to {mod['GEOMETRY']['IPARM']}"
             mod["GEOMETRY"]["PARM1"] = 180 - solar_azimuth
             mod["GEOMETRY"]["PARM2"] = solar_zenith
             # TODO: Is this angle correct?

--- a/examples/py-hypertrace/workflow.py
+++ b/examples/py-hypertrace/workflow.py
@@ -5,8 +5,12 @@
 import sys
 import json
 import itertools
+import logging
 
 from hypertrace import do_hypertrace, mkabs
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 clean = False
 if len(sys.argv) > 1:
@@ -16,7 +20,7 @@ if len(sys.argv) > 1:
 else:
     configfile = "./config.json"
 configfile = mkabs(configfile)
-print(f"Using config file `{configfile}`")
+logger.info("Using config file `%s`", configfile)
 
 with open(configfile) as f:
     config = json.load(f)
@@ -42,13 +46,13 @@ for key in ["lut_path", "template_file", "engine_base_dir"]:
 
 # Create iterable config permutation object
 ht_iter = itertools.product(*hypertrace_config.values())
-print("Starting Hypertrace workflow.")
+logger.info("Starting Hypertrace workflow.")
 for ht in ht_iter:
     argd = dict()
     for key, value in zip(hypertrace_config.keys(), ht):
         argd[key] = value
-    print(f"Running config: {argd}")
+    logger.info("Running config: %s", argd)
     do_hypertrace(isofit_config, wavelength_file, reflectance_file,
                   libradtran_template_file, lutdir, outdir,
                   **argd)
-print("Workflow completed successfully.")
+logging.info("Workflow completed successfully.")

--- a/examples/py-hypertrace/workflow.py
+++ b/examples/py-hypertrace/workflow.py
@@ -27,7 +27,9 @@ with open(configfile) as f:
 
 wavelength_file = mkabs(config["wavelength_file"])
 reflectance_file = mkabs(config["reflectance_file"])
-libradtran_template_file = mkabs(config["libradtran_template_file"])
+if "libradtran_template_file" in config:
+    raise Exception("`libradtran_template_file` is deprecated. Use `rtm_template_file` instead.")
+rtm_template_file = mkabs(config["rtm_template_file"])
 lutdir = mkabs(config["lutdir"])
 outdir = mkabs(config["outdir"])
 
@@ -53,6 +55,6 @@ for ht in ht_iter:
         argd[key] = value
     logger.info("Running config: %s", argd)
     do_hypertrace(isofit_config, wavelength_file, reflectance_file,
-                  libradtran_template_file, lutdir, outdir,
+                  rtm_template_file, lutdir, outdir,
                   **argd)
 logging.info("Workflow completed successfully.")

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -168,14 +168,13 @@ class Isofit:
                     io.write_spectrum(row, col, self.states, meas,
                                       geom, flush_immediately=True)
                 except ValueError as err:
-                    logging.error(err)
                     logging.info(
                         """
-                        Encountered the following ValueError in row %d and col %d:
-                        %s.
+                        Encountered the following ValueError in row %d and col %d.
                         Results for this pixel will be all zeros.
-                        """, row, col, err
+                        """, row, col
                     )
+                    logging.error(err)
                 if (index - index_start) % 100 == 0:
                     logging.info(
                         'Core at start index %d completed inversion %d/%d',


### PR DESCRIPTION
Main change is introducing (prototype) MODTRAN support for Hypertrace. I don't have any way to test whether this successfully builds new MODTRAN LUTs, but it does work with preexisting ones (as long as the paths are formatted correctly).

This PR also replaces all the Hypertrace `print` statements with proper `logging` capabilities.

Finally, this resolves a minor annoyance where `logging` was not correctly processing `valueErrors` in Isofit.