### PR TITLE
Aerosol LUT grid rounding fix, ftol discussion

### DIFF
--- a/isofit/configs/sections/inversion_config.py
+++ b/isofit/configs/sections/inversion_config.py
@@ -135,9 +135,9 @@ class LeastSquaresConfig(BaseConfigSection):
         Default is None, which disables termination from this criteria."""
 
         self._ftol_type = float
-        self.ftol = 0.01
+        self.ftol = 0.0001
         """float: Tolerance for termination by the change of the cost function.
-        Default is 0.01"""
+        Default is 0.0001"""
 
         self._gtol_type = float
         self.gtol = None

--- a/isofit/configs/sections/inversion_config.py
+++ b/isofit/configs/sections/inversion_config.py
@@ -135,7 +135,7 @@ class LeastSquaresConfig(BaseConfigSection):
         Default is None, which disables termination from this criteria."""
 
         self._ftol_type = float
-        self.ftol = 0.0001
+        self.ftol = 0.01
         """float: Tolerance for termination by the change of the cost function.
         Default is 0.0001"""
 

--- a/isofit/configs/sections/inversion_config.py
+++ b/isofit/configs/sections/inversion_config.py
@@ -137,7 +137,7 @@ class LeastSquaresConfig(BaseConfigSection):
         self._ftol_type = float
         self.ftol = 0.01
         """float: Tolerance for termination by the change of the cost function.
-        Default is 0.0001"""
+        Default is 0.01"""
 
         self._gtol_type = float
         self.gtol = None

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -1201,13 +1201,15 @@ def build_main_config(paths: Pathnames, lut_params: LUTConfig, h2o_lut_grid: np.
         grid = {}
         if h2o_lut_grid is not None:
             h2o_delta = float(h2o_lut_grid[-1]) - float(h2o_lut_grid[0])
-            grid['H2OSTR'] = [round(h2o_lut_grid[0]+h2o_delta*0.02,4), round(h2o_lut_grid[-1]-h2o_delta*0.02,4)]
+            grid['H2OSTR'] = [round(h2o_lut_grid[0]+h2o_delta*0.02,4), 
+                              round(h2o_lut_grid[-1]-h2o_delta*0.02,4)]
 
         # We will initialize using different AODs for the first aerosol in the LUT
         if len(aerosol_lut_grid)>0:
             key = list(aerosol_lut_grid.keys())[0]
             aer_delta = aerosol_lut_grid[key][-1] - aerosol_lut_grid[key][0]
-            grid[key] = [round(aerosol_lut_grid[key][0]+aer_delta*0.02), round(aerosol_lut_grid[key][-1]-aer_delta*0.02,4)]
+            grid[key] = [round(aerosol_lut_grid[key][0]+aer_delta*0.02,4), 
+                         round(aerosol_lut_grid[key][-1]-aer_delta*0.02,4)]
         isofit_config_modtran['implementation']['inversion']['integration_grid'] = grid
         isofit_config_modtran['implementation']['inversion']['inversion_grid_as_preseed'] = True
 


### PR DESCRIPTION
I have been chasing a problem where the default settings fail to fully correct water vapor absorption features.  This is most obvious over bare soil.   It appears to be that the default convergence tolerance is too loose.  I tightened it back to 0.0001, confirming that (a) any less yields residual vapor features, and (b) further tightening does not change the solution. 

![tolerance_0p01](https://user-images.githubusercontent.com/2358270/102024482-2b199000-3d47-11eb-9f64-88e87df8e6c7.png)
![tolerance_0p0001](https://user-images.githubusercontent.com/2358270/102024487-2fde4400-3d47-11eb-8182-39b47053857f.png)

Also a bug fix in apply_oe.py to avoid aerosol out of bounds initialization errors.