### PR TITLE
Fix `black` CI failure

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -113,7 +113,16 @@ def apply_oe(args):
     """
     use_superpixels = (args.empirical_line == 1) or (args.analytical_line == 1)
 
-    if args.sensor not in ["ang", "avcl", "neon", "prism", "emit", "hyp", "prisma", "av3"]:
+    if args.sensor not in [
+        "ang",
+        "avcl",
+        "neon",
+        "prism",
+        "emit",
+        "hyp",
+        "prisma",
+        "av3",
+    ]:
         if args.sensor[:3] != "NA-":
             raise ValueError(
                 'argument sensor: invalid choice: "NA-test" (choose from '


### PR DESCRIPTION
GitHub Actions CI currently shows a ❌ for every commit because the `black` formatting test fails.

This obviously isn't an important problem, but this PR fixes the issue so we can expect to see a ✅ in future PRs.