### PR TITLE
Fix 'ray' imports

### DIFF
--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -26,11 +26,11 @@ from types import SimpleNamespace
 
 import click
 import numpy as np
-import ray
 from matplotlib import pyplot as plt
 from osgeo import gdal
 from spectral.io import envi
 
+from isofit import ray
 from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
 from isofit.inversion.inverse_simple import invert_liquid_water

--- a/isofit/wrappers/ray.py
+++ b/isofit/wrappers/ray.py
@@ -14,8 +14,6 @@ $ ISOFIT_DEBUG=1 python isofit.py ...
 """
 import logging
 
-import ray
-
 Logger = logging.getLogger("isofit/wrappers/ray")
 
 


### PR DESCRIPTION
I see most modules expect to get `ray` from:

```python
from isofit import ray
```

in order to possibly get the local-only wrapper. If this is a project expectation, I think it would be wise to implement something in the test suite that looks for improper imports. Thoughts?

I also removed one unused `import ray`.