### PR TITLE
Instructions for dev environment setup and a collection of setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dist/*.whl
 .pytest_cache/
 isofit/test/output/*.txt
 tests/output/*.txt
+logs/
 
 # Ignore documentation files
 docs/_build/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ local/
 
 # Additional external libraries
 6sv-2.1/
+
+# Data dependencies
+sRTMnet_v100/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ docs/html/_sources/
 
 # Ignore local testing directories
 local/
+
+# Additional external libraries
+6sv-2.1/

--- a/docs/source/custom/CONTRIBUTING.rst
+++ b/docs/source/custom/CONTRIBUTING.rst
@@ -18,6 +18,9 @@ at the addresses given below, and we can coordinate efforts.  Our general policy
 is to for the maintainers to delegate technical authority to individuals to make
 changes and additions to specific topics.
 
+.. contents:: Table of Contents
+    :depth: 2
+
 
 Getting Started
 ---------------
@@ -43,6 +46,30 @@ example, if you are working on issue #314 you would run:
 .. code::
 
   git checkout -b 314-update-docs-libradtran
+
+
+Developer Environment
+---------------------
+
+ISOFIT has a number of dependencies that complicate setting up a developer
+environment. Ultimately the goal is to develop within a Python virtual
+environment with a compliant set of dependencies. While ISOFIT is a Python
+library with mostly pure-Python dependencies, some dependencies in turn require
+non-Python libraries. On Ubuntu, these dependencies can often be satisfied by
+``$ apt`` or ``$ apt-get``, and on MacOS the `Homebrew <https://brew.sh/>`_
+package manager is a common choice.
+
+Generally, the steps outlined in `setup-devenv.sh <setup-devenv.sh>`_ can be
+followed to create a virtual environment, but there are just too many variables
+to confidently provide a per-platform script to set up a developer environment.
+A good course of action is to follow that script, address any ``$ pip`` errors,
+and try to run some tests. GDAL in particular may install successfully but
+fail when running tests.
+
+The CI system can provide some guidance as well, but note that this system
+runs in isolation, so the exact commands are not necessarily appropriate to
+execute in your environment.
+
 
 Unit Tests
 ----------

--- a/docs/source/custom/CONTRIBUTING.rst
+++ b/docs/source/custom/CONTRIBUTING.rst
@@ -71,14 +71,14 @@ runs in isolation, so the exact commands are not necessarily appropriate to
 execute in your environment.
 
 
-Unit Tests
-----------
+Testing
+-------
 
-Unit tests are implemented in the tests/ subdirectory, and use the pytest library.  You can run the tests from the base directory simply by running:
-
-.. code::
-
-  pytest
+Tests live in `isofit/tests/ <isofit/tests/>`_, and are executed using
+``pytest``. Some tests require specific environment variables to be set, so
+the `run-tests.sh <run-tests.sh>`_ script can be used to invoke ``pytest`` with
+the appropriate environment variables. It is a drop-in replacement for the
+``$ pytest`` executable, so users can add flags as they wish.
 
 Our development strategy employs continuous integration and unit testing to validate all changes.  We appreciate your writing additional tests for new modifications or features.  In the interest of validating your code, please also be sure to run realistic examples like this:
 

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -32,13 +32,43 @@ or
     conda install -c conda-forge isofit
 
 
-Install from pip
-****************
-Not recommended, as package dependencies may not fully resolve.
+Install with ``pip``
+********************
+
+.. note::
+
+    The commands below use ``$ pip``, however ``$ python -m pip`` or is often a
+    safer choice. It is possible for the ``$ pip`` executable to point to a
+    different version of Python than the ``$ python`` executable. Using
+    ``$ python -m pip`` at least ensures that the package is installed against
+    the Python interpreter in use. The issue is further compounded on systems
+    that also have ``$ python3`` and ``$ pip3`` executables, or executables for
+    specific versions of Python like ``$ python3.11`` and ``$ pip3.11``.
+
+ISOFIT can be installed from the `Python Package Index <https://pypi.org/project/isofit/>`_
+with:
 
 .. code-block:: bash
 
-    pip install isofit
+    $ pip install isofit
+
+In order to support a wide variety of environments, ISOFIT does not overly
+constrain its dependencies, however this means that in some cases ``pip`` can
+take a very long time to resolve ISOFIT's dependency tree. Some users may need
+to provide constraints for specific packages, or install ISOFIT last. In
+particular, ``tensorflow`` can be troublesome. Users might have success with:
+
+.. code-block:: bash
+
+    $ pip install numpy tensorflow
+    $ pip install isofit
+
+``pip`` also supports installing from a remote git repository – this installs
+against the ``main`` branch:
+
+.. code-block:: bash
+
+    $ pip install "git+https://github.com/isofit/isofit.git@main"
 
 
 Install from github

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -1,6 +1,9 @@
 Installation
 ============
 
+.. contents:: Table of Contents
+    :depth: 2
+
 Install from conda-forge
 ************************
 Recommended approach!

--- a/download-and-build-6s.sh
+++ b/download-and-build-6s.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+
+# Download, modify, and build the 6S library.
+
+
+set -x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+SIXS_DIR="6sv-2.1"
+SIXS_MAKEFILE_PATH="${SIXS_DIR}/Makefile"
+
+
+# If the 'Makefile' doesn't exist then 6s probably has not been downloaded.
+# Given that the project is built with '$ make' it seems prudent to always run
+# '$ make', but only download the library if necessary.
+if [ ! -f "${SIXS_MAKEFILE_PATH}" ]; then
+
+  mkdir -p "${SIXS_DIR}"
+  wget \
+    --no-verbose \
+    --directory-prefix "${SIXS_DIR}" \
+    https://github.com/ashiklom/isofit/releases/download/6sv-mirror/6sv-2.1.tar
+
+fi
+
+
+# Build 6s.
+#
+# Run as a subprocess to allow 'cd'-ing into a subdirectory while automatically
+# returning to the current working directory once the subprocess exits.
+(
+
+  cd "${SIXS_DIR}"
+  tar -xf 6sv-2.1.tar
+
+  # Modify build flags
+  cp Makefile Makefile.bak
+  sed -i -e 's/FFLAGS.*/& -std=legacy/' Makefile
+
+  # Historically '$ nproc' is not the most portable command, but that may have
+  # changed. This could be replaced with:
+  #   python -c 'import os; print(os.cpu_count())'
+  make -j "$(nproc)"
+)

