### PR TITLE
High orbit emulator

### DIFF
--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -265,7 +265,7 @@ class IO:
 
         self.config = config
 
-        self.bbl = '[]'
+        self.bbl = '{}'
         self.radiance_correction = None
         self.meas_wl = forward.instrument.wl_init
         self.meas_fwhm = forward.instrument.fwhm_init

--- a/isofit/radiative_transfer/six_s.py
+++ b/isofit/radiative_transfer/six_s.py
@@ -90,7 +90,7 @@ class SixSRT(TabularRT):
                        'day':   engine_config.day,
                        'month': engine_config.month,
                        'elev':  engine_config.elev,
-                       'alt':   engine_config.alt,
+                       'alt':   min(engine_config.alt, 99),
                        'atm_file': None,
                        'abscf_data_directory': None,
                        'wlinf': self.sixs_grid_init[0]/1000.0,  # convert to nm
@@ -154,7 +154,7 @@ class SixSRT(TabularRT):
         if 'GNDALT' in vals:
             vals['elev'] = vals['GNDALT']
         if 'H1ALT' in vals:
-            vals['alt'] = vals['H1ALT']
+            vals['alt'] = min(vals['H1ALT'], 99)
         if 'TRUEAZ' in vals:
             vals['viewaz'] = vals['TRUEAZ']
         if 'OBSZEN' in vals:
@@ -294,7 +294,7 @@ class SixSRT(TabularRT):
             elif name == "elev":
                 point[point_ind] = geom.surface_elevation_km
             elif name == "alt":
-                point[point_ind] = geom.observer_altitude_km
+                point[point_ind] = min(geom.observer_altitude_km, 99)
             elif name == "viewzen":
                 point[point_ind] = geom.observer_zenith
             elif name == "viewaz":

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -241,6 +241,11 @@ def main(rawargs=None):
     logging.info(f'To-sensor Azimuth (deg): {mean_to_sensor_azimuth}')
     logging.info(f'Altitude (km): {mean_altitude_km}')
 
+    if args.emulator_base is not None and mean_altitude_km > 99:
+        logging.info('Adjusting altitude to 99 km for integration with 6S, because emulator is chosen.')
+        mean_altitude_km = 99
+
+
     # We will use the model discrepancy with covariance OR uncorrelated 
     # Calibration error, but not both.
     if args.model_discrepancy_path is not None:


### PR DESCRIPTION
Adjust emulator to work in high orbits.  Builds off suggestions from #244, but handles the possibility of altitude bing in the LUT.  Uses the 'cap-at-99' style approach.