### PR TITLE
Docker Updates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Build Dockers
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/isofit
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,8 @@
 name: Build Dockers
 
-on: [push, pull_request_target]
-  # push:
-  #   branches:
-  #     - main
-  #     - dev
-  # pull_request:
-  #   branches:
-  #     - main
-  #     - dev
+on:
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,7 @@ jobs:
           images: |
             jammont/isofit
           tags: |
+            type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,15 @@
 name: Build Dockers
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - main
-      - dev
+  pull_request_target
+  # push:
+  #   branches:
+  #     - main
+  #     - dev
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - dev
 
 concurrency:
   group: ${{ github.workflow }}
@@ -19,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -37,7 +40,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/isofit
+            jammont/isofit
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -51,3 +54,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: jammont/isofit
+          readme-filepath: docs/Docker-README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,15 +1,14 @@
 name: Build Dockers
 
-on:
-  pull_request_target
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - main
-      - dev
+on: [push, pull_request_target]
+  # push:
+  #   branches:
+  #     - main
+  #     - dev
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - dev
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,17 +1,8 @@
 name: Build Dockers
 
-# on:
-#   release:
-#     types: [published]
 on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - main
-      - dev
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}
@@ -34,8 +25,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: jammont
-          password: dckr_pat_KNHBTJgniLz0DVbjsOpTLsYeCX8
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
@@ -61,7 +52,7 @@ jobs:
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: jammont
-          password: dckr_pat_KNHBTJgniLz0DVbjsOpTLsYeCX8
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: jammont/isofit
           readme-filepath: docs/Docker-README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v6
+        with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,17 @@
 name: Build Dockers
 
+# on:
+#   release:
+#     types: [published]
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
 
 concurrency:
   group: ${{ github.workflow }}
@@ -25,8 +34,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: jammont
+          password: dckr_pat_KNHBTJgniLz0DVbjsOpTLsYeCX8
 
       - name: Docker meta
         id: meta
@@ -51,7 +60,7 @@ jobs:
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: jammont
+          password: dckr_pat_KNHBTJgniLz0DVbjsOpTLsYeCX8
           repository: jammont/isofit
           readme-filepath: docs/Docker-README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,14 +2,14 @@ name: Build Dockers
 
 on:
   pull_request_target
