### PR TITLE
Ray dashboard

### DIFF
--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -61,10 +61,6 @@ class ImplementationConfig(BaseConfigSection):
         self.ray_include_dashboard = False
         """str: Ray - parameter.  Boolean to include dashboard."""
 
-        self._ray_worker_timeout_type = int
-        self.ray_worker_timeout = 600
-        """str: Ray - parameter.  Updates enviornment variable RAY_worker_register_timeout_seconds."""
-
         self._rte_configure_and_exit_type = bool
         self.rte_configure_and_exit = False
         """bool: Indicates that code should terminate as soon as all radiative transfer engine configuration files are

--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -57,6 +57,14 @@ class ImplementationConfig(BaseConfigSection):
         self.redis_password = None
         """str: Ray - parameter.  Redis-password (for multi-node runs)."""
 
+        self._ray_include_dashboard_type = str
+        self.ray_include_dashboard = False
+        """str: Ray - parameter.  Boolean to include dashboard."""
+
+        self._ray_worker_timeout_type = int
+        self.ray_worker_timeout = 600
+        """str: Ray - parameter.  Updates enviornment variable RAY_worker_register_timeout_seconds."""
+
         self._rte_configure_and_exit_type = bool
         self.rte_configure_and_exit = False
         """bool: Indicates that code should terminate as soon as all radiative transfer engine configuration files are

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -48,8 +48,6 @@ class Isofit:
         # Explicitly set the number of threads to be 1, so we more effectively
         # run in parallel
         os.environ["MKL_NUM_THREADS"] = "1"
-        # Update the ray timeout rate
-        os.environ["RAY_worker_register_timeout_seconds"] = str(self.config.implementation.ray_worker_timeout)
         # Set logging level
         self.loglevel = level
         self.logfile = logfile

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -48,6 +48,8 @@ class Isofit:
         # Explicitly set the number of threads to be 1, so we more effectively
         # run in parallel
         os.environ["MKL_NUM_THREADS"] = "1"
+        # Update the ray timeout rate
+        os.environ["RAY_worker_register_timeout_seconds"] = str(self.config.implementation.ray_worker_timeout)
         # Set logging level
         self.loglevel = level
         self.logfile = logfile
@@ -64,7 +66,9 @@ class Isofit:
         # Initialize ray for parallel execution
         rayargs = {'address': self.config.implementation.ip_head,
                    '_redis_password': self.config.implementation.redis_password,
+                   '_temp_dir': self.config.implementation.ray_temp_dir,
                    'ignore_reinit_error': self.config.implementation.ray_ignore_reinit_error,
+                   'include_dashboard': self.config.implementation.ray_include_dashboard,
                    'local_mode': self.config.implementation.n_cores == 1}
         
         # We can only set the num_cpus if running on a single-node

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -368,6 +368,7 @@ def empirical_line(reference_radiance_file: str, reference_reflectance_file: str
                'local_mode': n_cores == 1,
                "address": iconfig.implementation.ip_head,
                '_temp_dir': iconfig.implementation.ray_temp_dir,
+               'include_dashboard': iconfig.implementation.ray_include_dashboard,
                "_redis_password": iconfig.implementation.redis_password}
 
     # We can only set the num_cpus if running on a single-node

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -135,6 +135,7 @@ def extractions(inputfile, labels, output, chunksize, flag, n_cores: int = 1, ra
     rayargs = {'ignore_reinit_error': True,
                'local_mode': n_cores == 1,
                "address": ray_address,
+               'include_dashboard': False,
                '_temp_dir': ray_temp_dir,
                 '_redis_password': ray_redis_password}
 

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -152,6 +152,7 @@ def segment(spectra: tuple, nodata_value: float, npca: int, segsize: int, nchunk
     rayargs = {'ignore_reinit_error': True,
                'local_mode': n_cores == 1,
                "address": ray_address,
+               'include_dashboard': False,
                '_temp_dir': ray_temp_dir,
                "_redis_password": ray_redis_password}
 


### PR DESCRIPTION
- sets ray dashboard as parameter, defaults to false
- adds _temp_dir back to main isofit init

Also worth considering is setting RAY_worker_register_timeout_seconds to a higher value - 400 is recommended.  This is excluded as it should be run before the very first ray instance is run, but could also be passed into each utility separately.