### PR TITLE
Integration work.  

### DIFF
--- a/examples/20171108_Pasadena/configs/ang20171108t184227_beckmanlawn-multimodtran-topoflux.json
+++ b/examples/20171108_Pasadena/configs/ang20171108t184227_beckmanlawn-multimodtran-topoflux.json
@@ -34,7 +34,6 @@
     },
 
     "radiative_transfer": {
-     "topography_model": true,
       "statevector": {
         "H2OSTR": {
           "bounds": [1.5, 2.0],
@@ -61,6 +60,7 @@
       "radiative_transfer_engines": {
         "vswir": {
           "engine_name": "modtran",
+          "topography_model": true,
           "multipart_transmittance": true,
           "wavelength_range":[370,2505],
           "lut_path": "../lut_multi/",

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -60,6 +60,8 @@ class VectorInterpolator:
         lut_interp_types: List[str],
         version="nds-1",
     ):
+        ndshape = tuple([len(x) for x in grid_input]) + (data_input.shape[-1],)
+        data = data_input.reshape(ndshape)
         if version[:3] in ["rg", "nds"]:
             self.method = 1
 
@@ -68,7 +70,7 @@ class VectorInterpolator:
 
             # Lists and arrays are mutable, so copy first
             grid = grid_input.copy()
-            data = data_input.copy()
+            # data = data_input.copy()
 
             # Check if we are using a single grid point. If so, store the grid input.
             if np.prod(list(map(len, grid))) == 1:
@@ -158,7 +160,7 @@ class VectorInterpolator:
             self.method = 2
 
             self.gridtuples = [np.array(t) for t in grid_input]
-            self.gridarrays = data_input
+            self.gridarrays = data
             self.binwidth = [
                 t[1:] - t[:-1] for t in self.gridtuples
             ]  # binwidth arrays for each dimension

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -252,7 +252,6 @@ class ModtranRT(RadiativeTransferEngine):
                         path_rdn
                     )  # path radiance (sum of single and multiple scattering)
 
-        print("mtp: ", self.multipart_transmittance)
         if self.multipart_transmittance:
             (
                 transms,
@@ -800,9 +799,6 @@ class ModtranRT(RadiativeTransferEngine):
 
         # total transmittance
         transms = (t_down_dirs + t_down_difs) * (t_up_dirs + t_up_difs)
-
-        print("transup", transups[0])
-        print("t_down_difs", t_down_difs[0])
 
         return transms, t_down_dirs, t_down_difs, t_up_dirs, t_up_difs, sphalbs
 

--- a/isofit/radiative_transfer/modtran.py
+++ b/isofit/radiative_transfer/modtran.py
@@ -252,6 +252,7 @@ class ModtranRT(RadiativeTransferEngine):
                         path_rdn
                     )  # path radiance (sum of single and multiple scattering)
 
+        print("mtp: ", self.multipart_transmittance)
         if self.multipart_transmittance:
             (
                 transms,
@@ -799,6 +800,9 @@ class ModtranRT(RadiativeTransferEngine):
 
         # total transmittance
         transms = (t_down_dirs + t_down_difs) * (t_up_dirs + t_up_difs)
+
+        print("transup", transups[0])
+        print("t_down_difs", t_down_difs[0])
 
         return transms, t_down_dirs, t_down_difs, t_up_dirs, t_up_difs, sphalbs
 


### PR DESCRIPTION
rhoatm and sphalb now estimated by RTE, transms are still nans.  Some notes:

- Failure mode for the interpolator is to produce an array of NaNs.  TODO: add checks so that bad inputs = verbose failure.
- fm.RT.rt_engines[0].lut['rhoatm'].load().data is the transpose of what I'd expect (which then required transposes throughout the code).  Suggest changing dimensions on save/load
- Previous points array was an n-d array: (a,b,c,d,p), where (a,b,c,d) are the size of each component in lut_grid, and (p) is the number of elements in the given simulated property (e.g. rhoatm, 425).  Current points is (n,p), formed as a more general formulation (to facilitate eventual non-regular grids).  This means that the VectorInterpolator, if one of the current RG forms, requires reshaping to (a,b,c,d,p) for fast interpolation.  This is easily done, and added to the top of the class...but in order for this to work, points (and each of the lut components), needs to be in the right order.  We should enforce this on load.
- trans values in the non-topography case are NaNs, need to figure that out.
- we're carrying soliar_irr around in two places, rte.self.solar_irr, and rte.lut.solar_irr.data.  Suggest sticking to one.
- get function is fixed in rte, though the geometry components are untested (should work though)