### PR TITLE
make envi header references safe and global

### DIFF
--- a/examples/py-hypertrace/hypertrace.py
+++ b/examples/py-hypertrace/hypertrace.py
@@ -16,6 +16,7 @@ from scipy.interpolate import interp1d
 from isofit.core.isofit import Isofit
 from isofit.utils import empirical_line, segment, extractions
 from isofit.utils.apply_oe import write_modtran_template
+from isofit.core.common import envi_header
 
 logger = logging.getLogger(__name__)
 
@@ -345,7 +346,7 @@ def do_hypertrace(isofit_config, wavelength_file, reflectance_file,
         cov = calmat["Covariance"]
         cov_l = np.linalg.cholesky(cov)
         cov_wl = np.squeeze(calmat["wavelengths"])
-        rad_img = sp.open_image(str(radfile) + ".hdr")
+        rad_img = sp.open_image(envi_header(str(radfile)))
         rad_wl = rad_img.bands.centers
         del rad_img
         for ical in range(n_calibration_draws):
@@ -414,7 +415,7 @@ def do_inverse(isofit_inv: dict,
             logger.info("Skipping segmentation and extraction because files exist.")
         else:
             logger.info("Fixing any radiance values slightly less than zero...")
-            rad_img = sp.open_image(str(radfile) + ".hdr")
+            rad_img = sp.open_image(envi_header(str(radfile)))
             rad_m = rad_img.open_memmap(writable=True)
             nearzero = np.logical_and(rad_m < 0, rad_m > -2)
             rad_m[nearzero] = 0.0001
@@ -472,8 +473,8 @@ def sample_calibration_uncertainty(input_file: pathlib.Path,
                                    cov_wl: np.ndarray,
                                    rad_wl: np.ndarray,
                                    bias_scale=1.0):
-    input_file_hdr = str(input_file) + ".hdr"
-    output_file_hdr = str(output_file) + ".hdr"
+    input_file_hdr = envi_header(str(input_file))
+    output_file_hdr = envi_header(str(output_file))
     shutil.copy(input_file, output_file)
     shutil.copy(input_file_hdr, output_file_hdr)
 

--- a/examples/py-hypertrace/summarize.py
+++ b/examples/py-hypertrace/summarize.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import spectral as sp
 import matplotlib.pyplot as plt
+from isofit.core.common import envi_header
 
 assert len(sys.argv) > 1, "Please specify a JSON config file."
 
@@ -25,7 +26,7 @@ reflfiles = list(outdir.glob("**/estimated-reflectance"))
 assert len(reflfiles) > 0, f"No reflectance files found in directory {outdir}"
 
 true_refl_file = Path(config["reflectance_file"]).expanduser()
-true_reflectance = sp.open_image(str(true_refl_file) + ".hdr")
+true_reflectance = sp.open_image(envi_header(str(true_refl_file)))
 true_waves = np.array(true_reflectance.metadata["wavelength"], dtype=float)
 true_refl_m = true_reflectance.open_memmap()
 
@@ -72,7 +73,7 @@ info["rel_bias"] = np.nan
 for i in range(info.shape[0]):
     ddir = Path(info["directory"][i])
     est_refl_file = ddir / "estimated-reflectance"
-    est_refl = sp.open_image(str(est_refl_file) + ".hdr")
+    est_refl = sp.open_image(envi_header(str(est_refl_file)))
     est_refl_waves = np.array(est_refl.metadata["wavelength"], dtype=float)
     est_refl_m = est_refl.open_memmap()
     if est_refl_m.shape != true_refl_m.shape:

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -517,8 +517,6 @@ def spectral_response_function(response_range: np.array, mu: float, sigma: float
     return srf
 
 
-
-
 def combos(inds: List[List[float]]) -> np.array:
     """Return all combinations of indices in a list of index sublists.
     For example, the call::
@@ -570,3 +568,25 @@ def conditional_gaussian(mu: np.array, C: np.array, window: np.array, remain: np
     conditional_cov = C22 - C21 @ Cinv @ C12
     return conditional_mean, conditional_cov
 
+def envi_header(inputpath):
+    """
+    Convert a envi binary/header path to a header, handling extensions
+    Args:
+        inputpath: path to envi binary file
+    Returns:
+        str: the header file associated with the input reference.
+
+    """
+    if os.path.splitext(inputpath)[-1] == '.img' or os.path.splitext(inputpath)[-1] == '.dat' or os.path.splitext(inputpath)[-1] == '.raw':
+        # headers could be at either filename.img.hdr or filename.hdr.  Check both, return the one that exists if it
+        # does, if not return the latter (new file creation presumed).
+        hdrfile = os.path.splitext(inputpath)[0] + '.hdr'
+        if os.path.isfile(hdrfile):
+            return hdrfile
+        elif os.path.isfile(inputpath + '.hdr'):
+            return inputpath + '.hdr'
+        return hdrfile
+    elif os.path.splitext(inputpath)[-1] == '.hdr':
+        return inputpath
+    else:
+        return inputpath + '.hdr'

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -22,7 +22,6 @@ import os
 import numpy as np
 import scipy.io
 import scipy.interpolate
-import pylab as plt
 from spectral.io import envi
 import logging
 from collections import OrderedDict
@@ -34,7 +33,7 @@ from .geometry import Geometry
 from isofit.configs import Config
 from isofit.core.forward import ForwardModel
 from typing import List
-import time
+from isofit.core.common import envi_header
 
 
 ### Variables ###
@@ -120,12 +119,12 @@ class SpectrumFile:
             if not self.write:
 
                 # If we are an input file, the header must preexist.
-                if not os.path.exists(self.fname+'.hdr'):
-                    logging.error('Could not find %s' % (self.fname+'.hdr'))
-                    raise IOError('Could not find %s' % (self.fname+'.hdr'))
+                if not os.path.exists(envi_header(self.fname)):
+                    logging.error('Could not find %s' % (envi_header(self.fname)))
+                    raise IOError('Could not find %s' % (envi_header(self.fname)))
 
                 # open file and copy metadata
-                self.file = envi.open(self.fname + '.hdr', fname)
+                self.file = envi.open(envi_header(self.fname), fname)
                 self.meta = self.file.metadata.copy()
 
                 self.n_rows = int(self.meta['lines'])
@@ -166,11 +165,11 @@ class SpectrumFile:
                         logging.error('Must specify %s' % (k))
                         raise IOError('Must specify %s' % (k))
 
-                if os.path.isfile(fname+'.hdr') is False:
-                    self.file = envi.create_image(fname+'.hdr', meta, ext='',
+                if os.path.isfile(envi_header(fname)) is False:
+                    self.file = envi.create_image(envi_header(fname), meta, ext='',
                                                   force=True)
                 else:
-                    self.file = envi.open(fname+'.hdr')
+                    self.file = envi.open(envi_header(fname))
 
             self.open_map_with_retries()
 
@@ -244,7 +243,7 @@ class SpectrumFile:
                     self.memmap[row, valid, :] = frame[valid, :]
             self.frames = OrderedDict()
             del self.file
-            self.file = envi.open(self.fname+'.hdr', self.fname)
+            self.file = envi.open(envi_header(self.fname), self.fname)
             self.open_map_with_retries()
 
 class InputData:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -1411,7 +1411,7 @@ def envi_header(inputpath):
 
     """
     if os.path.splitext()[-1] == '.img' or os.path.splitext()[-1] == '.dat':
-        return os.path.splitext()[-1] + '.hdr'
+        return os.path.splitext()[0] + '.hdr'
     elif os.path.splitext()[-1] == '.hdr':
         return inputpath
     else:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -20,6 +20,7 @@ from typing import List
 
 from isofit.utils import segment, extractions, empirical_line
 from isofit.core import isofit, common
+from isofit.core.common import envi_header
 
 EPS = 1e-6
 CHUNKSIZE = 256
@@ -1400,23 +1401,6 @@ def write_modtran_template(atmosphere_type: str, fid: str, altitude_km: float, d
     # write modtran_template
     with open(output_file, 'w') as fout:
         fout.write(json.dumps(h2o_template, cls=SerialEncoder, indent=4, sort_keys=True))
-
-def envi_header(inputpath):
-    """
-    Convert a envi binary/header path to a header, handling extensions
-    Args:
-        inputpath: path to envi binary file
-    Returns:
-        str
-
-    """
-    if os.path.splitext()[-1] == '.img' or os.path.splitext()[-1] == '.dat':
-        return os.path.splitext()[0] + '.hdr'
-    elif os.path.splitext()[-1] == '.hdr':
-        return inputpath
-    else:
-        return inputpath + '.hdr'
-
 
 if __name__ == "__main__":
     main()

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -32,6 +32,7 @@ from isofit.configs import configs
 import ray
 import ray.services
 import atexit
+from isofit.core.common import envi_header
 
 plt.switch_backend("Agg")
 
@@ -70,26 +71,26 @@ def _run_chunk(start_line: int, stop_line: int, reference_radiance_file: str, re
     logging.basicConfig(format='%(message)s', level=loglevel, filename=logfile)
 
     # Load reference images
-    reference_radiance_img = envi.open(reference_radiance_file + '.hdr', reference_radiance_file)
-    reference_reflectance_img = envi.open(reference_reflectance_file + '.hdr', reference_reflectance_file)
-    reference_uncertainty_img = envi.open(reference_uncertainty_file + '.hdr', reference_uncertainty_file)
-    reference_locations_img = envi.open(reference_locations_file + '.hdr', reference_locations_file)
+    reference_radiance_img = envi.open(envi_header(reference_radiance_file), reference_radiance_file)
+    reference_reflectance_img = envi.open(envi_header(reference_reflectance_file), reference_reflectance_file)
+    reference_uncertainty_img = envi.open(envi_header(reference_uncertainty_file), reference_uncertainty_file)
+    reference_locations_img = envi.open(envi_header(reference_locations_file), reference_locations_file)
 
     n_reference_lines, n_radiance_bands, n_reference_columns = [int(reference_radiance_img.metadata[n])
                                                                 for n in ('lines', 'bands', 'samples')]
     n_reference_uncertainty_bands = int(reference_uncertainty_img.metadata['bands'])
 
     # Load input images
-    input_radiance_img = envi.open(input_radiance_file + '.hdr', input_radiance_file)
+    input_radiance_img = envi.open(envi_header(input_radiance_file), input_radiance_file)
     n_input_lines, n_input_bands, n_input_samples = [int(input_radiance_img.metadata[n])
                                                      for n in ('lines', 'bands', 'samples')]
 
-    input_locations_img = envi.open(input_locations_file + '.hdr', input_locations_file)
+    input_locations_img = envi.open(envi_header(input_locations_file), input_locations_file)
     n_location_bands = int(input_locations_img.metadata['bands'])
 
     # Load output images
-    output_reflectance_img = envi.open(output_reflectance_file + '.hdr', output_reflectance_file)
-    output_uncertainty_img = envi.open(output_uncertainty_file + '.hdr', output_uncertainty_file)
+    output_reflectance_img = envi.open(envi_header(output_reflectance_file), output_reflectance_file)
+    output_uncertainty_img = envi.open(envi_header(output_uncertainty_file), output_uncertainty_file)
     n_output_reflectance_bands = int(output_reflectance_img.metadata['bands'])
     n_output_uncertainty_bands = int(output_uncertainty_img.metadata['bands'])
 
@@ -110,7 +111,7 @@ def _run_chunk(start_line: int, stop_line: int, reference_radiance_file: str, re
 
     # Load segmentation data
     if segmentation_file:
-        segmentation_img = envi.open(segmentation_file + '.hdr', segmentation_file)
+        segmentation_img = envi.open(envi_header(segmentation_file), segmentation_file)
         segmentation_img = segmentation_img.read_band(0)
     else:
         segmentation_img = None
@@ -304,39 +305,39 @@ def empirical_line(reference_radiance_file: str, reference_reflectance_file: str
 
     # Open input data to check that band formatting is correct
     # Load reference set radiance
-    reference_radiance_img = envi.open(reference_radiance_file + '.hdr', reference_radiance_file)
+    reference_radiance_img = envi.open(envi_header(reference_radiance_file), reference_radiance_file)
     n_reference_lines, n_radiance_bands, n_reference_columns = [int(reference_radiance_img.metadata[n])
                                                                 for n in ('lines', 'bands', 'samples')]
     if n_reference_columns != 1:
         raise IndexError("Reference data should be a single-column list")
 
     # Load reference set reflectance
-    reference_reflectance_img = envi.open(reference_reflectance_file + '.hdr', reference_reflectance_file)
+    reference_reflectance_img = envi.open(envi_header(reference_reflectance_file), reference_reflectance_file)
     nrefr, nbr, srefr = [int(reference_reflectance_img.metadata[n]) for n in ('lines', 'bands', 'samples')]
     if nrefr != n_reference_lines or nbr != n_radiance_bands or srefr != n_reference_columns:
         raise IndexError("Reference file dimension mismatch (reflectance)")
 
     # Load reference set uncertainty, assuming reflectance uncertainty is
     # recoreded in the first n_radiance_bands channels of data
-    reference_uncertainty_img = envi.open(reference_uncertainty_file + '.hdr', reference_uncertainty_file)
+    reference_uncertainty_img = envi.open(envi_header(reference_uncertainty_file), reference_uncertainty_file)
     nrefu, ns, srefu = [int(reference_uncertainty_img.metadata[n]) for n in ('lines', 'bands', 'samples')]
     if nrefu != n_reference_lines or ns < n_radiance_bands or srefu != n_reference_columns:
         raise IndexError("Reference file dimension mismatch (uncertainty)")
 
     # Load reference set locations
-    reference_locations_img = envi.open(reference_locations_file + '.hdr', reference_locations_file)
+    reference_locations_img = envi.open(envi_header(reference_locations_file), reference_locations_file)
     nrefl, lb, ls = [int(reference_locations_img.metadata[n]) for n in ('lines', 'bands', 'samples')]
     if nrefl != n_reference_lines or lb != 3:
         raise IndexError("Reference file dimension mismatch (locations)")
 
-    input_radiance_img = envi.open(input_radiance_file + '.hdr', input_radiance_file)
+    input_radiance_img = envi.open(envi_header(input_radiance_file), input_radiance_file)
     n_input_lines, n_input_bands, n_input_samples = [int(input_radiance_img.metadata[n])
                                                      for n in ('lines', 'bands', 'samples')]
     if n_radiance_bands != n_input_bands:
         msg = 'Number of channels mismatch: input (%i) vs. reference (%i)'
         raise IndexError(msg % (nbr, n_radiance_bands))
 
-    input_locations_img = envi.open(input_locations_file + '.hdr', input_locations_file)
+    input_locations_img = envi.open(envi_header(input_locations_file), input_locations_file)
     nll, nlb, nls = [int(input_locations_img.metadata[n])
                      for n in ('lines', 'bands', 'samples')]
     if nll != n_input_lines or nlb != 3 or nls != n_input_samples:
@@ -345,10 +346,10 @@ def empirical_line(reference_radiance_file: str, reference_reflectance_file: str
     # Create output files
     output_metadata = input_radiance_img.metadata
     output_metadata['interleave'] = 'bil'
-    output_reflectance_img = envi.create_image(output_reflectance_file + '.hdr', ext='',
+    output_reflectance_img = envi.create_image(envi_header(output_reflectance_file), ext='',
                                                metadata=output_metadata, force=True)
 
-    output_uncertainty_img = envi.create_image(output_uncertainty_file + '.hdr', ext='',
+    output_uncertainty_img = envi.create_image(envi_header(output_uncertainty_file), ext='',
                                                metadata=output_metadata, force=True)
 
     # Now cleanup inputs and outputs, we'll write dynamically above

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -25,6 +25,7 @@ import ray.services
 import logging
 import atexit
 from isofit.core.fileio import write_bil_chunk
+from isofit.core.common import envi_header
 
 @ray.remote
 def extract_chunk(lstart: int, lend: int, in_file: str, labels: np.array, flag: float, logfile=None, loglevel='INFO'):
@@ -48,7 +49,7 @@ def extract_chunk(lstart: int, lend: int, in_file: str, labels: np.array, flag: 
     logging.basicConfig(format='%(levelname)s:%(message)s', level=loglevel, filename=logfile)
     logging.info(f'{lstart}: starting')
 
-    in_img = envi.open(in_file + '.hdr')
+    in_img = envi.open(envi_header(in_file))
     img_mm = in_img.open_memmap(interleave='bip', writable=False)
 
     # Which labels will we extract? ignore zero index
@@ -118,13 +119,13 @@ def extractions(inputfile, labels, output, chunksize, flag, n_cores: int = 1, ra
     }
 
     # Open input data, get dimensions
-    in_img = envi.open(in_file+'.hdr', in_file)
+    in_img = envi.open(envi_header(in_file), in_file)
     meta = in_img.metadata
 
     nl, nb, ns = [int(meta[n]) for n in ('lines', 'bands', 'samples')]
     img_mm = in_img.open_memmap(interleave='bip', writable=False)
 
-    lbl_img = envi.open(lbl_file+'.hdr', lbl_file)
+    lbl_img = envi.open(envi_header(lbl_file), lbl_file)
     labels = lbl_img.read_band(0)
     un_labels = np.unique(labels).tolist()
     if 0 not in un_labels:
@@ -171,7 +172,7 @@ def extractions(inputfile, labels, output, chunksize, flag, n_cores: int = 1, ra
     meta["samples"] = '1'
     meta["interleave"] = "bil"
 
-    out_img = envi.create_image(out_file+'.hdr',  metadata=meta, ext='', force=True)
+    out_img = envi.create_image(envi_header(out_file),  metadata=meta, ext='', force=True)
     del out_img
     if dtm[meta['data type']] == np.float32:
         type = 'float32'

--- a/isofit/utils/instrument_model.py
+++ b/isofit/utils/instrument_model.py
@@ -24,7 +24,7 @@ import scipy
 from scipy.ndimage.filters import gaussian_filter1d
 from spectral.io import envi
 
-from isofit.core.common import expand_path, json_load_ascii
+from isofit.core.common import expand_path, json_load_ascii, envi_header
 
 
 def instrument_model(config):
@@ -49,7 +49,7 @@ def instrument_model(config):
     flatfile = expand_path(configdir, config['output_flatfield_file'])
     uniformity_thresh = float(config['uniformity_threshold'])
 
-    infile_hdr = infile + '.hdr'
+    infile_hdr = envi_header(infile)
     img = envi.open(infile_hdr, infile)
     inmm = img.open_memmap(interleave='bil', writable=False)
     X = np.array(inmm[:, :, :], dtype=np.float32)
@@ -57,7 +57,7 @@ def instrument_model(config):
 
     FF, Xhoriz, Xhorizp, use_ff = _flat_field(X, uniformity_thresh)
     np.array(FF, dtype=np.float32).tofile(flatfile)
-    with open(flatfile+'.hdr', 'w') as fout:
+    with open(envi_header(flatfile), 'w') as fout:
         fout.write(hdr_template.format(lines=nb, samples=nc))
 
     C, Xvert, Xvertp, use_C = _column_covariances(X, uniformity_thresh)

--- a/isofit/utils/remap.py
+++ b/isofit/utils/remap.py
@@ -20,6 +20,7 @@
 
 import numpy as np
 from spectral.io import envi
+from isofit.core.common import envi_header
 
 
 def remap(inputfile, labels, outputfile, flag, chunksize):
@@ -30,12 +31,12 @@ def remap(inputfile, labels, outputfile, flag, chunksize):
     out_file = outputfile
     nchunk = chunksize
 
-    ref_img = envi.open(ref_file+'.hdr', ref_file)
+    ref_img = envi.open(envi_header(ref_file), ref_file)
     ref_meta = ref_img.metadata
     ref_mm = ref_img.open_memmap(interleave='source', writable=False)
     ref = np.array(ref_mm[:, :])
 
-    lbl_img = envi.open(lbl_file+'.hdr', lbl_file)
+    lbl_img = envi.open(envi_header(lbl_file), lbl_file)
     lbl_meta = lbl_img.metadata
     labels = lbl_img.read_band(0)
 
@@ -51,7 +52,7 @@ def remap(inputfile, labels, outputfile, flag, chunksize):
     out_meta['data type'] = ref_meta['data type']
     out_meta["interleave"] = "bil"
 
-    out_img = envi.create_image(out_file+'.hdr',  metadata=out_meta,
+    out_img = envi.create_image(envi_header(out_file),  metadata=out_meta,
                                 ext='', force=True)
     out_mm = out_img.open_memmap(interleave='source', writable=True)
 

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -26,6 +26,7 @@ import ray
 import ray.services
 import atexit
 import logging
+from isofit.core.common import envi_header
 
 @ray.remote
 def segment_chunk(lstart, lend, in_file, nodata_value, npca, segsize, logfile=None, loglevel='INFO'):
@@ -52,7 +53,7 @@ def segment_chunk(lstart, lend, in_file, nodata_value, npca, segsize, logfile=No
 
     logging.info(f'{lstart}: starting')
 
-    in_img = envi.open(in_file + '.hdr', in_file)
+    in_img = envi.open(envi_header(in_file), in_file)
     meta = in_img.metadata
     nl, nb, ns = [int(meta[n]) for n in ('lines', 'bands', 'samples')]
     img_mm = in_img.open_memmap(interleave='bip', writable=False)
@@ -144,7 +145,7 @@ def segment(spectra: tuple, nodata_value: float, npca: int, segsize: int, nchunk
         lbl_file = spectra + '_lbl'
 
     # Open input data, get dimensions
-    in_img = envi.open(in_file+'.hdr', in_file)
+    in_img = envi.open(envi_header(in_file), in_file)
     meta = in_img.metadata
     nl, nb, ns = [int(meta[n]) for n in ('lines', 'bands', 'samples')]
 
@@ -197,7 +198,7 @@ def segment(spectra: tuple, nodata_value: float, npca: int, segsize: int, nchunk
     lbl_meta = {"samples": str(ns), "lines": str(nl), "bands": "1",
                 "header offset": "0", "file type": "ENVI Standard",
                 "data type": "4", "interleave": "bil"}
-    lbl_img = envi.create_image(lbl_file+'.hdr', lbl_meta, ext='', force=True)
+    lbl_img = envi.create_image(envi_header(lbl_file), lbl_meta, ext='', force=True)
     lbl_mm = lbl_img.open_memmap(interleave='source', writable=True)
     lbl_mm[:, :] = np.array(all_labels, dtype=np.float32).reshape((nl, 1, ns))
     del lbl_mm

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -24,7 +24,7 @@ from sklearn.cluster import KMeans
 from spectral.io import envi
 import os
 
-from isofit.core.common import expand_path, json_load_ascii
+from isofit.core.common import expand_path, json_load_ascii, envi_header
 
 
 def surface_model(config_path: str, wavelength_path: str = None, 
@@ -130,8 +130,7 @@ def surface_model(config_path: str, wavelength_path: str = None,
         spectra, attributes = [],[]
         for infile, attribute_file in zip(infiles, infiles_attributes):
 
-            hdrfile = infile + '.hdr'
-            rfl = envi.open(hdrfile, infile)
+            rfl = envi.open(envi_header(infile), infile)
             nl, nb, ns = [int(rfl.metadata[n])
                           for n in ('lines', 'bands', 'samples')]
             swl = np.array([float(f) for f in rfl.metadata['wavelength']])
@@ -154,8 +153,7 @@ def surface_model(config_path: str, wavelength_path: str = None,
             # Load attributes
             if attribute_file is not None:
 
-                hdrfile = attribute_file + '.hdr'
-                attr = envi.open(hdrfile, attribute_file)
+                attr = envi.open(envi_header(attribute_file), attribute_file)
                 nla, nba, nsa = [int(attr.metadata[n])
                           for n in ('lines', 'bands', 'samples')]
 


### PR DESCRIPTION
Updates all instances of file_name + '.hdr' throughout the codebase to use the envi_header function in common.py.  This lets files that use any of the following formats work:

filename & filename.hdr
filename.img & filename.hdr
filename.img & filename.img.hdr