### PR TITLE
sRTMnet support for Hypertrace

### DIFF
--- a/.github/workflows/py-hypertrace.yml
+++ b/.github/workflows/py-hypertrace.yml
@@ -3,7 +3,7 @@ name: Hypertrace
 on: [push, pull_request]
 
 jobs:
-  hypertrace:
+  sRTMnet:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,21 +27,16 @@ jobs:
         pip install .
         pip install pandas
 
-    - name: Install libradtran dependencies
+    - name: Download and compile 6Sv
       run: |
-        # apt-get update && apt-get install -y sudo build-essential gfortran python2
-        sudo apt-get install -y libnetcdf-dev libnetcdff-dev libgsl-dev
-
-    - name: Download and install libradtran
-      run: |
-        wget -nv http://www.libradtran.org/download/libRadtran-2.0.3.tar.gz
-        tar -xf libRadtran-2.0.3.tar.gz
-        cd libRadtran-2.0.3
-        wget -nv http://www.meteo.physik.uni-muenchen.de/~libradtran/lib/exe/fetch.php?media=download:reptran_2017_all.tar.gz -O reptran-2017-all.tar.gz
-        tar -xf reptran-2017-all.tar.gz
-        PYTHON=$(which python2) ./configure --prefix=$(pwd)
-        # For some reason, uvspecfunction compilation fails...
-        make --ignore-errors
+        cd examples/py-hypertrace
+        wget -nv https://github.com/ashiklom/isofit/releases/download/6sv-mirror/6sV-2.1.tar
+        mkdir -p 6sV-2.1
+        tar -xf 6sV-2.1.tar --directory 6sV-2.1
+        cd 6sV-2.1
+        # Necessary for compilation to work with recent GCC versions
+        sed -i Makefile -e 's/FFLAGS.*/& -std=legacy/'
+        make
 
     - name: Download and extract hypertrace data
       run: |
@@ -49,17 +44,86 @@ jobs:
         wget -nv https://github.com/ashiklom/isofit/releases/download/hypertrace-data/hypertrace-data.tar.gz
         tar -xf hypertrace-data.tar.gz
 
-    - name: Run continuous integration workflow
+    - name: Download sRTMnet
+      run: |
+        cd examples/py-hypertrace
+        mkdir sRTMnet_v100
+        cd sRTMnet_v100
+        wget -nv https://zenodo.org/record/4096627/files/sRTMnet_v100.zip
+        unzip sRTMnet_v100.zip && rm sRTMnet_v100.zip
+        pwd -P
+        ls -l ./
+
+    - name: Run Hypertrace
       run: |
         cd examples/py-hypertrace
         # Modify the workflow file for GitHub actions
-        export LIBRADTRAN_DIR=$GITHUB_WORKSPACE/libRadtran-2.0.3
-        jq -r ".isofit.forward_model.radiative_transfer.radiative_transfer_engines.vswir += {\"engine_base_dir\": \"/$GITHUB_WORKSPACE/libRadtran-2.0.3\", \"environment\": \"\"}" config-example.json > config.json
-        python workflow.py config.json
-        python summarize.py config.json
+        python workflow.py configs/example-srtmnet.json
+        # python summarize.py configs/example-srtmnet.json
 
-    - name: Upload summary from CI workflow
-      uses: actions/upload-artifact@v2
-      with:
-        name: summary
-        path: examples/py-hypertrace/output/summary.csv
+    # - name: Upload summary from CI workflow
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: summary
+    #     path: examples/py-hypertrace/output/summary.csv
+
+  # libradtran:
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: 3.8
+
+  #   - name: Install GDAL
+  #     run: |
+  #       sudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update
+  #       sudo apt-get install gdal-bin
+  #       sudo apt-get install libgdal-dev
+  #       pip install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==`gdal-config --version`
+
+  #   - name: Install Isofit
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install .
+  #       pip install pandas
+
+  #   - name: Install libradtran dependencies
+  #     run: |
+  #       # apt-get update && apt-get install -y sudo build-essential gfortran python2
+  #       sudo apt-get install -y libnetcdf-dev libnetcdff-dev libgsl-dev
+
+  #   - name: Download and install libradtran
+  #     run: |
+  #       wget -nv http://www.libradtran.org/download/libRadtran-2.0.3.tar.gz
+  #       tar -xf libRadtran-2.0.3.tar.gz
+  #       cd libRadtran-2.0.3
+  #       wget -nv http://www.meteo.physik.uni-muenchen.de/~libradtran/lib/exe/fetch.php?media=download:reptran_2017_all.tar.gz -O reptran-2017-all.tar.gz
+  #       tar -xf reptran-2017-all.tar.gz
+  #       PYTHON=$(which python2) ./configure --prefix=$(pwd)
+  #       # For some reason, uvspecfunction compilation fails...
+  #       make --ignore-errors
+
+  #   - name: Download and extract hypertrace data
+  #     run: |
+  #       cd examples/py-hypertrace
+  #       wget -nv https://github.com/ashiklom/isofit/releases/download/hypertrace-data/hypertrace-data.tar.gz
+  #       tar -xf hypertrace-data.tar.gz
+
+  #   - name: Run continuous integration workflow
+  #     run: |
+  #       cd examples/py-hypertrace
+  #       # Modify the workflow file for GitHub actions
+  #       export LIBRADTRAN_DIR=$GITHUB_WORKSPACE/libRadtran-2.0.3
+  #       jq -r ".isofit.forward_model.radiative_transfer.radiative_transfer_engines.vswir += {\"engine_base_dir\": \"/$GITHUB_WORKSPACE/libRadtran-2.0.3\", \"environment\": \"\"}" config-example.json > config.json
+  #       python workflow.py config.json
+  #       python summarize.py config.json
+
+  #   - name: Upload summary from CI workflow
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: summary
+  #       path: examples/py-hypertrace/output/summary.csv

