### PR TITLE
Separation of surface state vector indexes.

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -114,9 +114,12 @@ class ForwardModel:
 
         # Set up indices for references - MUST MATCH ORDER FROM ABOVE ASSIGNMENT
         self.idx_surface = np.arange(len(self.surface.statevec_names), dtype=int)
-        # Split surface state vector indices to cover cases where we retrieve additional surface parameters
-        self.idx_surf_ref = self.idx_surface[:len(self.surface.idx_lamb)]
-        self.idx_surf_params = self.idx_surface[len(self.surface.idx_lamb):]
+        # Sometimes, it's convenient to have the index of the entire surface
+        # as one variable, and sometimes you want the sub-components
+        # Split surface state vector indices to cover cases where we retrieve
+        # additional non-reflectance surface parameters
+        self.idx_surf_rfl = self.idx_surface[:len(self.surface.idx_lamb)]  # reflectance portion
+        self.idx_surf_nonrfl = self.idx_surface[len(self.surface.idx_lamb):]  # all non-reflectance surface parameters
         self.idx_RT = np.arange(len(self.RT.statevec_names), dtype=int) + len(self.idx_surface)
         self.idx_instrument = np.arange(
             len(self.instrument.statevec_names), dtype=int) + len(self.idx_surface) + len(self.idx_RT)

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -114,6 +114,9 @@ class ForwardModel:
 
         # Set up indices for references - MUST MATCH ORDER FROM ABOVE ASSIGNMENT
         self.idx_surface = np.arange(len(self.surface.statevec_names), dtype=int)
+        # Split surface state vector indices to cover cases where we retrieve additional surface parameters
+        self.idx_surf_ref = self.idx_surface[:len(self.surface.idx_lamb)]
+        self.idx_surf_params = self.idx_surface[len(self.surface.idx_lamb):]
         self.idx_RT = np.arange(len(self.RT.statevec_names), dtype=int) + len(self.idx_surface)
         self.idx_instrument = np.arange(
             len(self.instrument.statevec_names), dtype=int) + len(self.idx_surface) + len(self.idx_RT)
@@ -134,7 +137,6 @@ class ForwardModel:
         """Check if state vector is within bounds."""
 
         x_RT = x[self.idx_RT]
-        x_surface = x[self.idx_surface]
         bound_lwr = self.bounds[0]
         bound_upr = self.bounds[1]
         return any(x_RT >= (bound_upr[self.idx_RT] - eps*2.0)) or \

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -303,7 +303,7 @@ class Inversion:
 
             # Update regions outside retrieval windows to match priors
             if self.config.priors_in_initial_guess:
-                prior_subset_idx = np.arange(len(x0))[self.fm.idx_surface][self.outside_ret_windows]
+                prior_subset_idx = np.arange(len(x0))[self.fm.idx_surf_rfl][self.outside_ret_windows]
                 x0[prior_subset_idx] = self.fm.surface.xa(x0, geom)[prior_subset_idx]
 
             trajectory.append(x0)

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -42,6 +42,7 @@ class Surface:
         self.init = np.array([])
         self.bvec = []
         self.bval = np.array([])
+        self.idx_lamb = np.empty(shape=0)
         self.emissive = False
 
         self.wl = None

--- a/isofit/surface/surface_glint.py
+++ b/isofit/surface/surface_glint.py
@@ -21,7 +21,6 @@
 import scipy as s
 
 from ..core.common import eps
-from .surface_multicomp import MultiComponentSurface
 from .surface_thermal import ThermalSurface
 from isofit.configs import Config
 

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -45,7 +45,7 @@ class MultiComponentSurface(Surface):
         config = full_config.forward_model.surface
 
         # Models are stored as dictionaries in .mat format
-        # TODO: inforce surface_file existence in the case of multicomponent_surface
+        # TODO: enforce surface_file existence in the case of multicomponent_surface
         model_dict = loadmat(config.surface_file)
         self.components = list(zip(model_dict['means'], model_dict['covs']))
         self.n_comp = len(self.components)


### PR DESCRIPTION
This PR implements a separation of surface state vector indexes within the forward class to cover cases where we retrieve additional non-reflectance surface parameters, such as sun glint for water surfaces or liquid water over vegetated pixels. This also fixes #315.