### PR TITLE
Various patch fixes

### DIFF
--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -45,6 +45,10 @@ class ImplementationConfig(BaseConfigSection):
         self.n_cores = None
         """int: number of cores to use."""
 
+        self._task_inflation_factor_type = int
+        self.task_inflation_factor = 10
+        """int: Submit task_inflation_factor*n_cores number of tasks."""
+
         self._ip_head_type = str
         self.ip_head = None
         """str: Ray - parameter.  IP-head (for multi-node runs)."""

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -440,7 +440,7 @@ class IO:
         if len(states) == 0:
 
             # Write a bad data flag
-            atm_bad = np.zeros(len(self.fm.n_chan)*5) * -9999.0
+            atm_bad = np.zeros(len(self.fm.instrument.n_chan)*5) * -9999.0
             state_bad = np.zeros(len(self.fm.statevec)) * -9999.0
             data_bad = np.zeros(self.fm.instrument.n_chan) * -9999.0
             to_write = {

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -27,6 +27,7 @@ import time
 import multiprocessing
 import numpy as np
 import ray
+import ray.services
 
 from isofit.core.forward import ForwardModel
 from isofit.inversion.inverse import Inversion

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -196,15 +196,21 @@ class Isofit:
         self.io = None
 
         if self.config.implementation.n_cores is None:
-            n_workers = min(multiprocessing.cpu_count(), n_iter)
+            n_workers = multiprocessing.cpu_count()
         else:
-            n_workers = min(self.config.implementation.n_cores, n_iter)
+            n_workers = self.config.implementation.n_cores
+
+        # Inflate the number of tasks to run, to prevent 1 or two cores holding up everything
+        n_tasks = min(n_workers * self.config.implementation.task_inflation_factor, n_iter)
+
+        # Max out the number of workers based on the number of tasks
+        n_workers = min(n_workers, n_tasks)
 
         start_time = time.time()
         logging.info('Beginning inversions using {} cores'.format(n_workers))
 
         # Divide up spectra to run into chunks
-        index_sets = np.linspace(0, n_iter, num=n_workers+1, dtype=int)
+        index_sets = np.linspace(0, n_iter, num=n_tasks+1, dtype=int)
 
         # Run spectra, in either serial or parallel depending on n_workers
         results = ray.get([self._run_set_of_spectra.remote(self, index_sets[l], index_sets[l + 1])

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -200,17 +200,14 @@ class Isofit:
         else:
             n_workers = self.config.implementation.n_cores
 
-        # Inflate the number of tasks to run, to prevent 1 or two cores holding up everything
-        n_tasks = min(n_workers * self.config.implementation.task_inflation_factor, n_iter)
-
         # Max out the number of workers based on the number of tasks
-        n_workers = min(n_workers, n_tasks)
+        n_workers = min(n_workers, n_iter)
 
         start_time = time.time()
         logging.info('Beginning inversions using {} cores'.format(n_workers))
 
         # Divide up spectra to run into chunks
-        index_sets = np.linspace(0, n_iter, num=n_tasks+1, dtype=int)
+        index_sets = np.linspace(0, n_iter, num=n_workers+1, dtype=int)
 
         # Run spectra, in either serial or parallel depending on n_workers
         results = ray.get([self._run_set_of_spectra.remote(self, index_sets[l], index_sets[l + 1])

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -140,7 +140,7 @@ def main():
             err_str = f'Input argument {infile_name} give as: {infile}.  File not found on system.'
             raise ValueError('argument ' + err_str)
         if infile_name != 'input_radiance':
-            input_dataset = gdal.Open(infile_name, gdal.GA_ReadOnly)
+            input_dataset = gdal.Open(infile, gdal.GA_ReadOnly)
             input_size = (input_dataset.RasterXSize, input_dataset.RasterYSize)
             if not (input_size[0] == rdn_size[0] and input_size[1] == rdn_size[1]):
                 err_str = f'Input file: {infile_name} size is {input_size}, which does not match input_radiance size: {rdn_size}'

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -144,7 +144,7 @@ def main():
             input_size = (input_dataset.RasterXSize, input_dataset.RasterYSize)
             if not (input_size[0] == rdn_size[0] and input_size[1] == rdn_size[1]):
                 err_str = f'Input file: {infile_name} size is {input_size}, which does not match input_radiance size: {rdn_size}'
-                ValueError(err_str)
+                raise ValueError(err_str)
 
 
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -140,7 +140,7 @@ def main():
             err_str = f'Input argument {infile_name} give as: {infile}.  File not found on system.'
             raise ValueError('argument ' + err_str)
         if infile_name != 'input_radiance':
-            input_dataset = gdal.Open(args.infile, gdal.GA_ReadOnly)
+            input_dataset = gdal.Open(infile_name, gdal.GA_ReadOnly)
             input_size = (input_dataset.RasterXSize, input_dataset.RasterYSize)
             if not (input_size[0] == rdn_size[0] and input_size[1] == rdn_size[1]):
                 err_str = f'Input file: {infile_name} size is {input_size}, which does not match input_radiance size: {rdn_size}'

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -667,7 +667,7 @@ class LUTConfig:
 
             # Protect memory against huge images
             if spatial_data.shape[0] > 1e6:
-                 use = np.linspace(0,spatial_data.shape[0]-1,1e6,dtype=int)
+                 use = np.linspace(0,spatial_data.shape[0]-1,int(1e6),dtype=int)
                  spatial_data = spatial_data[use,:]
 
             gmm.fit(spatial_data)

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -361,7 +361,7 @@ class Pathnames():
             self.fid = split(args.input_radiance)[-1][:21]
         elif args.sensor == 'emit':
             self.fid = split(args.input_radiance)[-1][:19]
-        elif args.sensor[3:] == 'NA-':
+        elif args.sensor[:3] == 'NA-':
             self.fid = os.path.splitext(os.path.basename(args.input_radiance))[0]
 
         # Names from inputs

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -131,6 +131,23 @@ def main():
     else:
         logging.basicConfig(format='%(message)s', level=args.logging_level, filename=args.log_file)
 
+    rdn_dataset = gdal.Open(args.input_radiance, gdal.GA_ReadOnly)
+    rdn_size = (rdn_dataset.RasterXSize, rdn_dataset.RasterYSize)
+    del rdn_dataset
+    for infile_name, infile in zip(['input_radiance','input_loc','input_obs'],
+                                   [args.input_radiance, args.input_loc, args.input_obs]):
+        if os.path.isfile(infile) is False:
+            err_str = f'Input argument {infile_name} give as: {infile}.  File not found on system.'
+            raise ValueError('argument ' + err_str)
+        if infile_name != 'input_radiance':
+            input_dataset = gdal.Open(args.infile, gdal.GA_ReadOnly)
+            input_size = (input_dataset.RasterXSize, input_dataset.RasterYSize)
+            if not (input_size[0] == rdn_size[0] and input_size[1] == rdn_size[1]):
+                err_str = f'Input file: {infile_name} size is {input_size}, which does not match input_radiance size: {rdn_size}'
+                ValueError(err_str)
+
+
+
     lut_params = LUTConfig(args.lut_config_file)
     if args.emulator_base is not None:
         lut_params.aot_550_range = lut_params.aerosol_2_range

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -29,6 +29,7 @@ import matplotlib
 import pylab as plt
 from isofit.configs import configs
 import ray
+import ray.services
 import atexit
 
 plt.switch_backend("Agg")

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -21,6 +21,7 @@
 import numpy as np
 from spectral.io import envi
 import ray
+import ray.services
 import logging
 import atexit
 

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -23,6 +23,7 @@ from spectral.io import envi
 from skimage.segmentation import slic
 import numpy as np
 import ray
+import ray.services
 import atexit
 import logging
 


### PR DESCRIPTION
- Handles #215
- Fixes IO bug (instrument object reference)
- Updates ray imports to facilitate local_mode (note, in future this will need to be switched to ray.utils to keep up with ray 2.+)
- Adds checks inside apply_oe for file sizes of radiance, loc, and obs (since I keep mixing ortho'd and non-ortho'd files)
- Adds a 'task inflation factor', so that more than n_cores jobs are launched, hopefully preventing individual cores from being handled the bulk for the work.  Defaults to 10x
- Puts an int() safety cast on 1e6 factor inside apply_oe