--- a/.github/workflows/py-hypertrace.yml
+++ b/.github/workflows/py-hypertrace.yml
@@ -51,79 +51,76 @@ jobs:
         cd sRTMnet_v100
         wget -nv https://zenodo.org/record/4096627/files/sRTMnet_v100.zip
         unzip sRTMnet_v100.zip && rm sRTMnet_v100.zip
-        pwd -P
-        ls -l ./
 
     - name: Run Hypertrace
       run: |
         cd examples/py-hypertrace
         # Modify the workflow file for GitHub actions
         python workflow.py configs/example-srtmnet.json
-        # python summarize.py configs/example-srtmnet.json
+        python summarize.py configs/example-srtmnet.json
 
-    # - name: Upload summary from CI workflow
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: summary
-    #     path: examples/py-hypertrace/output/summary.csv
+    - name: Upload summary from CI workflow
+      uses: actions/upload-artifact@v2
+      with:
+        name: srtmnet-summary
+        path: examples/py-hypertrace/output/example-srtmnet/summary.csv
 
-  # libradtran:
-  #   runs-on: ubuntu-latest
+  libradtran:
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #   - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: 3.8
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
 
-  #   - name: Install GDAL
-  #     run: |
-  #       sudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update
-  #       sudo apt-get install gdal-bin
-  #       sudo apt-get install libgdal-dev
-  #       pip install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==`gdal-config --version`
+    - name: Install GDAL
+      run: |
+        sudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update
+        sudo apt-get install gdal-bin
+        sudo apt-get install libgdal-dev
+        pip install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==`gdal-config --version`
 
-  #   - name: Install Isofit
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install .
-  #       pip install pandas
+    - name: Install Isofit
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install pandas
 
-  #   - name: Install libradtran dependencies
-  #     run: |
-  #       # apt-get update && apt-get install -y sudo build-essential gfortran python2
-  #       sudo apt-get install -y libnetcdf-dev libnetcdff-dev libgsl-dev
+    - name: Install libradtran dependencies
+      run: |
+        sudo apt-get install -y libnetcdf-dev libnetcdff-dev libgsl-dev
 
-  #   - name: Download and install libradtran
-  #     run: |
-  #       wget -nv http://www.libradtran.org/download/libRadtran-2.0.3.tar.gz
-  #       tar -xf libRadtran-2.0.3.tar.gz
-  #       cd libRadtran-2.0.3
-  #       wget -nv http://www.meteo.physik.uni-muenchen.de/~libradtran/lib/exe/fetch.php?media=download:reptran_2017_all.tar.gz -O reptran-2017-all.tar.gz
-  #       tar -xf reptran-2017-all.tar.gz
-  #       PYTHON=$(which python2) ./configure --prefix=$(pwd)
-  #       # For some reason, uvspecfunction compilation fails...
-  #       make --ignore-errors
+    - name: Download and install libradtran
+      run: |
+        cd examples/py-hypertrace
+        wget -nv http://www.libradtran.org/download/history/libRadtran-2.0.3.tar.gz
+        tar -xf libRadtran-2.0.3.tar.gz
+        cd libRadtran-2.0.3
+        wget -nv http://www.meteo.physik.uni-muenchen.de/~libradtran/lib/exe/fetch.php?media=download:reptran_2017_all.tar.gz -O reptran-2017-all.tar.gz
+        tar -xf reptran-2017-all.tar.gz
+        PYTHON=$(which python2) ./configure --prefix=$(pwd)
+        # For some reason, uvspecfunction compilation fails...
+        make --ignore-errors
 
-  #   - name: Download and extract hypertrace data
-  #     run: |
-  #       cd examples/py-hypertrace
-  #       wget -nv https://github.com/ashiklom/isofit/releases/download/hypertrace-data/hypertrace-data.tar.gz
-  #       tar -xf hypertrace-data.tar.gz
+    - name: Download and extract Hypertrace data
+      run: |
+        cd examples/py-hypertrace
+        wget -nv https://github.com/ashiklom/isofit/releases/download/hypertrace-data/hypertrace-data.tar.gz
+        tar -xf hypertrace-data.tar.gz
 
-  #   - name: Run continuous integration workflow
-  #     run: |
-  #       cd examples/py-hypertrace
-  #       # Modify the workflow file for GitHub actions
-  #       export LIBRADTRAN_DIR=$GITHUB_WORKSPACE/libRadtran-2.0.3
-  #       jq -r ".isofit.forward_model.radiative_transfer.radiative_transfer_engines.vswir += {\"engine_base_dir\": \"/$GITHUB_WORKSPACE/libRadtran-2.0.3\", \"environment\": \"\"}" config-example.json > config.json
-  #       python workflow.py config.json
-  #       python summarize.py config.json
+    - name: Run continuous integration workflow
+      run: |
+        cd examples/py-hypertrace
+        # Modify the workflow file for GitHub actions
+        export LIBRADTRAN_DIR=$GITHUB_WORKSPACE/libRadtran-2.0.3
+        python workflow.py configs/example-libradtran.json
+        python summarize.py configs/example-libradtran.json
 
-  #   - name: Upload summary from CI workflow
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: summary
-  #       path: examples/py-hypertrace/output/summary.csv
+    - name: Upload summary from CI workflow
+      uses: actions/upload-artifact@v2
+      with:
+        name: summary-libradtran
+        path: examples/py-hypertrace/output-libradtran/summary.csv

