### PR TITLE
Downloads CLI updates

### DIFF
--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -84,7 +84,15 @@ Install from github
     mamba activate isofit_env
     pip install -e ./isofit
 
+Downloading Extra Files
+-----------------------
 
+Once ISOFIT is installed, the CLI provides an easy way to download additional files that may be useful.
+These can be acquired via the `isofit download` command, and the current list of downloads we support is available via `isofit download --help`.
+
+> **_NOTE:_**  The default location for downloading extra files will be the `isofit.root` path, which is the installation path of the package.
+This path may not be writeable. In these cases, use the `--output [path]` flag to control where the downloads will occur.
+If the output path is different than the default, many of the provided configuration files may not work.
 
 Setting environment variables
 =============================
@@ -270,4 +278,4 @@ Ray may have compatability issues with older machines with glibc < 2.14.
 Additional Installation Info for Developers
 ========================================
 
-Be sure to read the :ref:`contributing` page as additional installation steps must be performed. 
+Be sure to read the :ref:`contributing` page as additional installation steps must be performed.

--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -64,5 +64,6 @@ import isofit.core.isofit
 import isofit.utils.add_HRRR_profiles_to_modtran_config
 import isofit.utils.analytical_line
 import isofit.utils.apply_oe
+import isofit.utils.downloads
 import isofit.utils.ewt_from_reflectance
 import isofit.utils.solar_position

--- a/isofit/utils/downloads.py
+++ b/isofit/utils/downloads.py
@@ -3,45 +3,125 @@ Implements the `isofit download` subcommands
 """
 
 import io
+import json
 import os
-import zipfile
+import urllib.request
+from email.message import EmailMessage
 from functools import partial
+from zipfile import ZipFile
 
 import click
-import requests
-from github import Github
 
 import isofit
 
 
-def downloadRelease(repo, output, name):
+def release_metadata(org, repo, tag="latest"):
     """
-    Downloads a specific tagged release from a given repository
+    Fetch GitHub metadata for the latest tagged release.
+
+    Credit to Kevin Wurster https://github.com/isofit/isofit/pull/448#issuecomment-1966747551
 
     Parameters
     ----------
+    org: str
+        GitHub organization name
     repo: str
