### PR TITLE
Surface config override parameters simplify calling scripts

### DIFF
--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -27,29 +27,40 @@ import os
 from isofit.core.common import expand_path, json_load_ascii
 
 
-def surface_model(config_file: str) -> None:
+def surface_model(config_path: str, wavelength_path: str = None, 
+        output_path: str = None) -> None:
     """The surface model tool contains everything you need to build basic
     multicomponent (i.e. colleciton of Gaussian) surface priors for the
     multicomponent surface model.
 
     Args:
-        config_file: path to a JSON formatted surface model configuration
+        config_path: path to a JSON formatted surface model configuration
+        wavelength_path: optional path to a three-column wavelength file, 
+           overriding the configuration file settings
+        output_path: optional path to the destination .mat file, overriding
+           the configuration file settings
     Returns:
         None
     """
 
     # Load configuration JSON into a local dictionary
-    configdir, _ = os.path.split(os.path.abspath(config_file))
-    config = json_load_ascii(config_file, shell_replace=True)
+    configdir, _ = os.path.split(os.path.abspath(config_path))
+    config = json_load_ascii(config_path, shell_replace=True)
 
     # Determine top level parameters
     for q in ['output_model_file', 'sources', 'normalize', 'wavelength_file']:
         if q not in config:
             raise ValueError("Missing parameter: %s" % q)
-    wavelength_file = expand_path(configdir, config['wavelength_file'])
+    if wavelength_path is not None:
+        wavelength_file = wavelength_path
+    else:
+        wavelength_file = expand_path(configdir, config['wavelength_file'])
+    if output_path is not None:
+        outfile = output_path
+    else:
+        outfile = expand_path(configdir, config['output_model_file'])
     normalize = config['normalize']
     reference_windows = config['reference_windows']
-    outfile = expand_path(configdir, config['output_model_file'])
 
     # load wavelengths file, and change units to nm if needed
     q = np.loadtxt(wavelength_file)


### PR DESCRIPTION
A simple parameter override simplifies scripting in large workflows.
Currently, the only way to build a surface model for a new wavelength grid is to write out a new .json formatted configuration file.  This minor change allows the surface_model() function call to overwrite wavelength file and output file locations, so we can create new surface models dynamically without having to parse/write a JSON file. 