### PR TITLE
CLI for downloading extras

### DIFF
--- a/isofit/utils/downloads.py
+++ b/isofit/utils/downloads.py
@@ -1,0 +1,59 @@
+"""
+Implements the `isofit download` subcommands
+"""
+
+import click
+
+import isofit
+
+
+@click.group(invoke_without_command=True)
+def download():
+    """\
+    Download extra ISOFIT files that do not come with the default installation
+    """
+    pass
+
+
+@download.command(name="data")
+@click.option(
+    "-o",
+    "--output",
+    default=f"{isofit.root}/data",
+    help="Directory to download ISOFIT data files to",
+)
+def data(output):
+    """\
+    Downloads the extra ISOFIT data files from the repository [].
+    """
+    click.echo(f"Downloading ISOFIT data to: {output}")
+
+    ...
+
+    click.echo("Done")
+
+
+@download.command(name="examples")
+@click.option(
+    "-o",
+    "--output",
+    default=f"{isofit.root}/examples",
+    help="Directory to download ISOFIT examples to",
+)
+def examples(output):
+    """\
+    Downloads the ISOFIT examples from the repository [].
+    """
+    click.echo(f"Downloading ISOFIT examples to: {output}")
+
+    ...
+
+    click.echo("Done")
+
+
+if __name__ == "__main__":
+    download()
+else:
+    from isofit import cli
+
+    cli.add_command(download)

--- a/isofit/utils/downloads.py
+++ b/isofit/utils/downloads.py
@@ -2,9 +2,49 @@
 Implements the `isofit download` subcommands
 """
 
+import io
+import os
+import zipfile
+from functools import partial
+
 import click
+import requests
+from github import Github
 
 import isofit
+
+
+def downloadRelease(repo, output, name):
+    """
+    Downloads a specific tagged release from a given repository
+
+    Parameters
+    ----------
+    repo: str
+        Repository URL
+    output: str
+        Directory to download to
+    name: str
+        Name of the directory. The downloaded directory is based off the Github name,
+        so this is used to rename it
+    """
+    git = Github()
+    repo = git.get_repo(repo)
+    latest = repo.get_latest_release()
+    url = latest.zipball_url
+
+    click.echo(f"Downloading {url}")
+
+    req = requests.get(url)
+    with zipfile.ZipFile(io.BytesIO(req.content)) as zip:
+        temp = zip.infolist()[0].filename
+        zip.extractall(output)
+
+    os.rename(f"{output}/{temp}", f"{output}/{name}")
+    click.echo(f"Now available at: {output}/{name}")
+
+
+# Main command
 
 
 @click.group(invoke_without_command=True)
@@ -15,38 +55,40 @@ def download():
     pass
 
 
-@download.command(name="data")
-@click.option(
-    "-o",
-    "--output",
-    default=f"{isofit.root}/data",
-    help="Directory to download ISOFIT data files to",
+# Shared click options
+
+output = partial(click.option, "-o", "--output", default=isofit.root, show_default=True)
+tag = click.option(
+    "-t", "--tag", default=f"latest", help="Release tag to pull", show_default=True
 )
+
+# Subcommands
+
+
+@download.command(name="data")
+@output(help="Root directory to download data files to, ie. [path]/data")
+# @tag
 def data(output):
     """\
-    Downloads the extra ISOFIT data files from the repository [].
+    Downloads the extra ISOFIT data files from the repository https://github.com/isofit/isofit-data.
     """
-    click.echo(f"Downloading ISOFIT data to: {output}")
+    click.echo(f"Downloading ISOFIT data")
 
-    ...
+    downloadRelease("isofit/isofit-data", output, "data")
 
     click.echo("Done")
 
 
 @download.command(name="examples")
-@click.option(
-    "-o",
-    "--output",
-    default=f"{isofit.root}/examples",
-    help="Directory to download ISOFIT examples to",
-)
+@output(help="Root directory to download ISOFIT examples to, ie. [path]/examples")
+# @tag
 def examples(output):
     """\
-    Downloads the ISOFIT examples from the repository [].
+    Downloads the ISOFIT examples from the repository https://github.com/isofit/isofit-tutorials.
     """
-    click.echo(f"Downloading ISOFIT examples to: {output}")
+    click.echo(f"Downloading ISOFIT examples")
 
-    ...
+    downloadRelease("isofit/isofit-tutorials", output, "examples")
 
     click.echo("Done")
 

--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -13,6 +13,7 @@ dependencies:
   - numpy>=1.20.0
   - pandas>=0.24
   - pre-commit
+  - PyGithub
   - pygrib
   - pytest>=3.5.1
   - python-xxhash<3

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
   netCDF4
   numpy >= 1.20
   pandas >= 0.24.0
+  PyGithub
   pygrib
   pyyaml >= 5.3.2
   ray >= 1.2.0


### PR DESCRIPTION
# Description
This PR implements the capability to download extra files that are useful for ISOFIT. This functionality will re-enable support for testing our examples in the new workflows (#421) as well as resolve #393.

# Changes
- Adds the subcommand `isofit download` which houses other subcommands:
  - `data` to download data files from https://github.com/isofit/isofit-data
  - `examples` to download from https://github.com/isofit/isofit-tutorials

# todo
- Expand commands to include installation of:
  - [ ] sRTMnet
  - [ ] 6S 