-  # push:
-  #   branches:
-  #     - main
-  #     - dev
-  # pull_request:
-  #   branches:
-  #     - main
-  #     - dev
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
 
 concurrency:
   group: ${{ github.workflow }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN micromamba config prepend channels conda-forge &&\
     micromamba install --name isofit ipykernel &&\
     echo "micromamba activate isofit" >> ~/.bashrc
 
-ENV PATH /opt/conda/envs/isofit/bin:$PATH
+ENV PATH=/opt/conda/envs/isofit/bin:$PATH
 
 # Install ISOFIT and extra files
 RUN pip install -e isofit &&\
@@ -28,7 +28,7 @@ RUN pip install -e isofit &&\
     isofit build
 
 # Explicitly set the shell to bash so the Jupyter server defaults to it
-ENV SHELL ["/bin/bash", "-l", "-c"]
+ENV SHELL=["/bin/bash", "-l", "-c"]
 
 # Ray Dashboard port
 EXPOSE 8265

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install -e isofit &&\
     isofit build
 
 # Explicitly set the shell to bash so the Jupyter server defaults to it
-ENV SHELL=["/bin/bash", "-l", "-c"]
+ENV SHELL ["/bin/bash", "-l", "-c"]
 
 # Ray Dashboard port
 EXPOSE 8265

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,24 +15,26 @@ COPY --chown=mambauser:mambauser . isofit/
 RUN micromamba config prepend channels conda-forge &&\
     micromamba update --all --yes &&\
     micromamba create --name isofit python=3.10 &&\
-    micromamba install --name base nb_conda_kernels jupyterlab &&\
+    micromamba install --name base jupyterlab &&\
     micromamba install --name isofit --file isofit/recipe/environment_isofit_basic.yml &&\
-    micromamba install --name isofit ipykernel &&\
+    micromamba install --name isofit ipykernel ipywidgets &&\
     echo "micromamba activate isofit" >> ~/.bashrc
 
 ENV PATH=/opt/conda/envs/isofit/bin:$PATH
 
 # Install ISOFIT and extra files
-RUN pip install -e isofit &&\
+RUN python -m ipykernel install --user --name isofit &&\
+    pip install -e isofit &&\
     isofit -b . download all &&\
     isofit build
 
-# Explicitly set the shell to bash so the Jupyter server defaults to it
-ENV SHELL ["/bin/bash", "-l", "-c"]
+# Jupyter needs this to access the terminal
+ENV SHELL="/bin/bash"
 
 # Ray Dashboard port
 EXPOSE 8265
 
 # Start the Jupyterlab server
 EXPOSE 8888
-CMD isofit/scripts/startJupyter.sh
+
+CMD ["jupyter-lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root", "--ServerApp.token=''", "--ServerApp.password=''", "examples/isotuts/NEON/neon.ipynb"]

--- a/docs/Docker-README.md
+++ b/docs/Docker-README.md
@@ -1,0 +1,48 @@
+These are the official container images for the [ISOFIT](https://github.com/isofit/isofit) package. They come pre-configured with everything a user may need to get started using ISOFIT and executing its examples.
+
+Tags
+----
+- `latest` - Most recent released ISOFIT version
+- `3.x.x` - Specific release builds
+
+Getting Started
+---------------
+
+
+Start by pulling the image:
+
+```bash
+$ docker pull jammont/isofit:latest
+```
+
+This image is default tagged as `jammont/isofit`. As such, to use it run:
+
+```bash
+$ docker run -it --rm jammont/isofit bash
+```
+
+- `-it` - Run in `[i]nteractive` and `[t]erminal` modes, which will build a container and place the user inside of it.
+- `--rm` - Removes the container once finished. If you intend to modify the container between sessions, remove this flag.
+- `jammont/isofit` - The `tag` name of the image. If you built your own ISOFIT image using a different tag, be sure to replace this string.
+- `bash` - The command to run for `-it`. Using `bash` here will invoke a bash instance for the user. If you wanted to launch a specific script without entering the container, you could replace this command.
+
+After running the above command, you will placed inside the container as the root user. From here you may proceed to use ISOFIT as you need.
+
+You may need to attach volumes to the container at runtime in order to access files external to the container. For instance:
+
+```
+$ docker run --rm -it -v /host/path:/container/path jammont/isofit bash
+```
+
+This will provide `/host/path` available inside of the container as `/container/path`. As such, any changes made inside the container to this path or its contents will be reflected on the host.
+
+Additional examples for executing ISOFIT interactively:
+
+```bash
+# Print version
+$ docker run --rm -it jammont/isofit isofit --version
+
+# Execute an example
+$ docker run --rm -it jammont/isofit bash examples/20151026_SantaMonica/run.sh
+$ docker run --rm -it jammont/isofit bash examples/image_cube/small/analytical.sh
+```

--- a/docs/Docker-README.md
+++ b/docs/Docker-README.md
@@ -7,8 +7,6 @@ Tags
 
 Getting Started
 ---------------
-
-
 Start by pulling the image:
 
 ```bash
@@ -46,3 +44,16 @@ $ docker run --rm -it jammont/isofit isofit --version
 $ docker run --rm -it jammont/isofit bash examples/20151026_SantaMonica/run.sh
 $ docker run --rm -it jammont/isofit bash examples/image_cube/small/analytical.sh
 ```
+
+Jupyter
+-------
+The default run command for the container is to start up a Jupyterlab server on internal port 8888.
+To connect to this port and make it accessible via the browser, pass the `-p [host]:8888` parameter:
+
+```
+$ docker run --rm -p 8888:8888 jammont/isofit
+```
+
+This will start up the Jupyterlab server on port `8888`. Navigate to `127.0.0.1:8888` in a web browser to start using the server.
+
+To shutdown, hit CTRL-C three times in the running terminal.

--- a/docs/Docker-README.md
+++ b/docs/Docker-README.md
@@ -16,11 +16,12 @@ $ docker pull jammont/isofit:latest
 This image is default tagged as `jammont/isofit`. As such, to use it run:
 
 ```bash
-$ docker run -it --rm jammont/isofit bash
+$ docker run -it --rm --shm-size=16gb jammont/isofit bash
 ```
 
 - `-it` - Run in `[i]nteractive` and `[t]erminal` modes, which will build a container and place the user inside of it.
 - `--rm` - Removes the container once finished. If you intend to modify the container between sessions, remove this flag.
+- `--shm-size=16gb` - Expands the shared memory space for the container. This is used by Ray and, if not set, may have significant performance impacts. The larger the better, this may need to be tweaked to your system.
 - `jammont/isofit` - The `tag` name of the image. If you built your own ISOFIT image using a different tag, be sure to replace this string.
 - `bash` - The command to run for `-it`. Using `bash` here will invoke a bash instance for the user. If you wanted to launch a specific script without entering the container, you could replace this command.
 
@@ -41,8 +42,8 @@ Additional examples for executing ISOFIT interactively:
 $ docker run --rm -it jammont/isofit isofit --version
 
 # Execute an example
-$ docker run --rm -it jammont/isofit bash examples/20151026_SantaMonica/run.sh
-$ docker run --rm -it jammont/isofit bash examples/image_cube/small/analytical.sh
+$ docker run --rm -it --shm-size=16gb jammont/isofit bash examples/20151026_SantaMonica/run.sh
+$ docker run --rm -it --shm-size=16gb jammont/isofit bash examples/image_cube/small/analytical.sh
 ```
 
 Jupyter
@@ -51,9 +52,9 @@ The default run command for the container is to start up a Jupyterlab server on 
 To connect to this port and make it accessible via the browser, pass the `-p [host]:8888` parameter:
 
 ```
-$ docker run --rm -p 8888:8888 jammont/isofit
+$ docker run --rm --shm-size=16gb -p 8888:8888 jammont/isofit
 ```
 
 This will start up the Jupyterlab server on port `8888`. Navigate to `127.0.0.1:8888` in a web browser to start using the server.
 
-To shutdown, hit CTRL-C three times in the running terminal.
+To shutdown, hit CTRL-C in the running terminal.

--- a/docs/source/custom/docker.rst
+++ b/docs/source/custom/docker.rst
@@ -1,44 +1,66 @@
 ISOFIT Docker
 =============
+The official container images are located on Dockerhub under [jammont/isofit](https://hub.docker.com/r/jammont/isofit).
+They come pre-configured with everything a user may need to get started using ISOFIT and executing its examples.
 
-The ISOFIT team provides a prebuilt Docker image that can be used for any purpose.
+Tags
+----
+- `latest` - Most recent released ISOFIT version
+- `3.x.x` - Specific release builds
 
-This image uses [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html) to provide two virtual environments:
+Images are currently built for `amd64` and `arm64` architectures.
 
-- `isofit` - The default environment that has ISOFIT installed alongside all of its dependencies.
-- `test` - The testing environment that does not include ISOFIT but does include its dependencies.
-- `nodeps` - An additional testing environment that does not include ISOFIT or its dependencies. This is primarily used for testing the installation process of ISOFIT.
 
-All three environments use Python 3.10. To activate an environment at container runtime, provide the flag `-e ENV_NAME=[env name]`.
-
-Additionally, 6S and sRTMnet are preinstalled under `/6sv-2.1` and `/sRTMnet_v100` respectively. ISOFIT is installed under `/isofit`.
-
-How to Use
-----------
+Getting Started
+---------------
 
 Start by pulling the image:
 
 .. code-block:: bash
-  docker pull jammont/isofit:latest
+  $ docker pull jammont/isofit:latest
 
 This image is default tagged as `jammont/isofit`. As such, to use it run:
 
 .. code-block:: bash
   $ docker run -it --rm jammont/isofit bash
 
-- `-it` - Run in `interactive` and `terminal` modes, which will build a container and place the user inside of it.
+- `-it` - Run in `[i]nteractive` and `[t]erminal` modes, which will build a container and place the user inside of it.
 - `--rm` - Removes the container once finished. If you intend to modify the container between sessions, remove this flag.
 - `jammont/isofit` - The `tag` name of the image. If you built your own ISOFIT image using a different tag, be sure to replace this string.
-- `bash` - The command to run for `-it`. Using `bash` here will invoke a bash instance for the user. If you wanted to launch a specific script without entering the container, you could replace this command eg. `python /some/path/to/a/script.py`
+- `bash` - The command to run for `-it`. Using `bash` here will invoke a bash instance for the user. If you wanted to launch a specific script without entering the container, you could replace this command.
 
 After running the above command, you will placed inside the container as the root user. From here you may proceed to use ISOFIT as you need.
 
 You may need to attach volumes to the container at runtime in order to access files external to the container. For instance:
 
 .. code-block:: bash
-  docker run -it -v /host/path:/container/path --rm jammont/isofit bash
+  $ docker run --rm -it -v /host/path:/container/path jammont/isofit bash
 
 This will provide `/host/path` available inside of the container as `/container/path`. As such, any changes made inside the container to this path or its contents will be reflected on the host.
+
+Additional examples for executing ISOFIT interactively:
+
+.. code-block:: bash
+  # Print version
+  $ docker run --rm -it jammont/isofit isofit --version
+
+  # Execute an example
+  $ docker run --rm -it jammont/isofit bash examples/20151026_SantaMonica/run.sh
+  $ docker run --rm -it jammont/isofit bash examples/image_cube/small/analytical.sh
+
+
+Jupyter
+-------
+The default run command for the container is to start up a Jupyterlab server on internal port 8888.
+To connect to this port and make it accessible via the browser, pass the `-p [host]:8888` parameter:
+
+.. code-block:: bash
+  $ docker run --rm -p 8888:8888 jammont/isofit
+
+This will start up the Jupyterlab server on port `8888`. Navigate to `127.0.0.1:8888` in a web browser to start using the server.
+
+To shutdown, hit CTRL-C three times in the running terminal.
+
 
 Building the Image
 ------------------
@@ -52,6 +74,7 @@ For example, to build a specific branch of ISOFIT, the following may be performe
   git checkout [branch]
   docker build --tag [branch] .
 
-This will build a container and tag it as [branch]. This tag can anything as it is local to your device.
+This will build a container and tag it as `[branch]`. This tag can anything as it is local to your device.
 
-Once the container is built, refer to the `How to Use` section for next steps.
+Once the container is built, refer to the `Getting Started` section for next steps.
+Replace the default `jammont/isofit` tag with the tag you chose for your newly built image.

--- a/docs/source/custom/docker.rst
+++ b/docs/source/custom/docker.rst
@@ -22,10 +22,11 @@ Start by pulling the image:
 This image is default tagged as `jammont/isofit`. As such, to use it run:
 
 .. code-block:: bash
-  $ docker run -it --rm jammont/isofit bash
+  $ docker run -it --rm --shm-size=16gb jammont/isofit bash
 
 - `-it` - Run in `[i]nteractive` and `[t]erminal` modes, which will build a container and place the user inside of it.
 - `--rm` - Removes the container once finished. If you intend to modify the container between sessions, remove this flag.
+- `--shm-size=16gb` - Expands the shared memory space for the container. This is used by Ray and, if not set, may have significant performance impacts. The larger the better, this may need to be tweaked to your system.
 - `jammont/isofit` - The `tag` name of the image. If you built your own ISOFIT image using a different tag, be sure to replace this string.
 - `bash` - The command to run for `-it`. Using `bash` here will invoke a bash instance for the user. If you wanted to launch a specific script without entering the container, you could replace this command.
 
@@ -45,8 +46,8 @@ Additional examples for executing ISOFIT interactively:
   $ docker run --rm -it jammont/isofit isofit --version
 
   # Execute an example
-  $ docker run --rm -it jammont/isofit bash examples/20151026_SantaMonica/run.sh
-  $ docker run --rm -it jammont/isofit bash examples/image_cube/small/analytical.sh
+  $ docker run --rm -it --shm-size=16gb jammont/isofit bash examples/20151026_SantaMonica/run.sh
+  $ docker run --rm -it --shm-size=16gb jammont/isofit bash examples/image_cube/small/analytical.sh
 
 
 Jupyter
@@ -55,11 +56,11 @@ The default run command for the container is to start up a Jupyterlab server on 
 To connect to this port and make it accessible via the browser, pass the `-p [host]:8888` parameter:
 
 .. code-block:: bash
-  $ docker run --rm -p 8888:8888 jammont/isofit
+  $ docker run --rm --shm-size=16gb -p 8888:8888 jammont/isofit
 
 This will start up the Jupyterlab server on port `8888`. Navigate to `127.0.0.1:8888` in a web browser to start using the server.
 
-To shutdown, hit CTRL-C three times in the running terminal.
+To shutdown, hit CTRL-C in the running terminal.
 
 
 Building the Image

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,7 @@
    custom/installation.rst
    custom/data.rst
    custom/best_practices.rst
+   custom/docker.rst
 
 .. toctree::
    :Caption: The Code

--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -16,7 +16,6 @@ dependencies:
   - pytest>=3.5.1
   - python-xxhash<3
   - pyyaml>=5.1.2
-  - ray-default
   - scikit-image>=0.17.0
   - scikit-learn>=0.19.1
   - scipy>=1.3.0
@@ -26,4 +25,5 @@ dependencies:
   - xarray<2024.1.1
 
   - pip:
+    - ray[default]
     - sphinx-autodoc-typehints>=1.19.4

--- a/scripts/startJupyter.sh
+++ b/scripts/startJupyter.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+jupyter-lab --ip 0.0.0.0 --no-browser --allow-root --ServerApp.token='' --ServerApp.password=''

--- a/scripts/startJupyter.sh
+++ b/scripts/startJupyter.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-jupyter-lab --ip 0.0.0.0 --no-browser --allow-root --ServerApp.token='' --ServerApp.password=''


### PR DESCRIPTION
This PR finally implements the ability to build our Docker images for multiple architectures using only one Dockerfile.

The command to build the ARM64 and AMD64 images is:
```bash
docker buildx build --platform linux/amd64,linux/arm64 -t jammont/isofit:latest . --push
```

Additionally developed a new github workflow to auto build and push these images on each ISOFIT release. This has been tested and working.

https://hub.docker.com/r/jammont/isofit