### PR TITLE
Add Zenodo json file to control and set upload metadata.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,89 @@
+{
+    "title": "ISOFIT - Imaging Spectrometer Optimal FITting",
+    "description": "ISOFIT contains a set of routines and utilities for fitting surface, atmosphere and instrument models to imaging spectrometer data.",
+    "license": "Apache-2.0",
+    "upload_type": "software",
+    "keywords": [
+        "ISOFIT",
+        "AVIRIS",
+        "EMIT",
+        "imaging spectroscopy",
+        "remote sensing",
+        "satellite",
+        "atmospheric correction"
+    ],
+    "creators": [
+        {
+            "name": "Brodrick, Philip",
+            "affiliation": "Jet Propulsion Laboratory, California Institute of Technology",
+            "orcid": "",
+            "type": "Researcher"
+        },
+        {
+            "name": "Thompson, David",
+            "affiliation": "Jet Propulsion Laboratory, California Institute of Technology",
+            "orcid": "",
+            "type": "Researcher"
+        }
+    ],
+    "contributors": [
+        {
+            "name": "Bohn, Niklas",
+            "affiliation": "Jet Propulsion Laboratory, California Institute of Technology",
+            "orcid": "0000-0003-4078-886X",
+            "type": "Researcher"
+        },
+        {
+            "name": "Carmon, Nimrod",
+            "affiliation": "Jet Propulsion Laboratory, California Institute of Technology",
+            "orcid": "",
+            "type": "Researcher"
+        },
+        {
+            "name": "Chlus, Adam",
+            "affiliation": "Jet Propulsion Laboratory, California Institute of Technology",
+            "orcid": "",
+            "type": "Researcher"
+        },
+        {
+            "name": "Eckert, Regina",
+            "affiliation": "Jet Propulsion Laboratory, California Institute of Technology",
+            "orcid": "",
+            "type": "Researcher"
+        },
+        {
+            "name": "Montgomery, James",
+            "affiliation": "Jet Propulsion Laboratory, California Institute of Technology",
+            "orcid": "",
+            "type": "Technologist"
+        }
+    ],
+    "related_identifiers": [
+        {
+            "scheme": "url",
+            "identifier": "https://github.com/isofit/isofit",
+            "relation": "isSupplementTo",
+            "resource_type": "software"
+        },
+        {
+            "scheme": "url",
+            "identifier": "https://isofit.readthedocs.io/en/latest/index.html",
+            "relation": "isDocumentedBy",
+            "resource_type": "publication-softwaredocumentation"
+        },
+        {
+            "scheme": "doi",
+            "identifier": "",
+            "relation": "isDocumentedBy",
+            "resource_type": "publication-article"
+        }
+    ]
+    ],
+    "grants": [
+        {
+            "code": "",
+            "funder": "",
+            "title": ""
+        }
+    ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -77,7 +77,6 @@
             "relation": "isDocumentedBy",
             "resource_type": "publication-article"
         }
-    ]
     ],
     "grants": [
         {


### PR DESCRIPTION
Zenodo automatically extracts metadata about the current release from GitHub APIs, insofar the respective webhook is configured. For example, the authors are determined from the repository’s contributor statistics. To overwrite some of the default metadata that would come from a regular GitHub release and to respond to #343, this PR adds a .zenodo.json file to the root of the repository. 

The contents of the .zenodo.json file are based on the Zenodo [deposit metadata documentation](https://developers.zenodo.org/#deposit-metadata).

Some examples are:

- software authorship and ORCiDs, via the creators and/or contributor fields
- licensing, via the license field (e.g., Apache-2.0 )
- a custom title, via the title field
- a related identifier to the Github repository, to the documentation, and/or to a potential software paper, via the related_identifiers field
- keywords, via the keywords field
- funding information, via the grants field

I marked this as draft PR since the entries of the json are not thorough yet and we need to think about, e.g., the list of authors, whether to separate into creators and contributors, but also if we want to add specific grants, descriptions, keywords, etc.

As a nice add-on, the `related_identifiers` field even allows to connect the Zenodo upload to a software publication later on, such as the JOSS submission we've been thinking about yesterday.