### PR TITLE
Updated path to radiometry correction file in configs for Santa Monica example.

### DIFF
--- a/examples/20151026_SantaMonica/configs/prm20151026t173213_D8W_6s.json
+++ b/examples/20151026_SantaMonica/configs/prm20151026t173213_D8W_6s.json
@@ -13,7 +13,7 @@
     "state_file":                 "../remote/prm20151026t173213_state_v1h3_D8W_6s.txt",
     "posterior_uncertainty_file": "../remote/prm20151026t173213_post_v1h3_D8W_6s.txt",
     "data_dump_file":             "../remote/prm20151026t173213_data_D8W_6s.mat",
-    "radiometry_correction_file": "../data/prm20151026t173213_vicarious_correction.txt",
+    "radiometry_correction_file": "../data/prm20151026t173213_rdn_6s_factors.txt",
     "plot_directory":             "../images/"
   },
 

--- a/examples/20151026_SantaMonica/configs/prm20151026t173213_D8p5W_6s.json
+++ b/examples/20151026_SantaMonica/configs/prm20151026t173213_D8p5W_6s.json
@@ -4,7 +4,7 @@
   "input": {
     "measured_radiance_file":     "../remote/prm20151026t173213_rawrdn_v1h3_D8p5W_clip.txt",
     "obs_file":                   "../remote/prm20151026t173213_obs_D8p5W.txt",
-    "radiometry_correction_file": "../data/prm20151026t173213_vicarious_correction.txt",
+    "radiometry_correction_file": "../data/prm20151026t173213_rdn_6s_factors.txt",
     "reference_reflectance_file": "../insitu/D8p5W.txt"
   },
 

--- a/examples/20151026_SantaMonica/configs/prm20151026t173213_D9W_6s.json
+++ b/examples/20151026_SantaMonica/configs/prm20151026t173213_D9W_6s.json
@@ -4,7 +4,7 @@
   "input": {
     "measured_radiance_file":     "../remote/prm20151026t173213_rawrdn_v1h3_D9W_clip.txt",
     "obs_file":                   "../remote/prm20151026t173213_obs_D9W.txt",
-    "radiometry_correction_file": "../data/prm20151026t173213_vicarious_correction.txt",
+    "radiometry_correction_file": "../data/prm20151026t173213_rdn_6s_factors.txt",
     "reference_reflectance_file": "../insitu/D9W.txt"
   },
 

--- a/examples/20151026_SantaMonica/configs/prm20151026t173213_D9p5W_6s.json
+++ b/examples/20151026_SantaMonica/configs/prm20151026t173213_D9p5W_6s.json
@@ -4,7 +4,7 @@
   "input": {
     "measured_radiance_file":     "../remote/prm20151026t173213_rawrdn_v1h3_D9p5W_clip.txt",
     "obs_file":                   "../remote/prm20151026t173213_obs_D9p5W.txt",
-    "radiometry_correction_file": "../data/prm20151026t173213_vicarious_correction.txt",
+    "radiometry_correction_file": "../data/prm20151026t173213_rdn_6s_factors.txt",
     "reference_reflectance_file": "../insitu/D9p5W.txt"
   },
 


### PR DESCRIPTION
The Santa Monica example runs failed due to an outdated radiometry correction file given in the configs. This should now be fixed.