### PR TITLE
Hypertrace forward runs should not interpolate on the LUT

### DIFF
--- a/.github/workflows/py-hypertrace.yml
+++ b/.github/workflows/py-hypertrace.yml
@@ -30,10 +30,10 @@ jobs:
     - name: Download and compile 6Sv
       run: |
         cd examples/py-hypertrace
-        wget -nv https://github.com/ashiklom/isofit/releases/download/6sv-mirror/6sV-2.1.tar
-        mkdir -p 6sV-2.1
-        tar -xf 6sV-2.1.tar --directory 6sV-2.1
-        cd 6sV-2.1
+        wget -nv https://github.com/ashiklom/isofit/releases/download/6sv-mirror/6sv-2.1.tar
+        mkdir -p 6sv-2.1
+        tar -xf 6sv-2.1.tar --directory 6sv-2.1
+        cd 6sv-2.1
         # Necessary for compilation to work with recent GCC versions
         sed -i Makefile -e 's/FFLAGS.*/& -std=legacy/'
         make

--- a/.github/workflows/py-hypertrace.yml
+++ b/.github/workflows/py-hypertrace.yml
@@ -56,8 +56,8 @@ jobs:
       run: |
         cd examples/py-hypertrace
         # Modify the workflow file for GitHub actions
-        python workflow.py configs/example-srtmnet.json
-        python summarize.py configs/example-srtmnet.json
+        python workflow.py configs/example-srtmnet-ci.json
+        python summarize.py configs/example-srtmnet-ci.json
 
     - name: Upload summary from CI workflow
       uses: actions/upload-artifact@v2

--- a/examples/py-hypertrace/README.md
+++ b/examples/py-hypertrace/README.md
@@ -11,8 +11,8 @@ NOTE: All of these instructions assume you are operating from inside this direct
 
 1. Install Isofit, following the standard instructions.
 
