### PR TITLE
Automatic PyPi Upload Patch #2

### DIFF
--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -24,7 +24,7 @@
 
 name = "isofit"
 
-__version__ = "2.9.8"
+__version__ = "2.9.9.2"
 
 warnings_enabled = False
 


### PR DESCRIPTION
The automatic PyPi upload workflow uses `setup.py` to build both distribution and wheel, and assigns the version number as given by `setup.py` to the upload file name. As the version number in `setup.py` is controlled by the ISOFIT `__init__`, the workflow failed due to an outdated version number in the `__init__`, producing the following error:

`Uploading isofit-2.9.8-py3-none-any.whl`
`HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/`   
`File already exists.`

To ensure a successful upload, we have to update the version number in the ISOFIT `__init__` manually before publishing a new release.

@pgbrodrick Could you merge this in and then publish a new release with the tag `v2.9.9.2`? This PR updates the version number in the `__init__` to `2.9.9.2`, so that the workflow should then upload a distribution to PyPi that doesn't exist yet.

This is also linked to #340.