### PR TITLE
Remove `protobuf` as a dependency?

### DIFF
--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -13,7 +13,6 @@ dependencies:
   - pandas>=0.24
   - pep8>=1.7.1
   - pre-commit
-  - protobuf~=3.19.0
   - pygrib
   - pytest>=3.5.1
   - pyyaml>=5.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ install_requires =
   numpy >= 1.20
   pandas >= 0.24.0
   pep8 >= 1.7.1
-  protobuf ~= 3.19.0
   pytest >= 3.5.1
   pyyaml >= 5.3.2
   ray >= 1.2.0


### PR DESCRIPTION
ISOFIT currently requires a specific version of `protobuf`. This is causing a dependency conflict. For example:

```bash
$ git clone -b dev https://github.com/isofit/isofit.git
$ python -m venv tmpenv
$ source tmpenv/bin/activate
$ pip install ./isofit

ERROR: Cannot install isofit, isofit==2.10.1 and tensorflow because these package versions have conflicting dependencies.

The conflict is caused by:
    isofit 2.10.1 depends on protobuf~=3.19.0
    ray 2.5.1 depends on protobuf!=3.19.5 and >=3.15.3
    tensorflow-macos 2.13.0 depends on protobuf!=4.21.0, !=4.21.1, !=4.21.2, !=4.21.3, !=4.21.4, !=4.21.5, <5.0.0dev and >=3.20.3
```

Can we remove `protobuf` as a dependency? It is not being imported by any ISOFIT code.

`protobuf` appears to have been introduced 18 months ago via #275 to solve an indirect dependency issue, but I suspect that issue has gone away.  Removing `protobuf` from the dependency list resolves the conflict without breaking tests on my machine.