### PR TITLE
Hashing covariance

### DIFF
--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -123,7 +123,11 @@ class Inversion:
         # If there aren't any fixed parameters, we just directly
         if self.x_fixed is None or self.grid_as_starting_points:
             Sa_inv, Sa_inv_sqrt = svd_inv_sqrt(Sa, hashtable=self.hashtable, max_hash_size=self.max_table_size)
-            return xa, Sa, Sa_inv, Sa_inv_sqrt
+            norm_scale = (norm(x[self.fm.idx_surface])**2)
+            norm_inverse_scale = 1/norm_scale
+            norm_inverse_scale_sqrt = np.sqrt(norm_inverse_scale)
+            return xa, Sa*norm_scale, Sa_inv*norm_inverse_scale, Sa_inv_sqrt*norm_inverse_scale_sqrt
+            
 
         else:
             # otherwise condition on fixed variables

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -24,7 +24,7 @@ import numpy as np
 from collections import OrderedDict
 from scipy.optimize import least_squares
 import scipy.linalg
-
+from scipy.linalg import norm
 from isofit.core.common import svd_inv, svd_inv_sqrt, eps, combos, conditional_gaussian
 from .inverse_simple import invert_simple
 from isofit.configs import Config

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -158,7 +158,7 @@ class MultiComponentSurface(Surface):
         lamb_ref = lamb[self.idx_ref]
         ci = self.component(x_surface, geom)
         Cov = self.components[ci][1]
-        Cov = Cov * (self.norm(lamb_ref)**2)
+        #Cov = Cov * (self.norm(lamb_ref)**2)
 
         # If there are no other state vector elements, we're done.
         if len(self.statevec_names) == len(self.idx_lamb):

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -154,11 +154,8 @@ class MultiComponentSurface(Surface):
         the covariance in a normalized space (normalizing by z) and then un-
         normalize the result for the calling function."""
 
-        lamb = self.calc_lamb(x_surface, geom)
-        lamb_ref = lamb[self.idx_ref]
         ci = self.component(x_surface, geom)
         Cov = self.components[ci][1]
-        #Cov = Cov * (self.norm(lamb_ref)**2)
 
         # If there are no other state vector elements, we're done.
         if len(self.statevec_names) == len(self.idx_lamb):


### PR DESCRIPTION
This change will make the hashtable to be used more. The reason it was not used a lot before is that the prior covariances are being scaled by the norm of the reflectance state, which changes within iterations, so the hashing can't match. Now we decoupled the scaling from the inversion, so the hashtable is used more. I banchmarked this and see about 1.5x in performance (spectra/second/core)