### PR TITLE
Adjust test paths

### DIFF
--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -64,6 +64,9 @@ jobs:
           # Install 'isofit'
           python3 -m pip install ".[test]"
 
+          # Ensure ISOFIT has been installed
+          python3 -c "import isofit; print(isofit.__file__)"
+
       - name: Cache 6S
         id: cache-6s-v21
         uses: actions/cache@v3

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -134,5 +134,11 @@ jobs:
       - name: Execute tests
         shell: bash
         run: |
+
           # Again, do NOT 'export PYTHONPATH=...'
-          PYTHONPATH="isolation/:${PYTHONPATH}" ./scripts/run-tests.sh ${{ matrix.pytest-flags }}
+          # We define 'testpaths' in 'pytest.ini', however that path is no
+          # longer valid. In this case 'pytest' searches for tests by default,
+          # but we know where they are, so explicitly point to the new location.
+          PYTHONPATH="isolation/:${PYTHONPATH}" ./scripts/run-tests.sh \
+            isolation/isofit/tests/ \
+            ${{ matrix.pytest-flags }}

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -38,6 +38,11 @@ jobs:
         shell: bash
         run: |
 
+          # WARNING: Do NOT 'export PYTHONPATH=...'. Environment variables seem
+          #          to be shared across all jobs, so this would break the
+          #          the 'isofit' install for some other jobs. Unclear exactly
+          #          which, but presumably any job running after this one.
+
           # Python packaging dependencies. The presence of 'wheel' triggers
           # a lot of new Python packaging machinery that will eventually
           # become the default.
@@ -78,9 +83,8 @@ jobs:
               exit 1
           fi
           
-          # Install 'isofit' via '$PYTHONPATH', and ensure it can be imported.
-          export PYTHONPATH="isolation/:${PYTHONPATH}"
-          python3 -c "import isofit; print(isofit.__file__)"
+          # Again, do NOT 'export PYTHONPATH=...' here. See note at top of
+          # section.
 
       - name: Cache 6S
         id: cache-6s-v21
@@ -130,4 +134,5 @@ jobs:
       - name: Execute tests
         shell: bash
         run: |
-          ./scripts/run-tests.sh ${{ matrix.pytest-flags }}
+          # Again, do NOT 'export PYTHONPATH=...'
+          PYTHONPATH="isolation/:${PYTHONPATH}" ./scripts/run-tests.sh ${{ matrix.pytest-flags }}

--- a/isofit/test/test_cli.py
+++ b/isofit/test/test_cli.py
@@ -5,7 +5,6 @@ These tests are to ensure any changes to the CLI will be backwards compatible.
 import io
 import json
 import os
-import pathlib
 import shutil
 import zipfile
 
@@ -13,7 +12,6 @@ import pytest
 import requests
 from click.testing import CliRunner
 
-from isofit import root
 from isofit.__main__ import cli
 from isofit.utils import surface_model
 
@@ -50,11 +48,10 @@ def surface(cube_example):
 
     # Generate the surface.mat using the image_cube example config
     # fmt: off
-    isofit = pathlib.Path(root)
     surface_model(
-        config_path     = str(isofit / "examples/20171108_Pasadena/configs/ang20171108t184227_surface.json"),
-        wavelength_path = str(isofit / "examples/20171108_Pasadena/remote/20170320_ang20170228_wavelength_fit.txt"),
-        output_path     = outp
+        config_path="examples/20171108_Pasadena/configs/ang20171108t184227_surface.json",
+        wavelength_path="examples/20171108_Pasadena/remote/20170320_ang20170228_wavelength_fit.txt",
+        output_path=outp
     )
     # fmt: on
     # Return the path to the mat file


### PR DESCRIPTION
See inline comments. The `$PYTHONPATH` tests are failing due to the missing `earth_sun_distance.txt` file, which is being handled elsewhere.