-2. Create a folder called `6Sv-2.1`.
-Download and compile the 6Sv atmospheric radiative transfer model inside this directory.
+2. Create a folder called `6sv-2.1`.
+Download and compile the 6SV atmospheric radiative transfer model inside this directory.
 The default source code location is here (http://6s.ltdri.org/pages/downloads.html),
 but if that link doesn't work, you can download a mirrored version from here (https://github.com/ashiklom/isofit/releases/tag/6sv-mirror).
 Once downloaded, compile the code by calling `make` inside the source code directory.
@@ -31,7 +31,7 @@ A script has been provided that will accomplish this for you:
 ```
 
 5. At this point, confirm that, inside the `examples/py-hypertrace` directory, you have
-a `6Sv-2.1` directory containing the `sixv2.1` binary executable;
+a `6sv-2.1` directory containing the `sixv2.1` binary executable;
 a `sRTMnet_v100` directory containing a subdirectory also called `sRTMnet_v100` and a file `sRTMnet_v100_aux.npz`;
 and
 a `hypertrace-data` directory containing subdirectories including `noise`, `priors`, `wavelengths`, and `reflectance`.

--- a/examples/py-hypertrace/configs/example-srtmnet-ci.json
+++ b/examples/py-hypertrace/configs/example-srtmnet-ci.json
@@ -1,0 +1,65 @@
+{
+    "wavelength_file": "./hypertrace-data/wavelengths/aviris-ng.txt",
+    "reflectance_file": "./hypertrace-data/reflectance/reference/reference_reflectance",
+    "rtm_template_file": "/dev/null",
+    "lutdir": "./luts/sRTMnet",
+    "outdir": "./output/example-srtmnet",
+    "isofit": {
+        "forward_model": {
+            "instrument": {
+                "SNR": 300,
+                "integrations": 1
+            },
+            "surface": {
+                "surface_category": "multicomponent_surface"
+            },
+            "radiative_transfer": {
+                "lut_grid": {
+                    "AOT550": [0.01, 0.505, 1.0],
+                    "H2OSTR": [0.1, 1.325, 3.775]
+                },
+                "statevector": {
+                    "AOT550": {
+                        "bounds": [0.01, 1.0],
+                        "scale": 0.01,
+                        "prior_mean": 0.05,
+                        "prior_sigma": 0.2,
+                        "init": 0.05
+                    },
+                    "H2OSTR": {
+                        "bounds": [0.1, 5.0],
+                        "scale": 0.01,
+                        "prior_mean": 1.75,
+                        "prior_sigma": 1.0,
+                        "init": 1.75
+                    }
+                },
+                "unknowns": {"H2O_ABSCO": 0.01},
+                "radiative_transfer_engines": {
+                    "vswir": {
+                        "engine_name": "sRTMnet",
+                        "engine_base_dir": "./6sv-2.1",
+                        "aerosol_template_path": "../../data/aerosol_template.json",
+                        "earth_sun_distance_file": "../../data/earth_sun_distance.txt",
+                        "irradiance_file": "../../examples/20151026_SantaMonica/data/prism_optimized_irr.dat",
+                        "emulator_aux_file": "./sRTMnet_v100/sRTMnet_v100_aux.npz",
+                        "emulator_file": "./sRTMnet_v100/sRTMnet_v100",
+                        "statevector_names": ["H2OSTR", "AOT550"]
+                    }
+                }
+            }
+        },
+        "implementation": {
+            "inversion": {
+                "windows": [[400, 1300], [1450, 1780], [1950, 2450]]
+            }
+        }
+    },
+    "hypertrace": {
+        "atm_aod_h2o": [["ATM_MIDLAT_SUMMER", 0.2, 1.0]],
+        "observer_zenith": [0],
+        "inversion_mode": ["inversion"],
+        "noisefile": ["./hypertrace-data/noise/noise_coeff_sbg_cbe0.txt"],
+        "surface_file": ["./hypertrace-data/priors/aviris-ng/surface_EMIT.mat"]
+    }
+}

--- a/examples/py-hypertrace/configs/example-srtmnet.json
+++ b/examples/py-hypertrace/configs/example-srtmnet.json
@@ -38,7 +38,7 @@
                 "radiative_transfer_engines": {
                     "vswir": {
                         "engine_name": "sRTMnet",
-                        "engine_base_dir": "./6sV-2.1",
+                        "engine_base_dir": "./6sv-2.1",
                         "aerosol_template_path": "../../data/aerosol_template.json",
                         "earth_sun_distance_file": "../../data/earth_sun_distance.txt",
                         "irradiance_file": "../../examples/20151026_SantaMonica/data/prism_optimized_irr.dat",

--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -290,6 +290,17 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
     fwd_state["AOT550"]["init"] = aod
     fwd_state["H2OSTR"]["init"] = h2o
 
+    # Also set the LUT grid to only target state. We don't want to interpolate
+    # over the LUT for our forward simulations!
+    fwd_lut = isofit_fwd["forward_model"]["radiative_transfer"]["lut_grid"]
+    fwd_lut["AOT550"] = [aod]
+    fwd_lut["H2OSTR"] = [h2o]
+    # Also have to create a one-off LUT directory for the forward run, to avoid
+    # using an (incorrect) previously cached one.
+    fwd_lutdir = outdir2 / "fwd_lut"
+    fwd_lutdir.mkdir(parents=True, exist_ok=True)
+    isofit_fwd["forward_model"]["radiative_transfer"]["radiative_transfer_engines"]["vswir"]["lut_path"] = str(fwd_lutdir)
+
     if radfile.exists() and not overwrite:
         logger.info("Skipping forward simulation because file exists.")
     else:

--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -299,7 +299,12 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
     # using an (incorrect) previously cached one.
     fwd_lutdir = outdir2 / "fwd_lut"
     fwd_lutdir.mkdir(parents=True, exist_ok=True)
-    isofit_fwd["forward_model"]["radiative_transfer"]["radiative_transfer_engines"]["vswir"]["lut_path"] = str(fwd_lutdir)
+    fwd_vswir = (isofit_fwd["forward_model"]
+                 ["radiative_transfer"]
+                 ["radiative_transfer_engines"]
+                 ["vswir"])
+    fwd_vswir["lut_path"] = str(fwd_lutdir)
+    fwd_vswir["interpolator_base_path"] = str(fwd_lutdir)
 
     if radfile.exists() and not overwrite:
         logger.info("Skipping forward simulation because file exists.")

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -53,10 +53,15 @@ class VectorInterpolator:
 
     def __init__(self, grid_input: List[List[float]], data_input: np.array, lut_interp_types: List[str]):
         self.lut_interp_types = lut_interp_types
+        self.single_point_data = None
 
         # Lists and arrays are mutable, so copy first
         grid = grid_input.copy()
         data = data_input.copy()
+
+        # Check if we are using a single grid point. If so, store the grid input.
+        if np.prod(list(map(len, grid))) == 1:
+            self.single_point_data = data
 
         # expand grid dimensionality as needed
         [radian_locations] = np.where(self.lut_interp_types == 'd')
@@ -123,6 +128,11 @@ class VectorInterpolator:
                                            bounds_error=False, fill_value=None)
 
     def __call__(self, points):
+
+        # If we only have one point, we can't do any interpolation, so just
+        # return the original data.
+        if self.single_point_data is not None:
+            return self.single_point_data
 
         x = np.zeros((self.n, len(points) + 1 +
                       np.sum(self.lut_interp_types != 'n')))

--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -74,6 +74,7 @@ class TabularRT:
 
         self.auto_rebuild = full_config.implementation.rte_auto_rebuild
         self.configure_and_exit = full_config.implementation.rte_configure_and_exit
+        self.implementation_mode = full_config.implementation.mode
 
         # We use a sorted dictionary here so that filenames for lookup
         # table (LUT) grid points are always constructed the same way, with
@@ -130,9 +131,10 @@ class TabularRT:
         for key, grid_values in self.lut_grid_config.items():
 
             # do some quick checks on the values
-            if len(grid_values) == 1:
-                err = 'Only 1 value in LUT grid {}. ' +\
-                    '1-d LUT grids cannot be interpreted.'.format(key)
+            # For forward (simulation) mode, 1-dimensional LUT grids are OK!
+            if len(grid_values) == 1 and not self.implementation_mode == "simulation":
+                err = 'Only 1 value in LUT grid {}. '.format(key) +\
+                    '1-d LUT grids cannot be interpreted.'
                 raise ValueError(err)
             if grid_values != sorted(grid_values):
                 logging.error('Lookup table grid needs ascending order')


### PR DESCRIPTION
Per the conversation between me, @pgbrodrick , and @serbinsh earlier, this ensures that forward simulations in Hypertrace do not use any interpolation, but instead pass the AOD and H2O directly to the atmospheric RTM. This allows us to explore the impacts of denser vs. coarser LUTs, and is generally the right thing to do.

Note that currently, this will fail with the following error:

```
ValueError: Only 1 value in LUT grid {}. 1-d LUT grids cannot be interpreted.
```

The easiest workaround for me is to just add another point to the LUT. That wastes a bit of computation (forces a minimum of 4 (2? Can I use a 2x1 grid LUT?) RTM evaluations for every forward model run), but doesn't require upstream changes to Isofit itself. Not the end of the world, and should mostly only impact CPU but not runtime (because most computers have at least 4 cores these days), but might be worth at least considering alternatives. One possibility is to implement a slightly hidden flag to _force_ allow a 1-dimensional LUT grid (e.g., `allow_1D_lut=True`).

Thoughts?