### PR TITLE
Ray Timeouts

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -1939,10 +1939,10 @@ def write_modtran_template(
 @click.option(
     "--empirical_line", type=int, default=0
 )  # ("--empirical_line", is_flag=True, default=False)
-@click.option("--analytical_line", is_flag=True, default=False)
 @click.option(
-    "--ray_temp_dir", type=int, default=0
-)  # ("--ray_temp_dir", default="/tmp/ray")
+    "--analytical_line", type=int, default=0
+)  # ("--analytical_line", is_flag=True, default=False)
+@click.option("--ray_temp_dir", default="/tmp/ray")
 @click.option("--emulator_base")
 @click.option("--segmentation_size", default=40)
 @click.option("--num_neighbors")


### PR DESCRIPTION
# Description

This PR directly addresses issue #368. 

The reason Ray fails to startup in apply_oe when executed from the CLI is because the click argument for it was wrongly set as an integer type and defaulted to `0`. 

The root of the problem is that the ISOFIT configuration module will typecast any value of `ray_temp_dir` to `str` because that's the type the value is supposed to be. Unless the value object explicitly prevents a `str()` cast, there's no warning/indication that this may cause issues. Since click was setting `ray_temp_dir = 0`, ISOFIT converts the value to `"0"` then passes it to [ray.init](https://github.com/isofit/isofit/blob/main/isofit/core/isofit.py#L86). 

Ray will not initialize with `ray.init(_temp_dir="0")`. Additionally, Ray would have raised an exception describing that this parameter was set incorrectly if it was type int (or `None` for below).

In fact, I discovered this through another avenue. I have been using apply_oe as a module through a Jupyter notebook which doesn't use click. I was attempting to pass the minimum number of parameters, defaulting everything else to `None` to reduce notebook bloat. I repeatedly hit this issue due to `ray_temp_dir = None`, where `None` was cast to `"None"`. Quite a bug!

# Solution

Simply fixed apply_oe's `ray_temp_dir` argument as that was a mistake. 

However, this does not address the above described issue inherent to the configuration module. The module ought to inform a user of any type casts to more easily diagnose problems like this. Though, there may be an argument that automated typecasting should be avoided. 

If we are planning to deprecate this in favour of mlky, I believe we should simply note this behaviour until the transition completes instead of devoting time to the module. With this PR, this issue should only be hit in the edge case of using apply_oe as a module. 

#### PS

Fixed `analytical_line` still being a boolean type instead of int type like the others. Seemingly harmless oversight but fixing for consistency. 
