### PR TITLE
Remove `matplotlib` as a hard dependency

### DIFF
--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -140,5 +140,5 @@ jobs:
           # longer valid. In this case 'pytest' searches for tests by default,
           # but we know where they are, so explicitly point to the new location.
           PYTHONPATH="isolation/:${PYTHONPATH}" ./scripts/run-tests.sh \
-            isolation/isofit/tests/ \
+            isolation/isofit/test/ \
             ${{ matrix.pytest-flags }}

--- a/isofit/test/test_cli_machinery.py
+++ b/isofit/test/test_cli_machinery.py
@@ -22,6 +22,11 @@ if "PYTHONPATH" in os.environ:
             IS_INSTALLED_VIA_PYTHONPATH = True
             break
 
+_NO_EXECUTABLE_MARKER = pytest.mark.skipif(
+    IS_INSTALLED_VIA_PYTHONPATH,
+    reason="'$ isofit' executable not available when installed via '$PYTHONPATH'",
+)
+
 
 # fmt: off
 @pytest.mark.parametrize("executable", [
@@ -31,7 +36,7 @@ if "PYTHONPATH" in os.environ:
 
     # The '$ isofit' executable is not available when installed via
     # '$PYTHONPATH', so sometimes this test is skipped.
-    pytest.param(["isofit"], marks=pytest.mark.skipif(IS_INSTALLED_VIA_PYTHONPATH)),
+    pytest.param(["isofit"], marks=_NO_EXECUTABLE_MARKER),
 
 ])
 # fmt: on

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -23,7 +23,6 @@ import time
 from typing import List
 
 import numpy as np
-import pylab as plt
 from scipy.linalg import inv
 from scipy.ndimage import gaussian_filter
 from scipy.spatial import KDTree
@@ -33,8 +32,6 @@ from isofit import ray
 from isofit.core.common import envi_header, ray_initiate
 from isofit.core.fileio import write_bil_chunk
 from isofit.core.forward import ForwardModel
-
-plt.switch_backend("Agg")
 
 
 @ray.remote

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -24,9 +24,7 @@ import time
 from types import SimpleNamespace
 
 import click
-import matplotlib
 import numpy as np
-import pylab as plt
 from scipy.linalg import inv
 from scipy.spatial import KDTree
 from spectral.io import envi
@@ -36,8 +34,6 @@ from isofit.configs import configs
 from isofit.core.common import envi_header, ray_initiate
 from isofit.core.fileio import write_bil_chunk
 from isofit.core.instrument import Instrument
-
-plt.switch_backend("Agg")
 
 
 @ray.remote
@@ -314,8 +310,6 @@ def _run_chunk(
                 output_uncertainty_row[col, :] = (
                     np.sqrt(np.diag(Sy) + pow(calunc * x, 2)) * bhat[:, 1]
                 )
-            # if loglevel == 'DEBUG':
-            #    plot_example(xv, yv, bhat)
 
             nspectra = nspectra + 1
 
@@ -352,30 +346,6 @@ def _run_chunk(
             row,
             (n_input_lines, n_output_uncertainty_bands, n_input_samples),
         )
-
-
-def _plot_example(xv, yv, b):
-    """Plot for debugging purposes."""
-
-    matplotlib.rcParams["font.family"] = "serif"
-    matplotlib.rcParams["font.sans-serif"] = "Times"
-    matplotlib.rcParams["legend.edgecolor"] = "None"
-    matplotlib.rcParams["axes.spines.top"] = False
-    matplotlib.rcParams["axes.spines.bottom"] = True
-    matplotlib.rcParams["axes.spines.left"] = True
-    matplotlib.rcParams["axes.spines.right"] = False
-    matplotlib.rcParams["axes.grid"] = True
-    matplotlib.rcParams["axes.grid.axis"] = "both"
-    matplotlib.rcParams["axes.grid.which"] = "major"
-    matplotlib.rcParams["legend.edgecolor"] = "1.0"
-    plt.plot(xv[:, 113], yv[:, 113], "ko")
-    plt.plot(xv[:, 113], xv[:, 113] * b[113, 1] + b[113, 0], "nneighbors")
-    # plt.plot(x[113], x[113]*b[113, 1] + b[113, 0], 'ro')
-    plt.grid(True)
-    plt.xlabel("Radiance, $\mu{W }nm^{-1} sr^{-1} cm^{-2}$")
-    plt.ylabel("Reflectance")
-    plt.show(block=True)
-    plt.savefig("empirical_line.pdf")
 
 
 def empirical_line(

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -128,25 +128,6 @@ def main(args: SimpleNamespace) -> None:
         f"{round(rfls[0]*rfls[1]/total_time/n_workers,4)} spectra/s/core"
     )
 
-    if args.plot_map:
-        ewt = envi.open(args.output_cwc_file + ".hdr")
-        plt.figure()
-        plt.imshow(ewt[:, :] * 10, vmin=0, vmax=args.ewt_limit * 10, cmap="jet")
-        plt.colorbar()
-        plt.grid()
-        ax = plt.gca()
-        ax.xaxis.set_tick_params(labelbottom=False)
-        ax.yaxis.set_tick_params(labelleft=False)
-        ax.set_xticks([])
-        ax.set_yticks([])
-        ax.spines["left"].set_visible(False)
-        ax.spines["bottom"].set_visible(False)
-        plt.title("Equivalent Water Thickness\n(EWT) [mm]", size=15)
-        plt.savefig(
-            args.output_cwc_file + ".png", dpi=600, bbox_inches="tight", pad_inches=0
-        )
-        plt.close()
-
 
 @ray.remote
 def run_lines(
@@ -209,7 +190,6 @@ def run_lines(
 @click.option("--n_cores", type=int, default=-1)
 @click.option("--ray_tmp_dir")
 @click.option("--ewt_limit", type=float, default=0.5)
-@click.option("--plot_map", is_flag=True, default=False)
 @click.option(
     "--debug-args",
     help="Prints the arguments list without executing the command",

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -26,7 +26,6 @@ from types import SimpleNamespace
 
 import click
 import numpy as np
-from matplotlib import pyplot as plt
 from spectral.io import envi
 
 from isofit import ray

--- a/isofit/utils/interpolate_atmosphere.py
+++ b/isofit/utils/interpolate_atmosphere.py
@@ -23,7 +23,6 @@ import multiprocessing
 import time
 
 import numpy as np
-import pylab as plt
 from scipy.linalg import inv
 from scipy.spatial import KDTree
 from sklearn.decomposition import PCA
@@ -34,8 +33,6 @@ from spectral.io import envi
 from isofit.configs import configs
 from isofit.core.common import envi_header
 from isofit.core.instrument import Instrument
-
-plt.switch_backend("Agg")
 
 
 def _write_bil_chunk(

--- a/isofit/utils/interpolate_atmosphere.py
+++ b/isofit/utils/interpolate_atmosphere.py
@@ -22,7 +22,6 @@ import logging
 import multiprocessing
 import time
 
-import matplotlib
 import numpy as np
 import pylab as plt
 from scipy.linalg import inv

--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -8,7 +8,6 @@ dependencies:
   - pip
   - click
   - dask
-  - matplotlib>=2.2.2
   - netCDF4
   - numpy>=1.20.0
   - pandas>=0.24

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ include_package_data = True
 install_requires =
   click
   dask
-  matplotlib >= 2.2.2
   netCDF4
   numpy >= 1.20
   pandas >= 0.24.0


### PR DESCRIPTION
_For https://github.com/isofit/isofit/issues/411_

`matplotlib` is no longer a hard dependency. We discussed this during one of the weekly tagup meetings several months ago, but have not revisited since.