-        Repository URL
-    output: str
-        Directory to download to
-    name: str
-        Name of the directory. The downloaded directory is based off the Github name,
-        so this is used to rename it
+        GitHub repository name
+    tag: str
+        Release tag to pull
+
+    Returns
+    -------
+    dict
+        Metadata returned by the retrieved release
     """
-    git = Github()
-    repo = git.get_repo(repo)
-    latest = repo.get_latest_release()
-    url = latest.zipball_url
+    url = f"https://api.github.com/repos/{org}/{repo}/releases/{tag}"
+    response = urllib.request.urlopen(url)
 
-    click.echo(f"Downloading {url}")
+    encoding = response.headers.get_content_charset()
+    payload = response.read()
 
-    req = requests.get(url)
-    with zipfile.ZipFile(io.BytesIO(req.content)) as zip:
-        temp = zip.infolist()[0].filename
-        zip.extractall(output)
+    return json.loads(payload.decode(encoding))
 
-    os.rename(f"{output}/{temp}", f"{output}/{name}")
-    click.echo(f"Now available at: {output}/{name}")
+
+def download_file(url, dstname=None, overwrite=True):
+    """
+    Download a file.
+
+    Credit to Kevin Wurster https://github.com/isofit/isofit/pull/448#issuecomment-1966747551
+
+    Parameters
+    ----------
+    url: str
+        URL to download
+    dstname: str
+        Destination file name
+    overwrite: bool, default=True
+        Overwrite the destination file if it already exists
+
+    Returns
+    -------
+    outfile: str
+        Output downloaded filepath
+    """
+    response = urllib.request.urlopen(url)
+
+    # Using Python's 'email' module for this is certainly odd, but due to an
+    # upcoming deprecation, this is actually the officially recommended way
+    # to do this: https://docs.python.org/3/library/cgi.html#cgi.parse_header
+    msg = EmailMessage()
+    msg["Content-Disposition"] = response.headers["Content-Disposition"]
+
+    outfile = dstname or msg["Content-Disposition"].params["filename"]
+    if os.path.exists(outfile) and not overwrite:
+        raise FileExistsError(outfile)
+
+    with open(outfile, "wb") as f:
+        while chunk := response.read(io.DEFAULT_BUFFER_SIZE):
+            f.write(chunk)
+
+    return outfile
+
+
+def unzip(file, path=None, rename=None, overwrite=False, cleanup=True):
+    """
+    Unzips a zipfile
+
+    Parameters
+    ----------
+    path: str, default=None
+        Path to extract the zipfile to. Defaults to the directory the zip is found in
+    rename: str, default=None
+        Renames the extracted data to this
+    overwrite: bool, default=False
+        Overwrites the path destination with the zip contents if enabled
+    cleanup: bool, default=True
+        Removes the zip file after completion
+
+    Returns
+    -------
+    outp: str
+        The extracted output path
+    """
+    path = path or os.path.dirname(file)
+
+    with ZipFile(file) as z:
+        name = z.namelist()[0]
+
+        # Verify the output target doesn't exist
+        outp = f"{path}/{rename or name}"
+        if os.path.exists(outp) and not overwrite:
+            raise FileExistsError(outp)
+
+        z.extractall(path)
+
+    if rename:
+        os.rename(f"{path}/{name}", outp)
+
+    if cleanup:
+        os.remove(file)
+
+    return outp
 
 
 # Main command
@@ -62,35 +142,48 @@ tag = click.option(
     "-t", "--tag", default=f"latest", help="Release tag to pull", show_default=True
 )
 
+
 # Subcommands
 
 
 @download.command(name="data")
 @output(help="Root directory to download data files to, ie. [path]/data")
-# @tag
-def data(output):
+@tag
+def data(output, tag):
     """\
     Downloads the extra ISOFIT data files from the repository https://github.com/isofit/isofit-data.
     """
     click.echo(f"Downloading ISOFIT data")
 
-    downloadRelease("isofit/isofit-data", output, "data")
+    metadata = release_metadata("isofit", "isofit-data", tag)
 
-    click.echo("Done")
+    click.echo(f"Pulling release {metadata['tag_name']}")
+    zipfile = download_file(metadata["zipball_url"], f"{output}/isofit-data.zip")
+
+    click.echo(f"Unzipping {zipfile}")
+    avail = unzip(zipfile, path=output, rename="data")
+
+    click.echo(f"Done, now available at: {avail}")
 
 
 @download.command(name="examples")
 @output(help="Root directory to download ISOFIT examples to, ie. [path]/examples")
-# @tag
-def examples(output):
+@tag
+def examples(output, tag):
     """\
     Downloads the ISOFIT examples from the repository https://github.com/isofit/isofit-tutorials.
     """
     click.echo(f"Downloading ISOFIT examples")
 
-    downloadRelease("isofit/isofit-tutorials", output, "examples")
+    metadata = release_metadata("isofit", "isofit-tutorials", tag)
 
-    click.echo("Done")
+    click.echo(f"Pulling release {metadata['tag_name']}")
+    zipfile = download_file(metadata["zipball_url"], f"{output}/isofit-tutorials.zip")
+
+    click.echo(f"Unzipping {zipfile}")
+    avail = unzip(zipfile, path=output, rename="examples")
+
+    click.echo(f"Done, now available at: {avail}")
 
 
 if __name__ == "__main__":

--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -13,7 +13,6 @@ dependencies:
   - numpy>=1.20.0
   - pandas>=0.24
   - pre-commit
-  - PyGithub
   - pygrib
   - pytest>=3.5.1
   - python-xxhash<3

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
   netCDF4
   numpy >= 1.20
   pandas >= 0.24.0
-  PyGithub
   pygrib
   pyyaml >= 5.3.2
   ray >= 1.2.0


### PR DESCRIPTION
# Description
Just a few updates to the new `isofit download` subcommand to include @pl-kevinwurster's suggestions in the comments of #448. 

# Changes
- Implements Kevin's code to not have to rely on the PyGithub package
  - Removed from the install requirements
- Enables `--tag` support to select which release to download
- Added the subcommand to the `isofit` CLI, which was missing in the previous PR
- Updated docs to include a note about this feature