### PR TITLE
`setup-devenv.sh` improvements

### DIFF
--- a/docs/source/custom/CONTRIBUTING.rst
+++ b/docs/source/custom/CONTRIBUTING.rst
@@ -51,24 +51,20 @@ example, if you are working on issue #314 you would run:
 Developer Environment
 ---------------------
 
-ISOFIT has a number of dependencies that complicate setting up a developer
-environment. Ultimately the goal is to develop within a Python virtual
-environment with a compliant set of dependencies. While ISOFIT is a Python
-library with mostly pure-Python dependencies, some dependencies in turn require
-non-Python libraries. On Ubuntu, these dependencies can often be satisfied by
-``$ apt`` or ``$ apt-get``, and on MacOS the `Homebrew <https://brew.sh/>`_
-package manager is a common choice.
+Generally, the process for creating a Python virtual environment for development
+is:
 
-Generally, the steps outlined in `setup-devenv.sh <setup-devenv.sh>`_ can be
-followed to create a virtual environment, but there are just too many variables
-to confidently provide a per-platform script to set up a developer environment.
-A good course of action is to follow that script, address any ``$ pip`` errors,
-and try to run some tests. GDAL in particular may install successfully but
-fail when running tests.
+.. code-block:: console
 
-The CI system can provide some guidance as well, but note that this system
-runs in isolation, so the exact commands are not necessarily appropriate to
-execute in your environment.
+    $ python3 -m venv venv
+    $ ./scripts/setup-devenv.sh venv
+
+however, developers on some platforms may need to install additional non-Python
+dependencies using an appropriate package manager for their system.
+
+``setup-devenv.sh`` should be run periodically to refresh a development
+environment to pick up new dependencies, updates to the ``isofit`` build
+process, etc.
 
 
 Testing

--- a/docs/source/custom/CONTRIBUTING.rst
+++ b/docs/source/custom/CONTRIBUTING.rst
@@ -71,10 +71,9 @@ Testing
 -------
 
 Tests live in `isofit/tests/ <isofit/tests/>`_, and are executed using
-``pytest``. Some tests require specific environment variables to be set, so
-the `run-tests.sh <scripts/run-tests.sh>`_ script can be used to invoke ``pytest`` with
-the appropriate environment variables. It is a drop-in replacement for the
-``$ pytest`` executable, so users can add flags as they wish.
+`pytest <https://pytest.org>_`. Some tests require specific environment
+variables to be set, so the ``scripts/run-tests.sh`` script can be used to
+bridge the gap. It is a drop-in replacement for ``$ pytest``.
 
 Our development strategy employs continuous integration and unit testing to validate all changes.  We appreciate your writing additional tests for new modifications or features.  In the interest of validating your code, please also be sure to run realistic examples like this:
 

--- a/scripts/setup-devenv.sh
+++ b/scripts/setup-devenv.sh
@@ -33,27 +33,22 @@ fi
 # Create virtual environment.
 python3 -m venv "${VENV_PATH}"
 
-# Activate virtual environment. SUPER CRITICAL that this activation happens.
-# Some shell scripts assume they are in an isolated environment.
-source "${VENV_PATH}/bin/activate"
-if [ "${VIRTUAL_ENV}" == "" ]; then
-  echo "ERROR: Virtual environment did not activate: ${VENV_PATH}"
-  exit 1
-fi
+# The version of Python inside of the virtual environment is isolated, and can
+# be used to install packages inside of the environment without activating it.
+PYTHON="${VENV_PATH}/bin/python3"
 
 # Useful for debugging
-which python3
-python3 --version
+"${PYTHON}" --version
 
 # Install and upgrade packaging dependencies. The presence of 'wheel' triggers
 # a lot of the emerging Python packaging ecosystem changes (PEP-517).
-python3 -m pip install setuptools wheel --upgrade
+"${PYTHON}" -m pip install pip setuptools wheel --upgrade
 
-# Install ISOFIT.
-python3 -m pip install -e ".[dev,test]"
+# Install ISOFIT and dependencies in editable mode.
+"${PYTHON}" -m pip install -e ".[dev,test]"
 
 # Install commit hooks.
-python3 -m pre_commit install
+"${PYTHON}" -m pre_commit install
 
 # Download and unpack additional dependencies.
 "./${SCRIPT_DIR}/download-and-unpack-sRTMnet.sh"

--- a/scripts/setup-devenv.sh
+++ b/scripts/setup-devenv.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
 
-# This script serves as a reference for how to set up a developer environment.
-# Some packages, like GDAL, must be installed prior to running this script.
-# On Ubuntu these packages are likely installed via '$ apt' or '$ apt-get',
-# and on MacOS Homebrew is a common choice. Developers should read through
-# this script, and the other scripts it invokes, and determine if it is
-# appropriate to execute for their environment. At a high-level the steps
-# should be matched, but the specific commands may need to be modified.
+# This script sets up, and refreshes, a development environment. Users must
+# create a virtual environment, and then point this script to it like:
+#
+#     $ python3.11 -m venv venv
+#     $ ./scripts/setup-devenv.sh venv
+#
+# Note that different developers may use different versions of Python. Some
+# environments may require installing additional non-Python dependencies using
+# an appropriate package manage.
 
 
 set -x
@@ -16,22 +18,19 @@ set -o pipefail
 set -o nounset
 
 
-VENV_PATH="venv"
-
-
-# Path to directory containing this script.
+# Path to directory containing this script. Needed to determine the location of
+# other scripts required for setup.
 SCRIPT_DIR=$(dirname "${0}")
 
 
-# Do not attempt to modify an existing virtual environment. We do not know what
-# it contains.
-if [ -d "${VENV_PATH}" ]; then
-  echo "Virtual environment already exists: ${VENV_PATH}"
-  exit 0
+# Parse arguments.
+if [ $# -eq 1 ]; then
+  VENV_PATH="$1"
+else
+  echo "Usage: ${SCRIPT_DIR}/$(basename "$0") path/to/venv"
+  exit 1
 fi
 
-# Create virtual environment.
-python3 -m venv "${VENV_PATH}"
 
 # The version of Python inside of the virtual environment is isolated, and can
 # be used to install packages inside of the environment without activating it.


### PR DESCRIPTION
I noticed while trying to refresh my development environment that this script may not be working correctly. A virtual environment does not need to be active in order to be modified. This is much simpler than attempting to activate the environment.