### PR TITLE
Fix for broken readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,7 @@ python:
   install:
     - method: pip
       path: .
+    - requirements: docs/source/requirements.txt
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,5 +1,5 @@
-sphinx>=3.1.0
-sphinx_rtd_theme
+sphinx==7.2.6
+sphinx_rtd_theme==2.0.0
 sphinxcontrib-napoleon
 sphinxcontrib-napoleon
-sphinx-autodoc-typehints>=1.11.0
+sphinx_autodoc_typehints==1.25.2

--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -21,6 +21,7 @@ dependencies:
   - scikit-learn>=0.19.1
   - scipy>=1.3.0
   - spectral>=0.19
+  - sphinx_rtd_theme
   - tensorflow >=2.0.1
   - utm
 


### PR DESCRIPTION
ISOFIT's readthedocs build has been failing since October last year. This PR updates some needed `sphinx` packages and infrastructure to fix the broken build.

@pgbrodrick, could you also resynchronize the webhook for the readthedocs GitHub integration? I appears that I don't have the respective access rights to do that (error message `Webhook activation failed. Make sure you have the necessary permissions`). Background is that previously manually configured webhooks from integrations did not have a secret attached to them. In order to improve security, readthedocs has deployed an update so that all new integrations will be created with a secret, and they're deprecating old integrations without a secret. We must migrate our integrations by January 31, 2024, when they will stop working. In order to do so, you'd simply navigate to ISOFIT's [integration settings](https://urldefense.us/v3/__https://readthedocs.org/dashboard/isofit/integrations/124764/__;!!PvBDto6Hs4WbVuu7!MXTmarSU2mgvh7LYvQl1g_L2POOfsHyiy_h4pT7CPfWgURFCadpAMR56Op-sQOEtbqfY9599xRo1wB-5AO4jgh3QgkAI$) and click on "Resync webhook" to generate a new secret, and then update the secret in ISOFIT's GitHub settings as well.