### PR TITLE
`pygrib` is an unlisted dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
   numpy >= 1.20
   pandas >= 0.24.0
   pep8 >= 1.7.1
+  pygrib
   pytest >= 3.5.1
   pyyaml >= 5.3.2
   ray >= 1.2.0


### PR DESCRIPTION
_For https://github.com/isofit/isofit/issues/418._

Currently the tests operate inside of a Docker container, and `$ conda install isofit`:

https://github.com/isofit/isofit/blob/db3e787560f43519f20d17b6efa3a3865ad23d3e/Dockerfile#L20

prior to `$ pip install`-ing the local version being tested:

https://github.com/isofit/isofit/blob/db3e787560f43519f20d17b6efa3a3865ad23d3e/Dockerfile#L21

The [`conda` package correctly lists `pygrib` as a dependency](https://github.com/conda-forge/isofit-feedstock/blob/1f5811eb96e3150f9d2672cdc4d577e016a8bfc7/recipe/meta.yaml#L28), so I believe that is why the test suite does not currently fail.