### PR TITLE
Wrapper Patch

### DIFF
--- a/.imgspec/apply_glt.py
+++ b/.imgspec/apply_glt.py
@@ -10,7 +10,7 @@ import pandas as pd
 from osgeo import gdal
 from spectral.io import envi
 import logging
-from isofit.wrappers import ray
+from isofit import ray
 from typing import List
 import os
 import multiprocessing

--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -27,3 +27,12 @@ name = "isofit"
 __version__ = "2.9.8"
 
 warnings_enabled = False
+
+import os
+
+if os.environ.get("ISOFIT_DEBUG"):
+    print("Internal ray")
+    from .wrappers import ray
+else:
+    print("External ray")
+    import ray

--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -28,11 +28,13 @@ __version__ = "2.9.8"
 
 warnings_enabled = False
 
+import logging
 import os
 
+Logger = logging.getLogger("isofit")
+
 if os.environ.get("ISOFIT_DEBUG"):
-    print("Internal ray")
+    Logger.info("Using ISOFIT internal ray")
     from .wrappers import ray
 else:
-    print("External ray")
     import ray

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -27,12 +27,12 @@ import time
 
 import numpy as np
 
+from isofit import ray
 from isofit.configs import configs
 from isofit.core.fileio import IO
 from isofit.core.forward import ForwardModel
 from isofit.inversion.inverse import Inversion
 from isofit.inversion.inverse_mcmc import MCMCInversion
-from isofit.wrappers import ray
 
 
 class Isofit:

--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -27,6 +27,7 @@ from typing import List
 
 import numpy as np
 
+from isofit import ray
 from isofit.configs import Config
 from isofit.configs.sections.implementation_config import ImplementationConfig
 from isofit.configs.sections.radiative_transfer_config import (
@@ -34,7 +35,6 @@ from isofit.configs.sections.radiative_transfer_config import (
 )
 from isofit.configs.sections.statevector_config import StateVectorElementConfig
 from isofit.core import common
-from isofit.wrappers import ray
 
 ### Functions ###
 

--- a/isofit/radiative_transfer/sRTMnet.py
+++ b/isofit/radiative_transfer/sRTMnet.py
@@ -30,6 +30,7 @@ import yaml
 from scipy import interpolate
 from tensorflow import keras
 
+from isofit import ray
 from isofit.configs import Config
 from isofit.configs.sections.radiative_transfer_config import (
     RadiativeTransferEngineConfig,
@@ -37,7 +38,6 @@ from isofit.configs.sections.radiative_transfer_config import (
 from isofit.core.common import VectorInterpolator, load_wavelen, resample_spectrum
 from isofit.core.sunposition import sunpos
 from isofit.radiative_transfer.six_s import SixSRT
-from isofit.wrappers import ray
 
 from .look_up_tables import TabularRT
 

--- a/isofit/test/test_wray.py
+++ b/isofit/test/test_wray.py
@@ -2,7 +2,7 @@ import os
 
 os.environ["ISOFIT_DEBUG"] = "1"
 
-from isofit.wrappers import ray
+from isofit import ray
 
 
 @ray.remote

--- a/isofit/test/test_wray.py
+++ b/isofit/test/test_wray.py
@@ -1,8 +1,4 @@
-import os
-
-os.environ["ISOFIT_DEBUG"] = "1"
-
-from isofit import ray
+from isofit.wrappers import ray
 
 
 @ray.remote

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -27,6 +27,7 @@ from glob import glob
 import numpy as np
 from spectral.io import envi
 
+from isofit import ray
 from isofit.configs import configs
 from isofit.core.common import envi_header, svd_inv, svd_inv_sqrt
 from isofit.core.fileio import write_bil_chunk
@@ -36,7 +37,6 @@ from isofit.inversion.inverse import Inversion
 from isofit.inversion.inverse_simple import invert_algebraic, invert_analytical
 from isofit.utils import remap
 from isofit.utils.atm_interpolation import atm_interpolation
-from isofit.wrappers import ray
 
 
 def main(rawargs=None) -> None:

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -29,11 +29,11 @@ from scipy.ndimage import gaussian_filter
 from scipy.spatial import KDTree
 from spectral.io import envi
 
+from isofit import ray
 from isofit.configs import configs
 from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
 from isofit.core.instrument import Instrument
-from isofit.wrappers import ray
 
 plt.switch_backend("Agg")
 

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -29,11 +29,11 @@ from scipy.linalg import inv
 from scipy.spatial import KDTree
 from spectral.io import envi
 
+from isofit import ray
 from isofit.configs import configs
 from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
 from isofit.core.instrument import Instrument
-from isofit.wrappers import ray
 
 plt.switch_backend("Agg")
 

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -24,9 +24,9 @@ import logging
 import numpy as np
 from spectral.io import envi
 
+from isofit import ray
 from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
-from isofit.wrappers import ray
 
 
 @ray.remote

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -27,8 +27,8 @@ import skimage
 from skimage.segmentation import slic
 from spectral.io import envi
 
+from isofit import ray
 from isofit.core.common import envi_header
-from isofit.wrappers import ray
 
 
 @ray.remote

--- a/isofit/wrappers/ray.py
+++ b/isofit/wrappers/ray.py
@@ -13,12 +13,10 @@ Additionally, you may pass it as a temporary environment variable via:
 $ ISOFIT_DEBUG=1 python isofit.py ...
 """
 import logging
-import os
 
 import ray
 
 Logger = logging.getLogger("isofit/wrappers/ray")
-DEBUG = os.environ.get("ISOFIT_DEBUG")
 
 
 class Remote:

--- a/isofit/wrappers/ray.py
+++ b/isofit/wrappers/ray.py
@@ -48,6 +48,7 @@ def __getattr__(key):
     """
     Reports any call to Ray that is not emulated
     """
+    print(f"__getattr__({key})")
     Logger.error(f"Unsupported operation: {key!r}")
     return lambda *a, **kw: None
 


### PR DESCRIPTION
Description
-
This is a patch for the Ray wrapper (and future wrappers) to properly respect the wrapper's environment flag. 

Problem
-
Early developments of the `ray` wrapper (`wray`) had it as an object that implemented `__getattribute__` to intercept all getattr calls and check if `DEBUG` is enabled or not. Depending on the flag, the object would either return our internal emulator functions or return the getattr of `ray`. 

Eventually we decided to remove config-defined debug flags in favour of environment variable flags. As such, to reduce implementation complexity, `wray` was converted from a class to a module. This module lost the `__getattribute__` functionality, thereby causing `wray` to always be enabled, essentially. 

Solution
-
Modules do not support `__getattribute__` (despite supporting `__getattr__` thanks to [PEP562](https://peps.python.org/pep-0562/)), so the solution is to decide in `isofit.__init__` which module to use, either `wray` or `ray`. This honestly is a better solution as it will return the `ray` package altogether instead of passing `ray` attributes through `wray` like previously. 

Additionally, it sets up the structure for future wrappers if they are ever needed. 