--- a/download-and-unpack-sRTMnet.sh
+++ b/download-and-unpack-sRTMnet.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+
+# Download and unpack sRTM net.
+
+
+set -x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+SRTMNET_DIR="sRTMnet_v100"
+SRTMNET_PATH="${SRTMNET_DIR}/sRTMnet_v100_aux.npz"
+SRTMNET_ZIPFILENAME="sRTMnet_v100.zip"
+
+# If the desired sRTM net file already exists just assume it is correct and do
+# nothing.
+if [ -f "${SRTMNET_PATH}" ]; then
+  echo "sRTM net already exists - nothing to do: ${SRTMNET_PATH}"
+  exit 0
+fi
+
+mkdir -p "${SRTMNET_DIR}"
+
+# Download sRTMnet file
+wget \
+  --no-verbose \
+  --directory-prefix "${SRTMNET_DIR}" \
+  "https://zenodo.org/record/4096627/files/${SRTMNET_ZIPFILENAME}"
+
+
+# Unpack and delete some extraneous files.
+#
+# Run as a subprocess to allow 'cd'-ing into a subdirectory while automatically
+# returning to the current working directory once the subprocess exits.
+(
+
+  cd "${SRTMNET_DIR}"
+  unzip "${SRTMNET_DIR}"
+
+  # Remove MacOS specific files that the original author erroneously included
+  # in the archive.
+  rm -rf "__MACOSX"
+  rm -f .DS_Store sRTMnet_v100/.DS_Store
+
+  # The archive is quite large and no longer needed.
+  rm "${SRTMNET_ZIPFILENAME}"
+
+)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+
+# Drop-in replacement for '$ pytest' that sets some environment variables
+# required by the test suite. Could be replaced by the 'pytest-env' plugin.
+
+
+set -x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+# Use absolute file paths for environment variables. Note that
+# 'EMULATOR_PATH' is not actually a filepath, so have to be a bit
+# more clever. Could possibly use the 'pytest-env' to make life better
+# for developers, and set this in 'pytest.ini'.
+EMULATOR_PATH="$(pwd)/sRTMnet_v100/sRTMnet_v100" \
+SIXS_DIR=$(realpath 6sv-2.1) \
+python3 -m pytest "$@"

--- a/setup-devenv.sh
+++ b/setup-devenv.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+
+# This script serves as a reference for how to set up a developer environment.
+# Some packages, like GDAL, must be installed prior to running this script.
+# On Ubuntu these packages are likely installed via '$ apt' or '$ apt-get',
+# and on MacOS Homebrew is a common choice. Developers should read through
+# this script, and the other scripts it invokes, and determine if it is
+# appropriate to execute for their environment. At a high-level the steps
+# should be matched, but the specific commands may need to be modified.
+
+
+set -x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+VENV_PATH="venv"
+
+
+# Do not attempt to modify an existing virtual environment. We do not know what
+# it contains.
+if [ -d "${VENV_PATH}" ]; then
+  echo "Virtual environment already exists: ${VENV_PATH}"
+  exit 0
+fi
+
+# Create virtual environment.
+python3 -m venv "${VENV_PATH}"
+
+# Activate virtual environment. SUPER CRITICAL that this activation happens.
+# Some shell scripts assume they are in an isolated environment.
+source "${VENV_PATH}/bin/activate"
+if [ "${VIRTUAL_ENV}" == "" ]; then
+  echo "ERROR: Virtual environment did not activate: ${VENV_PATH}"
+  exit 1
+fi
+
+# Useful for debugging
+which python3
+python3 --version
+
+# Install and upgrade packaging dependencies. The presence of 'wheel' triggers
+# a lot of the emerging Python packaging ecosystem changes (PEP-517).
+python3 -m pip install setuptools wheel --upgrade
+
+# Install ISOFIT.
+python3 -m pip install -e ".[dev]"
+
+# Install commit hooks.
+python3 -m pre_commit install
+
+# Download and unpack additional dependencies.
+./download-and-unpack-sRTMnet.sh
+./download-and-build-6s.sh


### PR DESCRIPTION
_For https://github.com/isofit/isofit/issues/418_

Happy to make adjustments as the project maintainers see fit.

This PR adds:

* `.github/workflows/install-python-gdal.sh` - Install the `gdal` Python package. Primarily supports a future change to the CI system, but can also be used during dev environment setup.
* `download-and-build-6s.sh` - Download and build 6s.
* `download-and-unpack-sRTMnet.sh` - Download and unpack sRTM net data.
* `setup-devenv.sh` - A script for setting up a developer environment that _should_ work for most people.
* `run-tests.sh` - Sets appropriate environment variables prior to running tests, and is otherwise a drop-in replacement for `$ pytest`.

It also adds:

* Instructions for how to install `isofit` via `$ pip`.
* Instructions for how to set up a developer environment.

and removes:

* `logs/pytest_logs.txt` from the repository. The file is empty so it is not clear to me why this was checked in, but possibly I am missing something?