### PR TITLE
Ray updates

### DIFF
--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -86,7 +86,7 @@ class ImplementationConfig(BaseConfigSection):
         with increased memory costs.
         """
 
-        self._debug_mode = bool
+        self._debug_mode_type = bool
         self.debug_mode = False
         """bool: A flag to run the code in debug mode, which circumvents ray.
         """

--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -86,6 +86,11 @@ class ImplementationConfig(BaseConfigSection):
         with increased memory costs.
         """
 
+        self._debug_mode = bool
+        self.debug_mode = False
+        """bool: A flag to run the code in debug mode, which circumvents ray.
+        """
+
 
         self.set_config_options(sub_configdic)
 

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -73,7 +73,9 @@ class Isofit:
         # We can only set the num_cpus if running on a single-node
         if self.config.implementation.ip_head is None and self.config.implementation.redis_password is None:
             rayargs['num_cpus'] = self.config.implementation.n_cores
-        ray.init(**rayargs)
+
+        if self.config.implementation.debug_mode is False:
+            ray.init(**rayargs)
 
         self.workers = None
 
@@ -130,28 +132,36 @@ class Isofit:
         # Max out the number of workers based on the number of tasks
         n_workers = min(n_workers, n_iter)
 
-        fm_id = ray.put(fm)
+        if not self.config.implementation.debug_mode:
+            fm_id = ray.put(fm)
 
-        if self.workers is None:
+        if self.workers is None and not self.config.implementation.debug_mode:
             remote_worker = ray.remote(Worker)
             self.workers = ray.util.ActorPool([remote_worker.remote(self.config, fm_id, self.loglevel, self.logfile, n, n_workers)
                                                for n in range(n_workers)])
+        elif self.config.implementation.debug_mode:
+            self.workers = Worker(self.config, fm, self.loglevel, self.logfile, 0, 1)
 
         start_time = time.time()
         n_tasks = min(n_workers * self.config.implementation.task_inflation_factor, n_iter)
 
         logging.info(f'Beginning {n_iter} inversions in {n_tasks} chunks using {n_workers} cores')
 
-        # Divide up spectra to run into chunks
-        index_sets = np.linspace(0, n_iter, num=n_tasks, dtype=int)
-        if len(index_sets) == 1:
-            indices_to_run = [index_pairs[0:1,:]]
-        else:
-            indices_to_run = [index_pairs[index_sets[l]:index_sets[l + 1], :]
-                              for l in range(len(index_sets) - 1)]
+        if not self.config.implementation.debug_mode:
+            # Divide up spectra to run into chunks
+            index_sets = np.linspace(0, n_iter, num=n_tasks, dtype=int)
+            if len(index_sets) == 1:
+                indices_to_run = [index_pairs[0:1,:]]
+            else:
+                indices_to_run = [index_pairs[index_sets[l]:index_sets[l + 1], :]
+                                  for l in range(len(index_sets) - 1)]
 
-        res = list(self.workers.map_unordered(lambda a, b: a.run_set_of_spectra.remote(b),
+            res = list(self.workers.map_unordered(lambda a, b: a.run_set_of_spectra.remote(b),
                                               indices_to_run))
+        else:
+            self.workers.run_set_of_spectra(index_pairs)
+
+
 
         total_time = time.time() - start_time
         logging.info(f'Inversions complete.  {round(total_time,2)}s total, {round(n_iter/total_time,4)} spectra/s, '

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -27,7 +27,6 @@ import time
 import multiprocessing
 import numpy as np
 import ray
-import ray.services
 
 from isofit.core.forward import ForwardModel
 from isofit.inversion.inverse import Inversion
@@ -68,14 +67,8 @@ class Isofit:
         rayargs = {'address': self.config.implementation.ip_head,
                    '_redis_password': self.config.implementation.redis_password,
                    'ignore_reinit_error': self.config.implementation.ray_ignore_reinit_error,
-                   'local_mode': self.config.implementation.n_cores == 1}
-
-        # only specify a temporary directory if we are not connecting to 
-        # a ray cluster
-        if rayargs['local_mode']:
-            rayargs['_temp_dir'] = self.config.implementation.ray_temp_dir
-            # Used to run on a VPN
-            ray.services.get_node_ip_address = lambda: '127.0.0.1'
+                   '_temp_dir': self.config.implementation.ray_temp_dir,
+                    'local_mode': self.config.implementation.n_cores == 1}
 
         # We can only set the num_cpus if running on a single-node
         if self.config.implementation.ip_head is None and self.config.implementation.redis_password is None:

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -30,7 +30,6 @@ import matplotlib
 import pylab as plt
 from isofit.configs import configs
 import ray
-import ray.services
 import atexit
 from isofit.core.common import envi_header
 
@@ -368,14 +367,8 @@ def empirical_line(reference_radiance_file: str, reference_reflectance_file: str
     rayargs = {'ignore_reinit_error': iconfig.implementation.ray_ignore_reinit_error,
                'local_mode': n_cores == 1,
                "address": iconfig.implementation.ip_head,
+               '_temp_dir': iconfig.implementation.ray_temp_dir,
                "_redis_password": iconfig.implementation.redis_password}
-
-    # only specify a temporary directory if we are not connecting to
-    # a ray cluster
-    if rayargs['local_mode']:
-        rayargs['_temp_dir'] = iconfig.implementation.ray_temp_dir
-        # Used to run on a VPN
-        ray.services.get_node_ip_address = lambda: '127.0.0.1'
 
     # We can only set the num_cpus if running on a single-node
     if iconfig.implementation.ip_head is None and iconfig.implementation.redis_password is None:

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -21,7 +21,6 @@
 import numpy as np
 from spectral.io import envi
 import ray
-import ray.services
 import logging
 import atexit
 from isofit.core.fileio import write_bil_chunk
@@ -136,12 +135,8 @@ def extractions(inputfile, labels, output, chunksize, flag, n_cores: int = 1, ra
     rayargs = {'ignore_reinit_error': True,
                'local_mode': n_cores == 1,
                "address": ray_address,
-               "_redis_password": ray_redis_password}
-
-    if rayargs['local_mode']:
-        rayargs['_temp_dir'] = ray_temp_dir
-        # Used to run on a VPN
-        ray.services.get_node_ip_address = lambda: '127.0.0.1'
+               '_temp_dir': ray_temp_dir,
+                '_redis_password': ray_redis_password}
 
     # We can only set the num_cpus if running on a single-node
     if ray_ip_head is None and ray_redis_password is None:


### PR DESCRIPTION
Addresses #251 by removing ray.services utilization.  This was a feature that had intended to circumvent the issues w/ running ray while a VPN was connected, but the strategy is now deprecated anyway, and also causes dependency issues.

Also adds an option to run isofit in debug mode, which circumvents ray but still utilizes the worker class.  In debug mode, spectra are inverted using only one core.

To be done: 
- investigate if there's an easy VPN circumvention strategy that works w/ ray 1.8.0, and 