### PR TITLE
Bugfix in multilinear grid interpolation.

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -223,10 +223,10 @@ class VectorInterpolator:
         cube = np.copy(self.gridarrays[idx], order='A')
 
         for i, di in enumerate(deltas):
-            # Eliminate those indexes where we are outside grid range
-            if points[i] > self.gridtuples[i][-1]:
+            # Eliminate those indexes where we are outside grid range or exactly on the grid point
+            if points[i] >= self.gridtuples[i][-1]:
                 cube = cube[1]
-            elif points[i] < self.gridtuples[i][0]:
+            elif points[i] <= self.gridtuples[i][0]:
                 cube = cube[0]
             # Otherwise eliminate index by linear interpolation
             else:


### PR DESCRIPTION
In common.py [lines 225 - 236](https://github.com/isofit/isofit/blob/57693cbbfe1bb655347a31bc809ec2529b4f76a4/isofit/core/common.py#L225), the multilinear grid interpolation loops through the deltas, points, and gridtuples. When using the previous implementation, the code tries to interpolate between indexes at 0 and -1 in the negative direction in cases the interpolation point **lies exactly on the gridpoint**. This leads to some weird results. This is now fixed by this PR.