### PR TITLE
Fixes multi MODTRAN template for Pasadena example.

### DIFF
--- a/examples/20171108_Pasadena/configs/ang20171108t184227_multimodtran.json
+++ b/examples/20171108_Pasadena/configs/ang20171108t184227_multimodtran.json
@@ -39,11 +39,12 @@
           "TRUEAZ": 0
         },
         "SURFACE": {
-          "SURFTYPE": "REFL_CONSTANT",
-          "SURREF": 0,
+          "SURFTYPE": "REFL_LAMBER_MODEL",
           "GNDALT": 0.35,
           "NSURF": 1,
-          "SALBFL": ""
+          "SURFP": {
+            "CSALB": "LAMB_CONST_0_PCT"
+          }
         },
         "SPECTRAL": {
           "V1": 350.0,


### PR DESCRIPTION
This updates the surface reflectance characterization in the multi MODTRAN template to fix the example workflow.