### PR TITLE
null extractions

### DIFF
--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -117,6 +117,8 @@ def extractions(inputfile, labels, output, chunksize, flag, n_cores: int = 1, ra
     lbl_img = envi.open(lbl_file+'.hdr', lbl_file)
     labels = lbl_img.read_band(0)
     un_labels = np.unique(labels).tolist()
+    if 0 not in un_labels:
+        un_labels.insert(0,0)
     nout = len(un_labels)
 
 


### PR DESCRIPTION
This simple PR forces 0 to exist in the extractions utility, even if there are no 0's (nodata ID's) in the segmentation file.  Useful for applying the empirical line in map-space, even if derived in raw-space.  Also just a good safety precaution.