### PR TITLE
Update installation instructions for using the mamba installer.

### DIFF
--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -1,103 +1,62 @@
 Installation
 ============
 
-From conda-forge (recommended)
-******************************
+Install from conda-forge
+************************
+Recommended approach!
 
-ISOFIT can be installed from the conda-forge channel by using different types of package managers. It is highly
-recommended to use the Mambaforge version of the Miniforge_ minimal installer. It allows to install the conda package
-manager with some useful features pre-configured:
-
-- support for Mamba_ in place of Conda, which is a reimplementation of the conda package manager in C++ that allows parallel downloading and much faster dependency solving
-- emphasis on supporting various CPU architectures (x86_64, ppc64le, and aarch64 including Apple M1)
-
-Using Mamba_ (latest version recommended), ISOFIT can be installed by first creating a virtual environment
-(optional but recommended), followed by the installation itself:
+New environment:
 
 .. code-block:: bash
 
     $ mamba create -n isofit_env -c conda-forge isofit
     $ mamba activate isofit_env
+    $ pip install ray ndsplines xxhash --upgrade
 
-In case you're using Mambaforge, you don't necessarily need to specify the conda-forge channel as it's set as the
-default (and only) channel.
+or 
 
-Alternatively, you can install ISOFIT in an already existing environment by simply running:
+.. code-block:: bash
+
+    $ conda create -n isofit_env -c conda-forge isofit
+    $ conda activate isofit_env
+    $ pip install ray ndsplines xxhash --upgrade
+
+Within an existing environment:
 
 .. code-block:: bash
 
     $ mamba install -c conda-forge isofit
+    $ pip install ray ndsplines xxhash --upgrade
 
-Of course, you can also use the Conda_ installer from the Anaconda_ or Miniconda_ package managers, which requires the
-same procedure as using Mamba_.
-
-Mamba_ or Conda_ are the preferred methods to install ISOFIT, as they will always install the most recent stable
-release and automatically resolve all the dependencies.
-
-The Ray_ package, which is a unified framework for scaling AI and Python applications, is currently not available for
-MacOS on conda-forge. Furthermore, the Ray conda package is maintained by the community, not the Ray team. While using
-a mamba or conda environment, please install Ray from PyPi using pip. Additionally, both the ndsplines library and the
-latest version of xxhash are not available on conda-forge, so that they need to be added to the pip command:
+or
 
 .. code-block:: bash
 
+    $ conda install -c conda-forge isofit
     $ pip install ray ndsplines xxhash --upgrade
 
-From PyPI (not recommended)
-***************************
+The additional pip installation is necessary as several packages are not available from conda-forge for all operating systems.
 
-There is also a pip_ installer for ISOFIT. However, please note that ISOFIT depends on some open source packages that
-may cause problems when installed with pip. Therefore, we strongly recommend to resolve the following dependencies
-before the pip installer is run:
 
-    * gdal>=2.0.0
-    * matplotlib-base>=2.2.2
-    * ndsplines>=0.1.2
-    * numpy>=1.20
-    * pandas>=0.24.0
-    * pep8>=1.7.1
-    * pytest>=3.5.1
-    * python-xxhash>=1.2.0
-    * pyyaml>=5.3.2
-    * ray>=1.2.0
-    * scikit-learn>=0.19.1
-    * scikit-image >=0.17.0
-    * scipy>=1.3.0
-    * spectral>=0.19
-    * tensorflow>=2.0.1
-
-Then, the pip installer can be run by:
+Install from pip
+****************
+Not recommended, as package dependencies may not fully resolve.
 
 .. code-block:: bash
 
     $ pip install isofit
 
-If you don't have pip_ installed, this `Python installation guide`_ can guide you through the process.
 
-From Github
-***********
-
-Alternatively, you can install ISOFIT from source by cloning the respective repository hosted on Github:
+Install from github
+*******************
 
 .. code-block:: bash
 
     $ git clone https://github.com/isofit/isofit
-
-The repository contains an environment file that includes all needed dependencies. It is recommended to create this
-specific environment prior to installing ISOFIT from source:
-
-.. code-block:: bash
-
-    $ cd isofit/recipe
-    $ mamba env create -f environment_isofit_basic.yml
+    $ mamba env create -f isofit/recipe/environment_isofit_basic.yml
     $ mamba activate isofit_env
+    $ pip install -e ./isofit
 
-Finally, install ISOFIT in editable mode:
-
-.. code-block:: bash
-
-    $ cd ..
-    $ pip install -e .
 
 
 Setting environment variables
@@ -154,6 +113,33 @@ Windows
     setx /M VARIABLE_NAME "DIRECTORY" (use your actual path)
 
     setx VARIABLE_NAME "DIRECTORY" (use your actual path)
