### PR TITLE
sRTMnet patch

### DIFF
--- a/isofit/radiative_transfer/sRTMnet.py
+++ b/isofit/radiative_transfer/sRTMnet.py
@@ -67,7 +67,7 @@ class SimulatedModtranRT(TabularRT):
                 del full_config.forward_model.radiative_transfer.lut_grid[name]
                 if name == 'OBSZEN':
                     full_config.forward_model.radiative_transfer.lut_grid[to_update] = \
-                        [180 - x for x in full_config.forward_model.radiative_transfer.lut_grid[to_update]]
+                        [180 - x for x in full_config.forward_model.radiative_transfer.lut_grid[to_update]].sort()
 
         full_config.forward_model.radiative_transfer.lut_grid = OrderedDict(sorted(full_config.forward_model.radiative_transfer.lut_grid.items(), key=lambda t: t[0]))
         engine_config.lut_names = engine_config.lut_names.sort()

--- a/isofit/radiative_transfer/sRTMnet.py
+++ b/isofit/radiative_transfer/sRTMnet.py
@@ -25,6 +25,7 @@ import numpy as np
 from copy import deepcopy
 import yaml
 import pickle
+from collections import OrderedDict
 
 from isofit.core.common import resample_spectrum, load_wavelen, VectorInterpolator
 from .look_up_tables import TabularRT
@@ -68,12 +69,8 @@ class SimulatedModtranRT(TabularRT):
                     full_config.forward_model.radiative_transfer.lut_grid[to_update] = \
                         [180 - x for x in full_config.forward_model.radiative_transfer.lut_grid[to_update]]
 
-        for _i, name in enumerate(full_config.forward_model.radiative_transfer.lut_grid):
-            if name in self.modtran_6s_name_conversion[0]:
-                to_update = self.modtran_6s_name_conversion[1][self.modtran_6s_name_conversion[0].index(name)]
-                logging.info(f'Switching {name} for {to_update} in forward_model->radiative_transfer_engines->[]'
-                             '->lut_names')
-                self.lut_names[_i] = to_update
+        full_config.forward_model.radiative_transfer.lut_grid = OrderedDict(sorted(full_config.forward_model.radiative_transfer.lut_grid.items(), key=lambda t: t[0]))
+        engine_config.lut_names = engine_config.lut_names.sort()
 
         logging.info('Swap known configuration names')
 

--- a/isofit/radiative_transfer/sRTMnet.py
+++ b/isofit/radiative_transfer/sRTMnet.py
@@ -195,7 +195,7 @@ class SimulatedModtranRT(TabularRT):
             
             for key_ind, key in enumerate(self.lut_quantities):
                 with open(interpolator_disk_paths[key_ind], 'wb') as fi:
-                    pickle.dump(self.luts[key], fi)
+                    pickle.dump(self.luts[key], fi, protocol=4)
 
         else:
             logging.info('Prebuilt LUT interpolators found, loading from disk')

--- a/isofit/radiative_transfer/sRTMnet.py
+++ b/isofit/radiative_transfer/sRTMnet.py
@@ -91,8 +91,8 @@ class SimulatedModtranRT(TabularRT):
 
         sixs_config.day = dt.day
         sixs_config.month = dt.month
-        sixs_config.elev = -1*modtran_input['SURFACE']['GNDALT']
-        sixs_config.alt = -1*modtran_input['GEOMETRY']['H1ALT']
+        sixs_config.elev = modtran_input['SURFACE']['GNDALT']
+        sixs_config.alt = modtran_input['GEOMETRY']['H1ALT']
         sixs_config.solzen = solar_zenith
         sixs_config.solaz = solar_azimuth
         sixs_config.viewzen = 180 - modtran_input['GEOMETRY']['OBSZEN']

--- a/isofit/radiative_transfer/sRTMnet.py
+++ b/isofit/radiative_transfer/sRTMnet.py
@@ -67,10 +67,11 @@ class SimulatedModtranRT(TabularRT):
                 del full_config.forward_model.radiative_transfer.lut_grid[name]
                 if name == 'OBSZEN':
                     full_config.forward_model.radiative_transfer.lut_grid[to_update] = \
-                        [180 - x for x in full_config.forward_model.radiative_transfer.lut_grid[to_update]].sort()
+                        [180 - x for x in full_config.forward_model.radiative_transfer.lut_grid[to_update]]
+                    full_config.forward_model.radiative_transfer.lut_grid[to_update].sort()
 
         full_config.forward_model.radiative_transfer.lut_grid = OrderedDict(sorted(full_config.forward_model.radiative_transfer.lut_grid.items(), key=lambda t: t[0]))
-        engine_config.lut_names = engine_config.lut_names.sort()
+        engine_config.lut_names.sort()
 
         logging.info('Swap known configuration names')
 

--- a/isofit/radiative_transfer/six_s.py
+++ b/isofit/radiative_transfer/six_s.py
@@ -57,11 +57,13 @@ class SixSRT(TabularRT):
     """A model of photon transport including the atmosphere."""
 
     def __init__(self, engine_config: RadiativeTransferEngineConfig, full_config: Config,
-                        build_lut=True, build_lut_only=False, wavelength_override=None, fwhm_override=None):
+                 build_lut=True, build_lut_only=False, wavelength_override=None, fwhm_override=None,
+                 modtran_emulation=False):
 
         self.angular_lut_keys_degrees = ['OBSZEN', 'TRUEAZ', 'viewzen', 'viewaz',
                                          'solzen', 'solaz']
         self.angular_lut_keys_radians = []
+        self.modtran_emulation = modtran_emulation
 
         super().__init__(engine_config, full_config)
 
