### PR TITLE
CLI Improvements

### DIFF
--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -57,6 +57,15 @@ def cli(ctx, version, path):
             click.echo(__path__[0])
 
 
+# If mlky is installed, add it to the CLI
+try:
+    from mlky import CLI as mli
+
+    mli.set_defaults(generate={"input": "/path/to/isofit/definitions.yml"})
+    cli.add_command(mli.group)
+except:
+    pass
+
 # Import all of the files that define a _cli command to register them
 import isofit.core.isofit
 import isofit.utils.add_HRRR_profiles_to_modtran_config

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -1916,9 +1916,7 @@ def write_modtran_template(
 @click.argument("input_obs")
 @click.argument("working_directory")
 @click.argument("sensor")
-@click.option(
-    "--copy_input_files", type=int, default=0
-)  # ("--copy_input_files", is_flag=True, default=False)
+@click.option("--copy_input_files", is_flag=False, flag_value=True, default=False)
 @click.option("--modtran_path")
 @click.option("--wavelength_path")
 @click.option("--surface_category", default="multicomponent_surface")
@@ -1929,26 +1927,18 @@ def write_modtran_template(
 @click.option("--channelized_uncertainty_path")
 @click.option("--model_discrepancy_path")
 @click.option("--lut_config_file")
-@click.option("--multiple_restarts", is_flag=True, default=False)
+@click.option("--multiple_restarts", is_flag=False, flag_value=True, default=False)
 @click.option("--logging_level", default="INFO")
 @click.option("--log_file")
 @click.option("--n_cores", type=int, default=1)
-@click.option(
-    "--presolve", type=int, default=0
-)  # ("--presolve", is_flag=True, default=False)
-@click.option(
-    "--empirical_line", type=int, default=0
-)  # ("--empirical_line", is_flag=True, default=False)
-@click.option("--analytical_line", is_flag=True, default=False)
-@click.option(
-    "--ray_temp_dir", type=int, default=0
-)  # ("--ray_temp_dir", default="/tmp/ray")
+@click.option("--presolve", is_flag=False, flag_value=True, default=False)
+@click.option("--empirical_line", is_flag=False, flag_value=True, default=False)
+@click.option("--analytical_line", is_flag=False, flag_value=True, default=False)
+@click.option("--ray_temp_dir", default="/tmp/ray")
 @click.option("--emulator_base")
 @click.option("--segmentation_size", default=40)
 @click.option("--num_neighbors")
-@click.option(
-    "--pressure_elevation", type=int, default=0
-)  # ("--pressure_elevation", is_flag=True)
+@click.option("--pressure_elevation", is_flag=False, flag_value=True, default=False)
 @click.option(
     "--debug-args",
     help="Prints the arguments list without executing the command",

--- a/isofit/utils/multisurface_oe.py
+++ b/isofit/utils/multisurface_oe.py
@@ -671,9 +671,7 @@ def multisurface_oe(args):
 @click.option("--wavelength_path")
 @click.option("--log_file")
 @click.option("--logging_level", default="INFO")
-@click.option(
-    "--pressure_elevation", type=int, default=0
-)  # ("--pressure_elevation", is_flag=True)
+@click.option("--pressure_elevation", is_flag=False, flag_value=True, default=False)
 @click.option("--debug-args", is_flag=True)
 def _cli(debug_args, **kwargs):
     """\


### PR DESCRIPTION
<h1>Description</h1>
The first CLI overhaul was implemented by #342. This PR is for improvement updates to that infrastructure. 


<h1>Changes</h1>

- ✨ New addition
- 🐛 Resolved a bug
- 🗒️ Documentation

<table>
  <tr>
    <th></th>
    <th>Description</th>
  </tr>
  <tr>
    <td>:sparkles:</td>
    <td>Changed boolean integer options back to boolean options that accept a boolean argument. This enables backwards compatibility for argument syntax "--empirical_line 1" while retaining flag syntax "--empirical_line"</td>
  </tr>
  <tr>
    <td>:sparkles:</td>
    <td>Added mlky as an optional subcommand of isofit. This is in preparation for the future mlky PR. These commands include generating templates and verifying configurations without executing isofit and by integrating them this way, they can be tailored specifically to isofit.</td>
  </tr>
</table>