### PR TITLE
Utility click

### DIFF
--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -11,6 +11,7 @@ from isofit.utils.convert_6s_to_srtmnet import cli_6s_to_srtmnet
 from isofit.utils.downloads import cli_download
 from isofit.utils.ewt_from_reflectance import cli_ewt
 from isofit.utils.solar_position import cli_sun
+from isofit.utils.surface_model import cli_surface_model
 
 
 @click.group(invoke_without_command=True)
@@ -39,6 +40,7 @@ cli.add_command(cli_apply_oe)
 cli.add_command(cli_sun)
 cli.add_command(cli_download)
 cli.add_command(cli_6s_to_srtmnet)
+cli.add_command(cli_surface_model)
 
 
 if __name__ == "__main__":

--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -9,6 +9,7 @@ from isofit.utils.analytical_line import cli_analytical_line
 from isofit.utils.apply_oe import cli_apply_oe
 from isofit.utils.convert_6s_to_srtmnet import cli_6s_to_srtmnet
 from isofit.utils.downloads import cli_download
+from isofit.utils.empirical_line import cli_empirical_line
 from isofit.utils.ewt_from_reflectance import cli_ewt
 from isofit.utils.solar_position import cli_sun
 from isofit.utils.surface_model import cli_surface_model
@@ -41,6 +42,7 @@ cli.add_command(cli_sun)
 cli.add_command(cli_download)
 cli.add_command(cli_6s_to_srtmnet)
 cli.add_command(cli_surface_model)
+cli.add_command(cli_empirical_line)
 
 
 if __name__ == "__main__":

--- a/isofit/test/test_cli_machinery.py
+++ b/isofit/test/test_cli_machinery.py
@@ -40,7 +40,7 @@ def test_subcommand_registration(executable):
         assert cmd in stdout_txt
 
     # Check to make sure the right number of subcommands are registered
-    assert subcommand_count == 8
+    assert subcommand_count == 10
 
 
 def test_version():

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -358,3 +358,9 @@ def cli_analytical_line(**kwargs):
     analytical_line(**kwargs)
 
     click.echo("Done")
+
+
+if __name__ == "__main__":
+    raise NotImplementedError(
+        "analytical_line.py can no longer be called this way.  Run as:\n isofit analytical_line [ARGS]"
+    )

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -640,3 +640,9 @@ def apply_oe(args):
 
     logging.info("Done.")
     ray_terminate()
+
+
+if __name__ == "__main__":
+    raise NotImplementedError(
+        "apply_oe.py can no longer be called this way.  Run as:\n isofit apply_oe [ARGS]"
+    )

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -21,7 +21,9 @@
 import atexit
 import logging
 import time
+from types import SimpleNamespace
 
+import click
 import matplotlib
 import numpy as np
 import pylab as plt
@@ -603,3 +605,29 @@ def empirical_line(
             line_sections[-1] * n_input_samples / total_time / n_cores,
         )
     )
+
+
+@click.command(name="empirical_line")
+@click.argument("reference_radiance_file", type=str)
+@click.argument("reference_reflectance_file", type=str)
+@click.argument("reference_uncertainty_file", type=str)
+@click.argument("reference_locations_file", type=str)
+@click.argument("segmentation_file", type=str)
+@click.argument("input_radiance_file", type=str)
+@click.argument("input_locations_file", type=str)
+@click.argument("output_reflectance_file", type=str)
+@click.argument("output_uncertainty_file", type=str)
+@click.option("--nneighbors", default=400, type=int, help="Number of neighbors")
+@click.option("--nodata_value", default=-9999.0, type=float, help="Nodata value")
+@click.option("--level", default="INFO", type=str, help="Logging level")
+@click.option("--logfile", default=None, type=str, help="Log file path")
+@click.option("--radiance_factors", default=None, type=str, help="Radiance factors")
+@click.option("--isofit_config", default=None, type=str, help="Isofit config")
+@click.option("--n_cores", default=-1, type=int, help="Number of cores")
+@click.option(
+    "--reference_class_file", default=None, type=str, help="Reference class file"
+)
+def cli_empirical_line(**kwargs):
+    """Run empirical line"""
+    empirical_line(SimpleNamespace(**kwargs))
+    click.echo("Done")

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -232,3 +232,9 @@ def cli_ewt(debug_args, **kwargs):
         main(SimpleNamespace(**kwargs))
 
     click.echo("Done")
+
+
+if __name__ == "__main__":
+    raise NotImplementedError(
+        "ewt_from_reflectance.py can no longer be called this way.  Run as:\n isofit ewt_from_reflectance [ARGS]"
+    )

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -19,7 +19,9 @@
 #
 
 import os
+from types import SimpleNamespace
 
+import click
 import numpy as np
 import scipy
 from scipy.linalg import inv
@@ -390,3 +392,23 @@ def surface_model(
     model["attribute_covs"] = np.array(model["attribute_covs"])
 
     scipy.io.savemat(outfile, model)
+
+
+# Input arguments
+@click.command(name="surface_model")
+@click.argument("config_path", type=str)
+@click.argument("--wavelength_path", type=str)
+@click.argument("--output_path", type=str)
+@click.argument("--seed", default=13, type=int)
+def cli_surface_model(debug_args, profile, **kwargs):
+    """Build a new surface model to a block of data"""
+
+    # SimpleNamespace converts a dict into dot-notational
+    surface_model(SimpleNamespace(**kwargs))
+    click.echo("Done")
+
+
+if __name__ == "__main__":
+    raise NotImplementedError(
+        "surface_model.py cannot be called this way.  Run as:\n isofit surface_model [CONFIG_PATH]"
+    )

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -400,7 +400,7 @@ def surface_model(
 @click.argument("--wavelength_path", type=str)
 @click.argument("--output_path", type=str)
 @click.argument("--seed", default=13, type=int)
-def cli_surface_model(debug_args, profile, **kwargs):
+def cli_surface_model(**kwargs):
     """Build a new surface model to a block of data"""
 
     # SimpleNamespace converts a dict into dot-notational


### PR DESCRIPTION
Small updates to add warnings about old run types.  Also enables click for some utilities (e.g. surface_model) that we didn't support before for convenience.

