### PR TITLE
Fix of ValueError in test_common.py to prevent failure of main test.

### DIFF
--- a/isofit/test/test_common.py
+++ b/isofit/test/test_common.py
@@ -8,7 +8,7 @@ def test_eps():
     assert eps == 1e-5
 
 def test_combos():
-    inds = np.array([[1, 2], [3, 4, 5]])
+    inds = np.array([[1, 2], [3, 4, 5]], dtype=object)
     result = np.array([[1, 3], [2, 3], [1, 4], [2, 4], [1, 5], [2, 5]])
     assert np.array_equal(combos(inds), result)
 


### PR DESCRIPTION
This adds the fix of a ValueError in test_common.py to prevent future failure of the main test workflow. I encountered the problem in my fork yesterday. The PR fixes the following error:

```
def test_combos():
    inds = np.array([[1, 2], [3, 4, 5]])
ValueError: setting an array element with a sequence.
The requested array has an inhomogeneous shape after 1 dimensions.
The detected shape was (2,) + inhomogeneous part.
```