--- a/examples/py-hypertrace/.gitignore
+++ b/examples/py-hypertrace/.gitignore
@@ -10,12 +10,9 @@ htmlcov
 
 output/*
 
-# JSON files that are NOT the config example
-*.json
-!config-example.json
-
 # Example look-up table directory
-/luts/
+luts
+^luts/
 
 # Recommended hypertrace data directory
 /hypertrace-data

--- a/examples/py-hypertrace/configs/.gitignore
+++ b/examples/py-hypertrace/configs/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+*.json
+!example-*.json

--- a/examples/py-hypertrace/configs/example-calibration.json
+++ b/examples/py-hypertrace/configs/example-calibration.json
@@ -1,9 +1,9 @@
 {
     "wavelength_file": "./hypertrace-data/priors/avirisc-wavelengths.txt",
     "reflectance_file": "./hypertrace-data/reflectance/reference/reference_reflectance",
-    "libradtran_template_file": "./lrt-template.inp",
+    "rtm_template_file": "./lrt-template.inp",
     "lutdir": "./luts",
-    "outdir": "./output",
+    "outdir": "./output/calibration",
     "isofit": {
         "forward_model": {
             "instrument": {
@@ -53,12 +53,12 @@
         }
     },
     "hypertrace": {
-        "atm_aod_h2o": [["midlatitude_winter", 0.2, 1.0], ["midlatitude_winter", 0.3, 2.0]],
-        "observer_zenith": [0.0, 20.0],
-        "inversion_mode": ["simple", "inversion"],
-        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt",
-                      "./hypertrace-data/noise/noise_coeff_sbg_cbe1.txt"],
-        "surface_file": ["./hypertrace-data/priors/uninformative.mat",
-                        "./hypertrace-data/priors/basemap_surface_model.mat"]
+        "calibration_uncertainty_file": ["./hypertrace-data/other/20201006_calibration_drift.mat"],
+        "n_calibration_draws": [5],
+        "calibration_scale": [16],
+        "atm_aod_h2o": [["midlatitude_winter", 0.2, 1.0]],
+        "inversion_mode": ["inversion"],
+        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt"],
+        "surface_file": ["./hypertrace-data/priors/uninformative.mat"]
     }
 }

--- a/examples/py-hypertrace/configs/example-libradtran.json
+++ b/examples/py-hypertrace/configs/example-libradtran.json
@@ -1,0 +1,64 @@
+{
+    "wavelength_file": "./hypertrace-data/priors/avirisc-wavelengths.txt",
+    "reflectance_file": "./hypertrace-data/reflectance/reference/reference_reflectance",
+    "rtm_template_file": "./lrt-template.inp",
+    "lutdir": "./luts",
+    "outdir": "./output",
+    "isofit": {
+        "forward_model": {
+            "instrument": {
+                "SNR": 300,
+                "integrations": 1
+            },
+            "surface": {
+                "surface_category": "multicomponent_surface"
+            },
+            "radiative_transfer": {
+                "lut_grid": {
+                    "AOT550": [0.001, 0.123, 0.6],
+                    "H2OSTR": [1.0, 2.5, 3.25]
+                },
+                "statevector": {
+                    "AOT550": {
+                        "bounds": [0.01, 0.6],
+                        "scale": 0.01,
+                        "prior_mean": 0.05,
+                        "prior_sigma": 0.2,
+                        "init": 0.05
+                    },
+                    "H2OSTR": {
+                        "bounds": [1.0, 3.25],
+                        "scale": 0.01,
+                        "prior_mean": 1.75,
+                        "prior_sigma": 1.0,
+                        "init": 1.75
+                    }
+                },
+                "unknowns": {"H2O_ABSCO": 0.01},
+                "radiative_transfer_engines": {
+                    "vswir": {
+                        "engine_name": "libradtran",
+                        "engine_base_dir": "~/projects/models/libRadtran-2.0.3",
+                        "environment": "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib",
+                        "lut_names": ["H2OSTR", "AOT550"],
+                        "statevector_names": ["H2OSTR", "AOT550"]
+                    }
+                }
+            }
+        },
+        "implementation": {
+            "inversion": {
+                "windows": [[400, 1300], [1450, 1780], [1950, 2450]]
+            }
+        }
+    },
+    "hypertrace": {
+        "atm_aod_h2o": [["midlatitude_winter", 0.2, 1.0], ["midlatitude_winter", 0.3, 2.0]],
+        "observer_zenith": [0.0, 20.0],
+        "inversion_mode": ["simple", "inversion"],
+        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt",
+                      "./hypertrace-data/noise/noise_coeff_sbg_cbe1.txt"],
+        "surface_file": ["./hypertrace-data/priors/uninformative.mat",
+                        "./hypertrace-data/priors/basemap_surface_model.mat"]
+    }
+}

--- a/examples/py-hypertrace/configs/example-libradtran.json
+++ b/examples/py-hypertrace/configs/example-libradtran.json
@@ -53,9 +53,9 @@
         }
     },
     "hypertrace": {
-        "atm_aod_h2o": [["midlatitude_winter", 0.2, 1.0], ["midlatitude_winter", 0.3, 2.0]],
-        "observer_zenith": [0.0, 20.0],
-        "inversion_mode": ["simple", "inversion"],
+        "atm_aod_h2o": [["midlatitude_winter", 0.2, 1.0]],
+        "observer_zenith": [0.0],
+        "inversion_mode": ["inversion"],
         "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt"],
         "surface_file": ["./hypertrace-data/priors/aviris-ng/surface_EMIT.mat"]
     }

--- a/examples/py-hypertrace/configs/example-libradtran.json
+++ b/examples/py-hypertrace/configs/example-libradtran.json
@@ -3,7 +3,7 @@
     "reflectance_file": "./hypertrace-data/reflectance/reference/reference_reflectance",
     "rtm_template_file": "./lrt-template.inp",
     "lutdir": "./luts",
-    "outdir": "./output",
+    "outdir": "./output-libradtran",
     "isofit": {
         "forward_model": {
             "instrument": {
@@ -38,7 +38,7 @@
                 "radiative_transfer_engines": {
                     "vswir": {
                         "engine_name": "libradtran",
-                        "engine_base_dir": "~/projects/models/libRadtran-2.0.3",
+                        "engine_base_dir": "./libRadtran-2.0.3",
                         "environment": "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib",
                         "lut_names": ["H2OSTR", "AOT550"],
                         "statevector_names": ["H2OSTR", "AOT550"]

--- a/examples/py-hypertrace/configs/example-libradtran.json
+++ b/examples/py-hypertrace/configs/example-libradtran.json
@@ -1,8 +1,8 @@
 {
-    "wavelength_file": "./hypertrace-data/priors/avirisc-wavelengths.txt",
+    "wavelength_file": "./hypertrace-data/wavelengths/aviris-ng.txt",
     "reflectance_file": "./hypertrace-data/reflectance/reference/reference_reflectance",
     "rtm_template_file": "./lrt-template.inp",
-    "lutdir": "./luts",
+    "lutdir": "./luts/libradtran",
     "outdir": "./output-libradtran",
     "isofit": {
         "forward_model": {
@@ -56,9 +56,7 @@
         "atm_aod_h2o": [["midlatitude_winter", 0.2, 1.0], ["midlatitude_winter", 0.3, 2.0]],
         "observer_zenith": [0.0, 20.0],
         "inversion_mode": ["simple", "inversion"],
-        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt",
-                      "./hypertrace-data/noise/noise_coeff_sbg_cbe1.txt"],
-        "surface_file": ["./hypertrace-data/priors/uninformative.mat",
-                        "./hypertrace-data/priors/basemap_surface_model.mat"]
+        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt"],
+        "surface_file": ["./hypertrace-data/priors/aviris-ng/surface_EMIT.mat"]
     }
 }

--- a/examples/py-hypertrace/configs/example-modtran.json
+++ b/examples/py-hypertrace/configs/example-modtran.json
@@ -1,0 +1,63 @@
+{
+    "wavelength_file": "./hypertrace-data/priors/avirisc-wavelengths.txt",
+    "reflectance_file": "./hypertrace-data/reflectance/reference/reference_reflectance",
+    "rtm_template_file": "./modtran-template.json",
+    "lutdir": "./luts/modtran",
+    "outdir": "./output/modtran",
+    "isofit": {
+        "forward_model": {
+            "instrument": {
+                "SNR": 300,
+                "integrations": 1
+            },
+            "surface": {
+                "surface_category": "multicomponent_surface"
+            },
+            "radiative_transfer": {
+                "lut_grid": {
+                    "AOT550": [0.001, 0.6],
+                    "H2OSTR": [0.543, 3.216]
+                },
+                "statevector": {
+                    "AOT550": {
+                        "bounds": [0.01, 0.6],
+                        "scale": 0.01,
+                        "prior_mean": 0.05,
+                        "prior_sigma": 0.2,
+                        "init": 0.05
+                    },
+                    "H2OSTR": {
+                        "bounds": [1.0, 3.25],
+                        "scale": 0.01,
+                        "prior_mean": 1.75,
+                        "prior_sigma": 1.0,
+                        "init": 1.75
+                    }
+                },
+                "unknowns": {"H2O_ABSCO": 0.01},
+                "radiative_transfer_engines": {
+                    "vswir": {
+                        "engine_name": "modtran",
+                        "engine_base_dir": "/dev/null",
+                        "lut_names": ["H2OSTR", "AOT550"],
+                        "statevector_names": ["H2OSTR", "AOT550"]
+                    }
+                }
+            }
+        },
+        "implementation": {
+            "inversion": {
+                "windows": [[400, 1300], [1450, 1780], [1950, 2450]]
+            }
+        }
+    },
+    "hypertrace": {
+        "atmosphere_type": ["ATM_MIDLAT_SUMMER"],
+        "aod": [0.2, 0.3],
+        "h2o": [1.0, 2.0],
+        "observer_zenith": [0, 22.5],
+        "inversion_mode": ["inversion"],
+        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt"],
+        "surface_file": ["./hypertrace-data/priors/uninformative.mat"]
+    }
+}

--- a/examples/py-hypertrace/configs/example-srtmnet.json
+++ b/examples/py-hypertrace/configs/example-srtmnet.json
@@ -1,0 +1,65 @@
+{
+    "wavelength_file": "./hypertrace-data/wavelengths/aviris-ng.txt",
+    "reflectance_file": "./hypertrace-data/reflectance/reference/reference_reflectance",
+    "rtm_template_file": "/dev/null",
+    "lutdir": "./luts/sRTMnet",
+    "outdir": "./output/example-srtmnet",
+    "isofit": {
+        "forward_model": {
+            "instrument": {
+                "SNR": 300,
+                "integrations": 1
+            },
+            "surface": {
+                "surface_category": "multicomponent_surface"
+            },
+            "radiative_transfer": {
+                "lut_grid": {
+                    "AOT550": [0.01, 0.1, 0.258, 0.505, 0.752, 1.0],
+                    "H2OSTR": [0.1, 0.6125, 1.325, 2.55, 3.775, 5.0]
+                },
+                "statevector": {
+                    "AOT550": {
+                        "bounds": [0.01, 1.0],
+                        "scale": 0.01,
+                        "prior_mean": 0.05,
+                        "prior_sigma": 0.2,
+                        "init": 0.05
+                    },
+                    "H2OSTR": {
+                        "bounds": [0.1, 5.0],
+                        "scale": 0.01,
+                        "prior_mean": 1.75,
+                        "prior_sigma": 1.0,
+                        "init": 1.75
+                    }
+                },
+                "unknowns": {"H2O_ABSCO": 0.01},
+                "radiative_transfer_engines": {
+                    "vswir": {
+                        "engine_name": "simulated_modtran",
+                        "engine_base_dir": "./6sV-2.1",
+                        "aerosol_template_path": "../../data/aerosol_template.json",
+                        "earth_sun_distance_file": "../../data/earth_sun_distance.txt",
+                        "irradiance_file": "../../examples/20151026_SantaMonica/data/prism_optimized_irr.dat",
+                        "emulator_aux_file": "./sRTMnet_v100/sRTMnet_v100_aux.npz",
+                        "emulator_file": "./sRTMnet_v100/sRTMnet_v100",
+                        "statevector_names": ["H2OSTR", "AOT550"]
+                    }
+                }
+            }
+        },
+        "implementation": {
+            "inversion": {
+                "windows": [[400, 1300], [1450, 1780], [1950, 2450]]
+            }
+        }
+    },
+    "hypertrace": {
+        "atm_aod_h2o": [["ATM_MIDLAT_SUMMER", 0.2, 1.0], ["ATM_MIDLAT_SUMMER", 0.3, 2.0]],
+        "observer_zenith": [0, 22.5],
+        "inversion_mode": ["inversion"],
+        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt"],
+        "surface_file": ["./hypertrace-data/priors/aviris-ng/surface_EMIT.mat"]
+    }
+}

--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -5,12 +5,17 @@
 import copy
 import pathlib
 import json
+import shutil
 import logging
 
 import numpy as np
+import spectral as sp
 from scipy.io import loadmat
+from scipy.interpolate import interp1d
 
 from isofit.core.isofit import Isofit
+from isofit.utils import empirical_line, segment, extractions
+from isofit.utils.apply_oe import write_modtran_template
 
 logger = logging.getLogger(__name__)
 
@@ -19,12 +24,22 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
                   lutdir, outdir,
                   surface_file="./data/prior.mat",
                   noisefile=None, snr=300,
-                  aod=0.1, h2o=1.0, lrt_atmosphere_type="midlatitude_winter",
+                  aod=0.1, h2o=1.0, atmosphere_type="ATM_MIDLAT_WINTER",
                   atm_aod_h2o=None,
                   solar_zenith=0, observer_zenith=0,
                   solar_azimuth=0, observer_azimuth=0,
+                  observer_altitude_km=99.9,
+                  dayofyear=200,
+                  latitude=34.15, longitude=-118.14,
+                  localtime=10.0,
+                  elevation_km=0.01,
                   inversion_mode="inversion",
-                  create_lut=True):
+                  use_empirical_line=False,
+                  calibration_uncertainty_file=None,
+                  n_calibration_draws=1,
+                  calibration_scale=1,
+                  create_lut=True,
+                  overwrite=False):
     """One iteration of the hypertrace workflow.
 
     Required arguments:
@@ -39,11 +54,11 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
         the convention of the `spectral` Python library, which will be used to
         read this file).
 
-        libradtran_template_file: Path to the LibRadtran template. Note that
-        this is slightly different from the Isofit template in that the Isofit
-        fields are surrounded by two sets of `{{` while a few additional options
-        related to geometry are surrounded by just `{` (this is because
-        Hypertrace does an initial pass at formatting the files).
+        rtm_template_file: Path to the atmospheric RTM template. For LibRadtran,
+        note that this is slightly different from the Isofit template in that
+        the Isofit fields are surrounded by two sets of `{{` while a few
+        additional options related to geometry are surrounded by just `{` (this
+        is because Hypertrace does an initial pass at formatting the files).
 
         `lutdir`: Directory where look-up tables will be stored. Will be created
         if missing.
@@ -65,8 +80,8 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
 
       h2o: True water vapor content. Default = 1.0
 
-      lrt_atmosphere_type: LibRadtran atmosphere type. See LibRadtran manual for
-      details. Default = `midlatitude_winter`
+      atmosphere_type: LibRadtran or Modtran atmosphere type. See RTM
+      manuals for details. Default = `ATM_MIDLAT_WINTER`
 
       atm_aod_h2o: A list containing three elements: The atmosphere type, AOD,
       and H2O. This provides a way to iterate over specific known atmospheres
@@ -77,20 +92,50 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
       respectively (0 = directly overhead, 90 = horizon). These are in degrees
       off nadir. Default = 0 for both. (Note that off-nadir angles make
       LibRadtran run _much_ more slowly, so be prepared if you need to generate
-      those LUTs).
+      those LUTs). (Note: For `modtran` and `modtran_simulator`, `solar_zenith`
+      is calculated from the `gmtime` and location, so this parameter is ignored.)
 
       solar_azimuth, observer_azimuth: Solar and observer azimuth angles,
       respectively, in degrees. Observer azimuth is the sensor _position_ (so
       180 degrees off from view direction) relative to N, rotating
       counterclockwise; i.e., 0 = Sensor in N, looking S; 90 = Sensor in W,
       looking E (this follows the LibRadtran convention). Default = 0 for both.
+      Note: For `modtran` and `modtran_simulator`, `observer_azimuth` is used as
+      `to_sensor_azimuth`; i.e., the *relative* azimuth of the sensor. The true
+      solar azimuth is calculated from lat/lon and time, so `solar_azimuth` is ignored.
+
+      observer_altitude_km: Sensor altitude in km. Must be less than 100. Default = 99.9.
+      (`modtran` and `modtran_simulator` only)
+
+      dayofyear: Julian date of observation. Default = 200
+      (`modtran` and `modtran_simulator` only)
+
+      latitude, longitude: Decimal degree coordinates of observation. Default =
+      34.15, -118.14 (Pasadena, CA).
+      (`modtran` and `modtran_simulator` only)
+
+      localtime: Local time, in decimal hours (0-24). Default = 10.0
+      (`modtran` and `modtran_simulator` only)
+
+      elevation_km: Target elevation above sea level, in km. Default = 0.01
+      (`modtran` and `modtran_simulator` only)
 
       inversion_mode: Inversion algorithm to use. Must be either "inversion"
       (default) for standard optimal estimation, or "mcmc_inversion" for MCMC.
+
+      use_empirical_line: (boolean, default = `False`) If `True`, perform
+      atmospheric correction on a segmented image and then resample using the
+      empirical line method. If `False`, run Isofit pixel-by-pixel.
+
+      overwrite: (boolean, default = `False`) If `False` (default), skip steps
+      where output files already exist. If `True`, run the full workflow
+      regardless of existing files.
     """
 
     outdir = mkabs(outdir)
     outdir.mkdir(parents=True, exist_ok=True)
+
+    assert observer_altitude_km < 100, "Isofit 6S does not support altitude >= 100km"
 
     isofit_common = copy.deepcopy(isofit_config)
     # NOTE: All of these settings are *not* copied, but referenced. So these
@@ -116,46 +161,100 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
         f"inversion_{inversion_mode}"
 
     if atm_aod_h2o is not None:
-        lrt_atmosphere_type = atm_aod_h2o[0]
+        atmosphere_type = atm_aod_h2o[0]
         aod = atm_aod_h2o[1]
         h2o = atm_aod_h2o[2]
 
-    lrttag = f"atm_{lrt_atmosphere_type}__" +\
-        f"szen_{solar_zenith}__" +\
-        f"ozen_{observer_zenith}__" +\
-        f"saz_{solar_azimuth}__" +\
-        f"oaz_{observer_azimuth}"
-    atmtag = f"aod_{aod}__h2o_{h2o}"
+    atmtag = f"aod_{aod:.3f}__h2o_{h2o:.3f}"
+    if calibration_uncertainty_file is not None:
+        caltag = f"cal_{pathlib.Path(calibration_uncertainty_file).stem}__" +\
+                f"draw_{n_calibration_draws}__" +\
+                f"scale_{calibration_scale}"
+    else:
+        caltag = "cal_NONE__draw_0__scale_0"
 
     if create_lut:
         lutdir = mkabs(lutdir)
         lutdir.mkdir(parents=True, exist_ok=True)
-        lutdir2 = lutdir / lrttag
-        lutdir2.mkdir(parents=True, exist_ok=True)
-        lrtfile = lutdir2 / "lrt-template.inp"
         vswir_conf = forward_settings["radiative_transfer"]["radiative_transfer_engines"]["vswir"]
-        with open(libradtran_template_file, "r") as f:
-            fs = f.read()
-            open(lrtfile, "w").write(fs.format(
-                atmosphere=lrt_atmosphere_type, solar_azimuth=solar_azimuth,
-                solar_zenith=solar_zenith,
-                cos_observer_zenith=np.cos(observer_zenith * np.pi / 180.0),
-                observer_azimuth=observer_azimuth
-            ))
-        open(lutdir2 / "prescribed_geom", "w").write(f"99:99:99   {solar_zenith}  {solar_azimuth}")
+        atmospheric_rtm = vswir_conf["engine_name"]
+
+        if atmospheric_rtm == "libradtran":
+            lrttag = f"atm_{atmosphere_type}__" +\
+                f"szen_{solar_zenith:.2f}__" +\
+                f"ozen_{observer_zenith:.2f}__" +\
+                f"saz_{solar_azimuth:.2f}__" +\
+                f"oaz_{observer_azimuth:.2f}"
+            lutdir2 = lutdir / lrttag
+            lutdir2.mkdir(parents=True, exist_ok=True)
+            lrtfile = lutdir2 / "lrt-template.inp"
+            with open(rtm_template_file, "r") as f:
+                fs = f.read()
+                open(lrtfile, "w").write(fs.format(
+                    atmosphere=atmosphere_type, solar_azimuth=solar_azimuth,
+                    solar_zenith=solar_zenith,
+                    cos_observer_zenith=np.cos(observer_zenith * np.pi / 180.0),
+                    observer_azimuth=observer_azimuth
+                ))
+            open(lutdir2 / "prescribed_geom", "w").write(f"99:99:99   {solar_zenith}  {solar_azimuth}")
+
+        elif atmospheric_rtm in ("modtran", "simulated_modtran"):
+            loctag = f"atm_{atmosphere_type}__" +\
+                f"alt_{observer_altitude_km:.2f}__" +\
+                f"doy_{dayofyear:.0f}__" +\
+                f"lat_{latitude:.3f}__lon_{longitude:.3f}"
+            angtag = f"az_{observer_azimuth:.2f}__" +\
+                f"zen_{180 - observer_zenith:.2f}__" +\
+                f"time_{localtime:.2f}__" +\
+                f"elev_{elevation_km:.2f}"
+            lrttag = loctag + "/" + angtag
+            lutdir2 = lutdir / lrttag
+            lutdir2.mkdir(parents=True, exist_ok=True)
+            lrtfile = lutdir2 / "modtran-template-h2o.json"
+            mt_params = {
+                "atmosphere_type": atmosphere_type,
+                "fid": "hypertrace",
+                "altitude_km": observer_altitude_km,
+                "dayofyear": dayofyear,
+                "latitude": latitude,
+                "longitude": longitude,
+                "to_sensor_azimuth": observer_azimuth,
+                "to_sensor_zenith": 180 - observer_zenith,
+                "gmtime": localtime,
+                "elevation_km": elevation_km,
+                "output_file": lrtfile,
+                "ihaze_type": "AER_NONE"
+            }
+            write_modtran_template(**mt_params)
+            mt_params["ihaze_type"] = "AER_RURAL"
+            mt_params["output_file"] = lutdir2 / "modtran-template.json"
+            write_modtran_template(**mt_params)
+
+            vswir_conf["modtran_template_path"] = str(mt_params["output_file"])
+            if atmospheric_rtm == "simulated_modtran":
+                vswir_conf["interpolator_base_path"] = str(lutdir2 / "sRTMnet_interpolator")
+                # These need to be absolute file paths
+                for path in ["emulator_aux_file", "emulator_file",
+                             "earth_sun_distance_file", "irradiance_file"]:
+                    vswir_conf[path] = str(mkabs(vswir_conf[path]))
+
+        else:
+            raise ValueError(f"Invalid atmospheric rtm {atmospheric_rtm}")
+
         vswir_conf["lut_path"] = str(lutdir2)
         vswir_conf["template_file"] = str(lrtfile)
 
-    outdir2 = outdir / lrttag / noisetag / priortag / atmtag
+    outdir2 = outdir / lrttag / noisetag / priortag / atmtag / caltag
     outdir2.mkdir(parents=True, exist_ok=True)
 
     # Observation file, which describes the geometry
+    # Angles follow LibRadtran conventions
     obsfile = outdir2 / "obs.txt"
     geomvec = [
         -999,              # path length; not used
         observer_azimuth,  # Degrees 0-360; 0 = Sensor in N, looking S; 90 = Sensor in W, looking E
         observer_zenith,   # Degrees 0-90; 0 = directly overhead, 90 = horizon
-        solar_azimuth,     # Degrees 0-360; 0 = N, 90 = W, 180 = S, 270 = E
+        solar_azimuth,     # Degrees 0-360; 0 = Sun in S; 90 = Sun in W.
         solar_zenith,      # Same units as observer zenith
         180.0 - abs(observer_zenith),  # MODTRAN OBSZEN -- t
         observer_azimuth - solar_azimuth + 180.0,  # MODTRAN relative azimuth
@@ -191,8 +290,14 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
     fwd_state["AOT550"]["init"] = aod
     fwd_state["H2OSTR"]["init"] = h2o
 
-    fwdfile = outdir2 / "forward.json"
-    json.dump(isofit_fwd, open(fwdfile, "w"), indent=2)
+    if radfile.exists() and not overwrite:
+        logger.info("Skipping forward simulation because file exists.")
+    else:
+        fwdfile = outdir2 / "forward.json"
+        json.dump(isofit_fwd, open(fwdfile, "w"), indent=2)
+        logger.info("Starting forward simulation.")
+        Isofit(fwdfile).run()
+        logger.info("Forward simulation complete.")
 
     isofit_inv = copy.deepcopy(isofit_common)
     if inversion_mode == "simple":
@@ -205,17 +310,166 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
     isofit_inv["implementation"]["mode"] = inversion_mode
     isofit_inv["input"]["measured_radiance_file"] = str(radfile)
     est_refl_file = outdir2 / "estimated-reflectance"
-    isofit_inv["output"] = {"estimated_reflectance_file": str(est_refl_file)}
 
-    invfile = outdir2 / "inverse.json"
-    json.dump(isofit_inv, open(invfile, "w"), indent=2)
+    post_unc_path = outdir2 / "posterior-uncertainty"
+
+    # Inverse mode
+    est_state_file = outdir2 / "estimated-state"
+    atm_coef_file = outdir2 / "atmospheric-coefficients"
+    post_unc_file = outdir2 / "posterior-uncertainty"
+    isofit_inv["output"] = {"estimated_reflectance_file": str(est_refl_file),
+                            "estimated_state_file": str(est_state_file),
+                            "atmospheric_coefficients_file": str(atm_coef_file),
+                            "posterior_uncertainty_file": str(post_unc_file)}
 
     # Run the workflow
-    Isofit(fwdfile).run()
-    Isofit(invfile).run()
+    if calibration_uncertainty_file is not None:
+        # Apply calibration uncertainty here
+        calmat = loadmat(calibration_uncertainty_file)
+        cov = calmat["Covariance"]
+        cov_l = np.linalg.cholesky(cov)
+        cov_wl = np.squeeze(calmat["wavelengths"])
+        rad_img = sp.open_image(str(radfile) + ".hdr")
+        rad_wl = rad_img.bands.centers
+        del rad_img
+        for ical in range(n_calibration_draws):
+            icalp1 = ical + 1
+            radfile_cal = f"{str(radfile)}-{icalp1:02d}"
+            reflfile_cal = f"{str(est_refl_file)}-{icalp1:02d}"
+            statefile_cal = f"{str(est_state_file)}-{icalp1:02d}"
+            atmfile_cal = f"{str(atm_coef_file)}-{icalp1:02d}"
+            uncfile_cal = f"{str(post_unc_file)}-{icalp1:02d}"
+            if pathlib.Path(reflfile_cal).exists() and not overwrite:
+                logger.info("Skipping calibration %d/%d because output exists",
+                            icalp1, n_calibration_draws)
+                next
+            logger.info("Applying calibration uncertainty (%d/%d)", icalp1, n_calibration_draws)
+            sample_calibration_uncertainty(radfile, radfile_cal, cov_l, cov_wl, rad_wl,
+                                           bias_scale=calibration_scale)
+            logger.info("Starting inversion (calibration %d/%d)", icalp1, n_calibration_draws)
+            do_inverse(
+                copy.deepcopy(isofit_inv), radfile_cal, reflfile_cal,
+                statefile_cal, atmfile_cal, uncfile_cal,
+                overwrite=overwrite, use_empirical_line=use_empirical_line
+            )
+            logger.info("Inversion complete (calibration %d/%d)", icalp1, n_calibration_draws)
 
+    else:
+        if est_refl_file.exists() and not overwrite:
+            logger.info("Skipping inversion because output exists.")
+        else:
+            logger.info("Starting inversion.")
+            do_inverse(
+                copy.deepcopy(isofit_inv), radfile, est_refl_file,
+                est_state_file, atm_coef_file, post_unc_file,
+                overwrite=overwrite, use_empirical_line=use_empirical_line
+            )
+            logger.info("Inversion complete.")
+    logger.info("Workflow complete!")
+
+
+##################################################
+def do_inverse(isofit_inv: dict,
+               radfile: pathlib.Path,
+               est_refl_file: pathlib.Path,
+               est_state_file: pathlib.Path,
+               atm_coef_file: pathlib.Path,
+               post_unc_file: pathlib.Path,
+               overwrite: bool,
+               use_empirical_line: bool):
+    if use_empirical_line:
+        # Segment first, then run on segmented file
+        SEGMENTATION_SIZE = 40
+        CHUNKSIZE = 256
+        lbl_working_path = radfile.parent / str(radfile).replace("toa-radiance", "segmentation")
+        rdn_subs_path = radfile.with_suffix("-subs")
+        rfl_subs_path = est_refl_file.with_suffix("-subs")
+        state_subs_path = est_state_file.with_suffix("-subs")
+        atm_subs_path = atm_coef_file.with_suffix("-subs")
+        unc_subs_path = post_unc_file.with_suffix("-subs")
+        isofit_inv["input"]["measured_radiance_file"] = str(rdn_subs_path)
+        isofit_inv["output"] = {
+            "estimated_reflectance_file":  str(rfl_subs_path),
+            "estimated_state_file":  str(state_subs_path),
+            "atmospheric_coefficients_file":  str(atm_subs_path),
+            "posterior_uncertainty_file": str(unc_subs_path)
+        }
+        if not overwrite and lbl_working_path.exists() and rdn_subs_path.exists():
+            logger.info("Skipping segmentation and extraction because files exist.")
+        else:
+            logger.info("Fixing any radiance values slightly less than zero...")
+            rad_img = sp.open_image(str(radfile) + ".hdr")
+            rad_m = rad_img.open_memmap(writable=True)
+            nearzero = np.logical_and(rad_m < 0, rad_m > -2)
+            rad_m[nearzero] = 0.0001
+            del rad_m
+            del rad_img
+            logger.info("Segmenting...")
+            segment(spectra=(str(radfile), str(lbl_working_path)),
+                    flag=-9999, npca=5, segsize=SEGMENTATION_SIZE, nchunk=CHUNKSIZE)
+            logger.info("Extracting...")
+            extractions(inputfile=str(radfile), labels=str(lbl_working_path),
+                        output=str(rdn_subs_path), chunksize=CHUNKSIZE, flag=-9999)
+
+    else:
+        # Run Isofit directly
+        isofit_inv["input"]["measured_radiance_file"] = str(radfile)
+        isofit_inv["output"] = {
+            "estimated_reflectance_file": str(est_refl_file),
+            "estimated_state_file": str(est_state_file),
+            "atmospheric_coefficients_file": str(atm_coef_file),
+            "posterior_uncertainty_file": str(post_unc_file)
+        }
+
+    if not overwrite and pathlib.Path(isofit_inv["output"]["estimated_reflectance_file"]).exists():
+        logger.info("Skipping inversion because output file exists.")
+    else:
+        invfile = radfile.parent / (str(radfile).replace("toa-radiance", "inverse") + ".json")
+        json.dump(isofit_inv, open(invfile, "w"), indent=2)
+        Isofit(invfile).run()
+
+    if use_empirical_line:
+        if not overwrite and est_refl_file.exists():
+            logger.info("Skipping empirical line because output exists.")
+        else:
+            logger.info("Applying empirical line...")
+            empirical_line(reference_radiance_file=str(rdn_subs_path),
+                           reference_reflectance_file=str(rfl_subs_path),
+                           reference_uncertainty_file=str(unc_subs_path),
+                           reference_locations_file=None,
+                           segmentation_file=str(lbl_working_path),
+                           input_radiance_file=str(radfile),
+                           input_locations_file=None,
+                           output_reflectance_file=str(est_refl_file),
+                           output_uncertainty_file=str(post_unc_file),
+                           isofit_config=str(invfile))
 
 def mkabs(path):
     """Make a path absolute."""
     path2 = pathlib.Path(path)
     return path2.expanduser().resolve()
+
+
+def sample_calibration_uncertainty(input_file: pathlib.Path,
+                                   output_file: pathlib.Path,
+                                   cov_l: np.ndarray,
+                                   cov_wl: np.ndarray,
+                                   rad_wl: np.ndarray,
+                                   bias_scale=1.0):
+    input_file_hdr = str(input_file) + ".hdr"
+    output_file_hdr = str(output_file) + ".hdr"
+    shutil.copy(input_file, output_file)
+    shutil.copy(input_file_hdr, output_file_hdr)
+
+    img = sp.open_image(str(output_file_hdr))
+    img_m = img.open_memmap(writable=True)
+
+    # Here, we assume that the calibration bias is constant across the entire
+    # image (i.e., the same bias is added to all pixels).
+    z = np.random.normal(size=cov_l.shape[0], scale=bias_scale)
+    Az = 1.0 + cov_l @ z
+    # Resample the added noise vector to match the wavelengths of the target
+    # image.
+    Az_resampled = interp1d(cov_wl, Az, fill_value="extrapolate")(rad_wl)
+    img_m *= Az_resampled
+    return output_file

--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -5,15 +5,17 @@
 import copy
 import pathlib
 import json
+import logging
 
 import numpy as np
 from scipy.io import loadmat
 
 from isofit.core.isofit import Isofit
 
+logger = logging.getLogger(__name__)
 
 def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
-                  libradtran_template_file,
+                  rtm_template_file,
                   lutdir, outdir,
                   surface_file="./data/prior.mat",
                   noisefile=None, snr=300,

--- a/examples/py-hypertrace/summarize.py
+++ b/examples/py-hypertrace/summarize.py
@@ -39,7 +39,10 @@ def parse_dir(ddir):
         if match is not None:
             match = match.group(1)
         grps[key] = [match]
-    for key in ["szen", "ozen", "saz", "oaz", "snr", "aod", "h2o"]:
+    for key in ["szen", "ozen", "zen",
+                "saz", "oaz", "az",
+                "time", "elev",
+                "snr", "aod", "h2o"]:
         pat = f".*{key}_([0-9.]+)" + r"(__|/|\Z)"
         match = re.match(pat, str(ddir))
         if match is not None:

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -168,14 +168,13 @@ class Isofit:
                     io.write_spectrum(row, col, self.states, meas,
                                       geom, flush_immediately=True)
                 except ValueError as err:
-                    logging.error(err)
                     logging.info(
                         """
-                        Encountered the following ValueError in row %d and col %d:
-                        %s.
+                        Encountered the following ValueError in row %d and col %d.
                         Results for this pixel will be all zeros.
-                        """, row, col, err
+                        """, row, col
                     )
+                    logging.error(err)
                 if (index - index_start) % 100 == 0:
                     logging.info(
                         'Core at start index %d completed inversion %d/%d',


### PR DESCRIPTION
- Adds support for the sRTMnet MODTRAN emulator to Hypertrace. This is now treated as the default model, though LibRadtran is still supported.
- Adds support for the constellation calibration uncertainty analysis.
- Add a GitHub Action CI test for sRTMnet. Also, fix the old LibRadtran test.
- Update the README to reflect the new default.