@@ -149,7 +151,21 @@ class SixSRT(TabularRT):
         # Translate a couple of special cases
         if 'H2OSTR' in self.lut_names:
             vals['h2o_mm'] = vals['H2OSTR']*10.0
+        if 'GNDALT' in vals:
+            vals['elev'] = vals['GNDALT']
+        if 'H1ALT' in vals:
+            vals['alt'] = vals['H1ALT']
+        if 'TRUEAZ' in vals:
+            vals['viewaz'] = vals['TRUEAZ']
+        if 'OBSZEN' in vals:
+            vals['viewzen'] = 180 - vals['OBSZEN']
+
+        if self.modtran_emulation:
+            if 'AERFRAC_2' in vals:
+                vals['AOT550'] = vals['AERFRAC_2']
+
         vals['elev'] = vals['elev']*-1
+        vals['alt'] = vals['alt']*-1
 
         # Check rebuild conditions: LUT is missing or from a different config
         scriptfilename = 'LUT_'+fn+'.sh'

--- a/isofit/radiative_transfer/six_s.py
+++ b/isofit/radiative_transfer/six_s.py
@@ -164,8 +164,8 @@ class SixSRT(TabularRT):
             if 'AERFRAC_2' in vals:
                 vals['AOT550'] = vals['AERFRAC_2']
 
-        vals['elev'] = vals['elev']*-1
-        vals['alt'] = vals['alt']*-1
+        if 'elev' in vals:
+            vals['elev'] = vals['elev']*-1
 
         # Check rebuild conditions: LUT is missing or from a different config
         scriptfilename = 'LUT_'+fn+'.sh'

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -441,7 +441,7 @@ class Pathnames():
         self.irradiance_file = abspath(join(self.isofit_path,'examples','20151026_SantaMonica','data','prism_optimized_irr.dat'))
 
         self.aerosol_tpl_path = join(self.isofit_path, 'data', 'aerosol_template.json')
-        self.rdn_factors_path = args.rdn_factors_path
+        self.rdn_factors_path = abspath(args.rdn_factors_path)
 
         self.ray_temp_dir = args.ray_temp_dir
 
@@ -567,7 +567,10 @@ class LUTConfig:
 
         if min_spacing > 0.0001:
             grid = np.round(grid, 4)
-        if np.abs(grid[1] - grid[0]) < min_spacing:
+        if len(grid) == 1:
+            logging.debug(f'Grid spacing is 0, which is less than {min_spacing}.  No grid used')
+            return None
+        elif np.abs(grid[1] - grid[0]) < min_spacing:
             logging.debug(f'Grid spacing is {grid[1]-grid[0]}, which is less than {min_spacing}.  No grid used')
             return None
         else:
@@ -633,11 +636,14 @@ class LUTConfig:
                 num_points = 1
             else:
                 # This very well might overly space the grid, but we don't / can't know in general
-                num_points = 360 / spacing
+                num_points = int(np.ceil(360 / spacing))
 
             # We initialize the GMM with a static seed for repeatability across runs
             gmm = mixture.GaussianMixture(n_components=num_points, covariance_type='full',
                                           random_state=1)
+            if spatial_data.shape[0]  == 1:
+                spatial_data = np.vstack([spatial_data, spatial_data])
+
             gmm.fit(spatial_data)
             central_angles = np.degrees(np.arctan2(gmm.means_[:, 1], gmm.means_[:, 0]))
             if num_points == 1:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -441,7 +441,10 @@ class Pathnames():
         self.irradiance_file = abspath(join(self.isofit_path,'examples','20151026_SantaMonica','data','prism_optimized_irr.dat'))
 
         self.aerosol_tpl_path = join(self.isofit_path, 'data', 'aerosol_template.json')
-        self.rdn_factors_path = abspath(args.rdn_factors_path)
+        self.rdn_factors_path = None
+        if args.rdn_factors_path is not None:
+            self.rdn_factors_path = abspath(args.rdn_factors_path)
+
 
         self.ray_temp_dir = args.ray_temp_dir
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -190,6 +190,13 @@ def main():
 
     mean_latitude, mean_longitude, mean_elevation_km, elevation_lut_grid = \
         get_metadata_from_loc(paths.loc_working_path, lut_params)
+    if args.emulator_base is not None:
+        if np.any(elevation_lut_grid < 0):
+            to_rem = elevation_lut_grid[elevation_lut_grid < 0].copy()
+            elevation_lut_grid[ elevation_lut_grid< 0] = 0
+            elevation_lut_grid = np.unique(elevation_lut_grid)
+            logging.info("Scene contains target lut grid elements < 0 km, and uses 6s (via sRTMnet).  6s does not "
+                         f"support targets below sea level in km units.  Setting grid points {to_rem} to 0.")
 
     # Need a 180 - here, as this is already in MODTRAN convention
     mean_altitude_km = mean_elevation_km + np.cos(np.deg2rad(180 - mean_to_sensor_zenith)) * mean_path_km


### PR DESCRIPTION
This update fixes a bug in sRTMnet, whereby some elements were left out of the statevector (elevation, for example).  Also prevents apply_oe from populating sRTMnet with elevations below sea level (as negative elevation units (in km) in 6s are treated as pressure units).

Range of LUT elements turn more reasonable, as demonstrated by the comparison:

previously:
![dim_LUT_visuals_H2OSTR](https://user-images.githubusercontent.com/23531204/103322578-74c6d380-49f3-11eb-8c37-6737cc5067bb.png)



with fix:
![dim_LUT_visuals_H2OSTR](https://user-images.githubusercontent.com/23531204/103322582-798b8780-49f3-11eb-852a-842e9e7ce0ad.png)