+
+Quick Start with sRTMnet (Recommended for new users)
+====================================================
+
+sRTMnet is an emulator for MODTRAN 6, that works by coupling a neural network with a surrogate RTM (6S v2.1).
+Installation requires two steps:
+
+1. Download `6S v2.1 <https://salsa.umd.edu/files/6S/6sV2.1.tar>`_, and compile.  If you use a modern system,
+it is likely you will need to specify a legacy compiling configuration by changing line 3 of the Makefile to:
+
+.. code::
+
+    EXTRA   = -O -ffixed-line-length-132 -std=legacy
+
+2. Configure your environment by pointing the SIXS_DIR variable to point to your installation directory.
+
+3. Download the `pre-trained sRTMnet neural network <https://zenodo.org/record/4096627>`_, and (for the example below)
+point the environment variable EMULATOR_PATH to the base unzipped path.
+
+4. Run the following code
+
+.. code::
+
+    cd examples/image_cube/
+    sh ./run_example_cube.sh
+
+
 
 
 Quick Start using MODTRAN 6.0
@@ -224,31 +210,6 @@ A few important steps have to be considered when installing the software, which 
 
 8. Look for output data in examples/20171108_Pasadena/output/.
 
-
-Quick Start with sRTMnet
-========================
-
-sRTMnet is an emulator for MODTRAN 6, that works by coupling a neural network with a surrogate RTM (6S v2.1).
-Installation requires two steps:
-
-1. Download `6S v2.1 <https://salsa.umd.edu/files/6S/6sV2.1.tar>`_, and compile.  If you use a modern system,
-it is likely you will need to specify a legacy compiling configuration by changing line 3 of the Makefile to:
-
-.. code::
-
-    EXTRA   = -O -ffixed-line-length-132 -std=legacy
-
-2. Configure your environment by pointing the SIXS_DIR variable to point to your installation directory.
-
-3. Download the `pre-trained sRTMnet neural network <https://zenodo.org/record/4096627>`_, and (for the example below)
-point the environment variable EMULATOR_PATH to the base unzipped path.
-
-4. Run the following code
-
-.. code::
-
-    cd examples/image_cube/
-    sh ./run_example_cube.sh
 
 
 Additional Installation Info for Mac OSX

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -20,6 +20,27 @@ Using Mamba_ (latest version recommended), ISOFIT can be installed by first crea
     $ mamba create -n isofit_env isofit
     $ mamba activate isofit_env
 
+You can also use the Mamba_ installer within Anaconda_ or Miniconda_ package managers. However, you have to either set
+the conda-forge channel as default prior to installing any packages or specifying the channel while installing the
+packages. Additionally, you'll have to install Mamba_ from conda-forge using the Conda_ command:
+
+.. code-block:: bash
+
+    $ conda config --add channels conda-forge
+    $ conda config --set channel_priority strict
+    $ conda install mamba
+    $ mamba create -n isofit_env isofit
+    $ mamba activate isofit_env
+
+or
+
+.. code-block:: bash
+
+    $ conda install -c conda-forge mamba
+    $ mamba create -n isofit_env
+    $ mamba activate isofit_env
+    $ mamba install -c conda-forge isofit
+
 Alternatively, you can of course install ISOFIT in an already existing environment by simply running:
 
 .. code-block:: bash
@@ -27,13 +48,8 @@ Alternatively, you can of course install ISOFIT in an already existing environme
     $ mamba install isofit
 
 Of course, you can also use the Conda_ installer from the Anaconda_ or Miniconda_ package managers. The installation
-procedure is equal to using Mamba_, but you should make sure to set the conda-forge channel as default prior to
-installing any packages:
-
-.. code-block:: bash
-
-    $ conda config --add channels conda-forge
-    $ conda config --set channel_priority strict
+procedure is equal to using Mamba_, but you should again make sure to set the conda-forge channel as default prior to
+installing any packages (see above).
 
 Mamba_ or Conda_ are the preferred methods to install ISOFIT, as they will always install the most recent stable
 release and automatically resolve all the dependencies.

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -8,7 +8,6 @@ ISOFIT can be installed from the conda-forge channel by using different types of
 recommended to use the Mambaforge version of the Miniforge_ minimal installer. It allows to install the conda package
 manager with some useful features pre-configured:
 
-- conda-forge is set as the default (and only) channel
 - support for Mamba_ in place of Conda, which is a reimplementation of the conda package manager in C++ that allows parallel downloading and much faster dependency solving
 - emphasis on supporting various CPU architectures (x86_64, ppc64le, and aarch64 including Apple M1)
 
