### PR TITLE
Dockerfile v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,68 +1,49 @@
-FROM mambaorg/micromamba:latest
+FROM rayproject/ray:2.4.0-py310-aarch64
+
 USER root
-
-WORKDIR /
-
 RUN apt-get update &&\
     apt-get install --no-install-recommends -y \
-      build-essential \
-      ca-certificates \
-      curl            \
-      git             \
-      gfortran        \
+      gfortran \
+      make \
       unzip
 
+USER ray
+WORKDIR /home/ray
+
+# Copy and install ISOFIT
+COPY --chown=ray:users . isofit/
+RUN conda config --prepend channels conda-forge &&\
+    conda create --name isofit --clone base &&\
+    conda install --name base --solver=classic conda-libmamba-solver nb_conda_kernels jupyterlab &&\
+    conda env update --name isofit --solver=libmamba --file isofit/recipe/unpinned.yml &&\
+    conda install --name isofit --solver=libmamba ipykernel &&\
+    anaconda3/envs/isofit/bin/pip install --no-deps -e isofit &&\
+    echo "conda activate isofit" >> ~/.bashrc
+ENV LD_PRELOAD="/usr/lib/aarch64-linux-gnu/libgomp.so.1:$LD_PRELOAD"
+
 # Install 6S
-RUN mkdir /6sv-2.1 &&\
-    cd /6sv-2.1 &&\
-    curl -SLO https://github.com/ashiklom/isofit/releases/download/6sv-mirror/6sv-2.1.tar &&\
+RUN mkdir 6sv-2.1 &&\
+    cd 6sv-2.1 &&\
+    wget https://github.com/ashiklom/isofit/releases/download/6sv-mirror/6sv-2.1.tar &&\
     tar -xf 6sv-2.1.tar &&\
     rm 6sv-2.1.tar &&\
     sed -i Makefile -e 's/FFLAGS.*/& -std=legacy/' &&\
     make
-ENV SIXS_DIR /6sv-2.1
+ENV SIXS_DIR="/home/ray/6sv-2.1"
 
 # Install sRTMnet
-RUN mkdir /sRTMnet_v100 &&\
-    cd /sRTMnet_v100 &&\
-    curl -SLO https://zenodo.org/record/4096627/files/sRTMnet_v100.zip &&\
+RUN mkdir sRTMnet_v100 &&\
+    cd sRTMnet_v100 &&\
+    wget https://zenodo.org/record/4096627/files/sRTMnet_v100.zip &&\
     unzip sRTMnet_v100.zip &&\
     rm sRTMnet_v100.zip
-ENV EMULATOR_PATH /sRTMnet_v100/sRTMnet_v100
+ENV EMULATOR_PATH="/home/ray/sRTMnet_v100/sRTMnet_v100"
 
-# Some examples require this env var to be present but does not need to be installed
-ENV MODTRAN_DIR ""
+# Some ISOFIT examples require this env var to be present but does not need to be installed
+ENV MODTRAN_DIR=""
 
-# Prebuild the virtual environments
-# Default environment is isofit. To activate the different one, use: docker run -e ENV_NAME=[env name]
-RUN micromamba create -y -n isofit -c conda-forge python=3.10 &&\
-    micromamba create -y -n test   -c conda-forge python=3.10 &&\
-    micromamba create -y -n nodeps -c conda-forge python=3.10
+# Start the Jupyterlab server
+EXPOSE 8888
+CMD jupyter-lab --ip 0.0.0.0 --no-browser --allow-root --NotebookApp.token='' --NotebookApp.password=''
 
-# Auto activate environments
-ARG MAMBA_DOCKERFILE_ACTIVATE=1
-
-COPY . /isofit
-
-# Setup the test environment
-ENV ENV_NAME test
-RUN micromamba install --name test --yes --file /isofit/recipe/environment_isofit_basic.yml &&\
-    micromamba install --name test --yes --channel conda-forge pip &&\
-    micromamba clean --all --yes &&\
-    pip install ray ndsplines xxhash tensorflow --upgrade
-
-# Install ISOFIT
-ENV ENV_NAME isofit
-RUN micromamba install --name isofit --yes --file /isofit/recipe/environment_isofit_basic.yml &&\
-    micromamba install --name isofit --yes --channel conda-forge pip &&\
-    micromamba clean --all --yes &&\
-    pip install ray ndsplines xxhash tensorflow --upgrade &&\
-    pip install --editable isofit
-
-# Run test examples at startup if not in -it mode
-CMD echo "Example: image_cube" &&\
-    cd /isofit/examples/image_cube/ && bash run_example_cube.sh &&\
-    echo "Example: 20151026_SantaMonica" &&\
-    cd /isofit/examples/20151026_SantaMonica/ && bash run_examples.sh &&\
-    echo "Example: 20171108_Pasadena" &&\
-    cd /isofit/examples/20171108_Pasadena/ && bash run_example_modtran.sh
+# FROM alpine:3.14 AS build -- https://docs.docker.com/build/building/multi-stage/


### PR DESCRIPTION
Remake PR of #372 due to some git base issues. This now only includes the Dockerfile changes.

Original PR text below

---

<h1>Description</h1>
This is a second take on the official Docker image for ISOFIT. This image differs from the first with the following:

- Replaced base image `mambaorg/micromamba:latest` with `rayproject/ray:2.4.0-py310-aarch64`
  - This is Ray's official image and comes with conda installed already. To gain the benefits of mamba, the `conda-libmamba-solver` is installed before installing ISOFIT
  - This stabilizes Ray significantly
- Default user is `ray` instead of `root` which is a better practice
- Removed test environment to reduce bloat
- Sets up a Jupyter-lab server and executes when the Docker is run
  - Simplifies the install and usage for the image

This image has been tested using [NEON ISOFIT Tutorials PR](https://github.com/isofit/isofit-tutorials/pull/1). Successful runs of ISOFIT have been performed, however greater stress-testing would be good to do eventually. 

<s>I'm leaving this as a draft PR as I would like to implement [multi-stage image building](https://docs.docker.com/build/building/multi-stage/) to further optimize the build process and reduce our final ISOFIT image size. This will also enable us to define dev and release stages to further support both dev and end-user environments. For now, the image is built primarily for the end-user. </s> 

Releasing as-is, the above features will be in v3. 

<h1>Changes</h1>

- ✨ New addition
- 🐛 Resolved a bug
- 🗒️ Documentation

<table>
  <tr>
    <th></th>
    <th>Description</th>
  </tr>
  <tr>
    <td>:sparkles:</td>
    <td>Refactored Dockerfile for better practices and stability</td>
  </tr>
  <tr>
    <td>:bug:</td>
    <td>Ray workers hanging/dying resolved using official Ray image</td>
  </tr>
  <tr>
    <td>:sparkles:</td>
    <td>WIP Docker documentation improvements</td>
  </tr>
</table>
