### PR TITLE
Fix of MODTRAN three albedo method

### DIFF
--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -426,15 +426,18 @@ class ModtranRT(TabularRT):
                 "GMTIME in MODTRAN driver overrides, but IPARM set to 12.  Check"
                 " modtran template."
             )
-        elif param[0]["MODTRANINPUT"]["GEOMETRY"]["IPARM"] == 11 and set(
-            ["solar_azimuth", "solaz", "solar_zenith", "solzen"]
-        ).intersection(set(overrides.keys())):
+        elif param[0]["MODTRANINPUT"]["GEOMETRY"]["IPARM"] == 11 and {
+            "solar_azimuth",
+            "solaz",
+            "solar_zenith",
+            "solzen",
+        }.intersection(set(overrides.keys())):
             raise AttributeError(
                 "Solar geometry (solar az/azimuth zen/zenith) is specified, but IPARM"
                 " is set to 12.  Check MODTRAN template"
             )
 
-        if set(["PARM1", "PARM2"]).intersection(set(overrides.keys())):
+        if {"PARM1", "PARM2"}.intersection(set(overrides.keys())):
             raise AttributeError(
                 "PARM1 and PARM2 keys not supported as LUT dimensions.  Please use"
                 " either solar_azimuth/solaz or solar_zenith/solzen"
@@ -639,16 +642,23 @@ class ModtranRT(TabularRT):
             lvl0["ABSC"] = [float(v) / total_extc550 for v in total_absc]
 
         if self.multipart_transmittance:
+            const_rfl = np.array(np.array(self.test_rfls) * 100, dtype=int)
             # Here we copy the original config and just change the surface reflectance
             param[0]["MODTRANINPUT"]["CASE"] = 0
-            param[0]["MODTRANINPUT"]["SURFACE"]["SURREF"] = self.test_rfls[0]
+            param[0]["MODTRANINPUT"]["SURFACE"]["SURFP"][
+                "CSALB"
+            ] = f"LAMB_CONST_{const_rfl[0]}_PCT"
             param1 = deepcopy(param[0])
             param1["MODTRANINPUT"]["CASE"] = 1
-            param1["MODTRANINPUT"]["SURFACE"]["SURREF"] = self.test_rfls[1]
+            param1["MODTRANINPUT"]["SURFACE"]["SURFP"][
+                "CSALB"
+            ] = f"LAMB_CONST_{const_rfl[1]}_PCT"
             param.append(param1)
             param2 = deepcopy(param[0])
             param2["MODTRANINPUT"]["CASE"] = 2
-            param2["MODTRANINPUT"]["SURFACE"]["SURREF"] = self.test_rfls[2]
+            param2["MODTRANINPUT"]["SURFACE"]["SURFP"][
+                "CSALB"
+            ] = f"LAMB_CONST_{const_rfl[2]}_PCT"
             param.append(param2)
 
         return json.dumps({"MODTRAN": param}), param


### PR DESCRIPTION
For running in multi-transmittance mode, the current MODTRAN config file uses the `["SURFACE"]["SURREF"]` keys to set a constant surface reflectance of 0.0, 0.1, and 0.5.

However, this mode is only compatible with `"SURFTYPE": "REFL_CONSTANT"`. Since we use `"SURFTYPE":  "REFL_LAMBER_MODEL"`, this setting has no effect and both ground reflected and multiple scattered radiance don't change between the three different reflectance cases (see pp. 72-75 of MODTRAN6 manual).

This PR updates the MODTRAN config file to use`LAMB_CONST_xx_PCT`  spectral albedo models from MODTRAN's spec_alb.dat file, with `xx` being the constant reflectance in percent, in case the three albedo method is applied to separate direct and diffuse downward transmittance.