@@ -17,39 +16,20 @@ Using Mamba_ (latest version recommended), ISOFIT can be installed by first crea
 
 .. code-block:: bash
 
-    $ mamba create -n isofit_env isofit
+    $ mamba create -n isofit_env -c conda-forge isofit
     $ mamba activate isofit_env
 
-You can also use the Mamba_ installer within Anaconda_ or Miniconda_ package managers. However, you have to either set
-the conda-forge channel as default prior to installing any packages or specifying the channel while installing the
-packages. Additionally, you'll have to install Mamba_ from conda-forge using the Conda_ command:
-
-.. code-block:: bash
-
-    $ conda config --add channels conda-forge
-    $ conda config --set channel_priority strict
-    $ conda install mamba
-    $ mamba create -n isofit_env isofit
-    $ mamba activate isofit_env
-
-or
-
-.. code-block:: bash
-
-    $ conda install -c conda-forge mamba
-    $ mamba create -n isofit_env
-    $ mamba activate isofit_env
-    $ mamba install -c conda-forge isofit
+In case you're using Mambaforge, you don't necessarily need to specify the conda-forge channel as it's set as the
+default (and only) channel.
 
 Alternatively, you can of course install ISOFIT in an already existing environment by simply running:
 
 .. code-block:: bash
 
-    $ mamba install isofit
+    $ mamba install -c conda-forge isofit
 
-Of course, you can also use the Conda_ installer from the Anaconda_ or Miniconda_ package managers. The installation
-procedure is equal to using Mamba_, but you should again make sure to set the conda-forge channel as default prior to
-installing any packages (see above).
+Of course, you can also use the Conda_ installer from the Anaconda_ or Miniconda_ package managers, which requires the
+same procedure as using Mamba_.
 
 Mamba_ or Conda_ are the preferred methods to install ISOFIT, as they will always install the most recent stable
 release and automatically resolve all the dependencies.

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -22,7 +22,7 @@ Using Mamba_ (latest version recommended), ISOFIT can be installed by first crea
 In case you're using Mambaforge, you don't necessarily need to specify the conda-forge channel as it's set as the
 default (and only) channel.
 
-Alternatively, you can of course install ISOFIT in an already existing environment by simply running:
+Alternatively, you can install ISOFIT in an already existing environment by simply running:
 
 .. code-block:: bash
 

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -9,31 +9,31 @@ New environment:
 
 .. code-block:: bash
 
-    $ mamba create -n isofit_env -c conda-forge isofit
-    $ mamba activate isofit_env
-    $ pip install ray ndsplines xxhash --upgrade
+    mamba create -n isofit_env -c conda-forge isofit
+    mamba activate isofit_env
+    pip install ray ndsplines xxhash --upgrade
 
 or 
 
 .. code-block:: bash
 
-    $ conda create -n isofit_env -c conda-forge isofit
-    $ conda activate isofit_env
-    $ pip install ray ndsplines xxhash --upgrade
+    conda create -n isofit_env -c conda-forge isofit
+    conda activate isofit_env
+    pip install ray ndsplines xxhash --upgrade
 
 Within an existing environment:
 
 .. code-block:: bash
 
-    $ mamba install -c conda-forge isofit
-    $ pip install ray ndsplines xxhash --upgrade
+    mamba install -c conda-forge isofit
+    pip install ray ndsplines xxhash --upgrade
 
 or
 
 .. code-block:: bash
 
-    $ conda install -c conda-forge isofit
-    $ pip install ray ndsplines xxhash --upgrade
+    conda install -c conda-forge isofit
+    pip install ray ndsplines xxhash --upgrade
 
 The additional pip installation is necessary as several packages are not available from conda-forge for all operating systems.
 
@@ -44,7 +44,7 @@ Not recommended, as package dependencies may not fully resolve.
 
 .. code-block:: bash
 
-    $ pip install isofit
+    pip install isofit
 
 
 Install from github
@@ -52,10 +52,10 @@ Install from github
 
 .. code-block:: bash
 
-    $ git clone https://github.com/isofit/isofit
-    $ mamba env create -f isofit/recipe/environment_isofit_basic.yml
-    $ mamba activate isofit_env
-    $ pip install -e ./isofit
+    git clone https://github.com/isofit/isofit
+    mamba env create -f isofit/recipe/environment_isofit_basic.yml
+    mamba activate isofit_env
+    pip install -e ./isofit
 
 
 


### PR DESCRIPTION
This adds updated installation instructions for installing ISOFIT using mamba. Previously, the installation failed when using mamba installed via conda instead of using mini- or mambaforge since the installer was not searching for ISOFIT on the conda-forge channel.