### PR TITLE
Error when 6S fails

### DIFF
--- a/isofit/radiative_transfer/look_up_tables.py
+++ b/isofit/radiative_transfer/look_up_tables.py
@@ -49,7 +49,9 @@ def spawn_rt(cmd, local_dir=None):
     # starting simultaneously
     time.sleep(float(np.random.random(1)) * 2)
 
-    subprocess.call(cmd, shell=True, cwd=local_dir)
+    exit_code = subprocess.call(cmd, shell=True, cwd=local_dir)
+    if exit_code != 0:
+        raise subprocess.SubprocessError(cmd)
 
 
 ### Classes ###


### PR DESCRIPTION
Currently, it is possible for 6S to totally fail without any indication. As far as I can tell the failure will eventually be discovered due to a missing LUT file, but is there any reason to not raise an exception if one of these commands fail?