### PR TITLE
Fix test failures in `test_cli.py`

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -182,7 +182,7 @@ def apply_oe(args):
     if args.sensor == "ang":
         # parse flightline ID (AVIRIS-NG assumptions)
         dt = datetime.strptime(paths.fid[3:], "%Y%m%dt%H%M%S")
-    if args.sensor == "av3":
+    elif args.sensor == "av3":
         dt = datetime.strptime(paths.fid[3:], "%Y%m%dt%H%M%S")
     elif args.sensor == "avcl":
         # parse flightline ID (AVIRIS-CL assumptions)


### PR DESCRIPTION
Hello ISOFIT maintainers! 👋 

When running `pytest` on both the `main` and `dev` branches, I noticed that the tests in `test/test_cli.py` fail consistently with the same error:
```
Datetime object could not be obtained. Please check file name of input data.
```
(See example error log [here](https://github.com/isofit/isofit/actions/runs/6618204928/job/17976120284#step:6:68).)

The failures appear to be caused by a bug in apply_oe's if-else logic which causes a ValueError to be raised for any AVIRIS-NG data set. I believe this PR should fix the issue.