### PR TITLE
Updates to EWT inversion from reflectance

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -447,19 +447,21 @@ def invert_liquid_water(
     r_shoulder: float = 1100,
     lw_init: tuple = (0.02, 0.3, 0.0002),
     lw_bounds: tuple = ([0, 0.5], [0, 1.0], [-0.0004, 0.0004]),
+    ewt_detection_limit: float = 0.5,
     return_abs_co: bool = False,
 ):
     """Given a reflectance estimate, fit a state vector including liquid water path length
     based on a simple Beer-Lambert surface model.
 
     Args:
-        rfl_meas:      surface reflectance spectrum
-        wl:            instrument wavelengths, must be same size as rfl_meas
-        l_shoulder:    wavelength of left absorption feature shoulder
-        r_shoulder:    wavelength of right absorption feature shoulder
-        lw_init:       initial guess for liquid water path length, intercept, and slope
-        lw_bounds:     lower and upper bounds for liquid water path length, intercept, and slope
-        return_abs_co: if True, returns absorption coefficients of liquid water
+        rfl_meas:            surface reflectance spectrum
+        wl:                  instrument wavelengths, must be same size as rfl_meas
+        l_shoulder:          wavelength of left absorption feature shoulder
+        r_shoulder:          wavelength of right absorption feature shoulder
+        lw_init:             initial guess for liquid water path length, intercept, and slope
+        lw_bounds:           lower and upper bounds for liquid water path length, intercept, and slope
+        ewt_detection_limit: upper detection limit for ewt
+        return_abs_co:       if True, returns absorption coefficients of liquid water
 
     Returns:
         solution: estimated liquid water path length, intercept, and slope based on a given surface reflectance
@@ -469,6 +471,10 @@ def invert_liquid_water(
     lw_feature_left = np.argmin(abs(l_shoulder - wl))
     lw_feature_right = np.argmin(abs(r_shoulder - wl))
     wl_sel = wl[lw_feature_left : lw_feature_right + 1]
+
+    # adjust upper detection limit for ewt if specified
+    if ewt_detection_limit != 0.5:
+        lw_bounds[0][1] = ewt_detection_limit
 
     # load imaginary part of liquid water refractive index and calculate wavelength dependent absorption coefficient
     # __file__ should live at isofit/isofit/inversion/

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -117,7 +117,7 @@ def main(args: SimpleNamespace) -> None:
         )
         for n in range(len(line_breaks))
     ]
-    results = [ray.get(result) for result in result_list]
+    [ray.get(result) for result in result_list]
 
     total_time = time.time() - start_time
     logging.info(
@@ -127,8 +127,9 @@ def main(args: SimpleNamespace) -> None:
     )
 
     if args.plot_map:
+        ewt = envi.open(args.output_cwc_file + ".hdr")
         plt.figure()
-        plt.imshow(results[:, :] * 10, vmin=0, vmax=args.ewt_limit * 10, cmap="jet")
+        plt.imshow(ewt[:, :] * 10, vmin=0, vmax=args.ewt_limit * 10, cmap="jet")
         plt.colorbar()
         plt.grid()
         ax = plt.gca()

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -27,6 +27,7 @@ from types import SimpleNamespace
 import click
 import numpy as np
 import ray
+from matplotlib import pyplot as plt
 from osgeo import gdal
 from spectral.io import envi
 
@@ -125,6 +126,24 @@ def main(args: SimpleNamespace) -> None:
         f"{round(rfls[0]*rfls[1]/total_time/n_workers,4)} spectra/s/core"
     )
 
+    if args.plot_map:
+        plt.figure()
+        plt.imshow(results[:, :] * 10, vmin=0, vmax=args.ewt_limit * 10, cmap="jet")
+        plt.colorbar()
+        plt.grid()
+        ax = plt.gca()
+        ax.xaxis.set_tick_params(labelbottom=False)
+        ax.yaxis.set_tick_params(labelleft=False)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.spines["left"].set_visible(False)
+        ax.spines["bottom"].set_visible(False)
+        plt.title("Equivalent Water Thickness\n(EWT) [mm]", size=15)
+        plt.savefig(
+            args.output_cwc_file + ".png", dpi=600, bbox_inches="tight", pad_inches=0
+        )
+        plt.close()
+
 
 @ray.remote
 def run_lines(
@@ -187,6 +206,7 @@ def run_lines(
 @click.option("--n_cores", type=int, default=-1)
 @click.option("--ray_tmp_dir")
 @click.option("--ewt_limit", type=float, default=0.5)
+@click.option("--plot_map", is_flag=True, default=False)
 @click.option(
     "--debug-args",
     help="Prints the arguments list without executing the command",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = isofit
-version = 2.9.9.2
+version = 2.10.0
 author = David R. Thompson, Winston Olson-Duvall, Philip G. Brodrick, and Team
 author_email = david.r.thompson@jpl.nasa.gov
 url = http://github.com/isofit/isofit


### PR DESCRIPTION
This PR adds a few updates to the EWT inversion from reflectance command line tool.

- replaced the hardcoded number of workers with the number of cores, if specified
- added the option `--ewt_limit` to set the upper detection limit of EWT
- added the option `--plot_map` to plot and save an image file of the inverted EWT map on runtime