### PR TITLE
Ray Out of Memory

### DIFF
--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -27,8 +27,10 @@ __version__ = importlib.metadata.version(__package__ or __name__)
 
 warnings_enabled = False
 
+import atexit
 import logging
 import os
+import signal
 
 Logger = logging.getLogger("isofit")
 
@@ -39,3 +41,16 @@ if os.environ.get("ISOFIT_DEBUG"):
     from .wrappers import ray
 else:
     import ray
+
+
+def shutdown_ray():
+    try:
+        ray.shutdown()
+    except:
+        pass
+
+
+# Auto call ray.shutdown when the python interpreter exits
+atexit.register(shutdown_ray)
+signal.signal(signal.SIGINT, shutdown_ray)  # ctrl+C
+signal.signal(signal.SIGTERM, shutdown_ray)  # kill

--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -45,12 +45,13 @@ else:
 
 def shutdown_ray():
     try:
-        ray.shutdown()
+        ray.shutdown(_exiting_interpreter=True)
     except:
         pass
 
 
 # Auto call ray.shutdown when the python interpreter exits
+# ray itself also implements this, but there's no harm in calling it twice
 atexit.register(shutdown_ray)
 signal.signal(signal.SIGINT, shutdown_ray)  # ctrl+C
 signal.signal(signal.SIGTERM, shutdown_ray)  # kill

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -43,10 +43,9 @@ class Isofit:
         config_file: isofit configuration file in JSON or YAML format
         level: logging level (ERROR, WARNING, INFO, DEBUG)
         logfile: file to write output logs to
-        autoshutdown: Enables calling ray.shutdown() on object deletion
     """
 
-    def __init__(self, config_file, level="INFO", logfile=None, autoshutdown=True):
+    def __init__(self, config_file, level="INFO", logfile=None):
         # Explicitly set the number of threads to be 1, so we more effectively
         # run in parallel
         os.environ["MKL_NUM_THREADS"] = "1"
@@ -86,19 +85,9 @@ class Isofit:
         ):
             rayargs["num_cpus"] = self.config.implementation.n_cores
 
-        self.autoshutdown = autoshutdown
         ray_initiate(rayargs)
 
         self.workers = None
-
-    def __del__(self):
-        if self.autoshutdown:
-            try:
-                ray.shutdown()
-                self.workers = None
-            except:
-                logging.error("Isofit Object Deletion unsuccessful")
-                return
 
     def run(self, row_column=None):
         """

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -148,16 +148,12 @@ class Isofit:
         # Max out the number of workers based on the number of tasks
         n_workers = min(n_workers, n_iter)
 
-        fm_id = ray.put(fm)
-
-        remote_worker = ray.remote(Worker)
+        params = [
+            ray.put(obj)
+            for obj in [self.config, fm, self.loglevel, self.logfile, n_workers]
+        ]
         self.workers = ray.util.ActorPool(
-            [
-                remote_worker.remote(
-                    self.config, fm_id, self.loglevel, self.logfile, n, n_workers
-                )
-                for n in range(n_workers)
-            ]
+            [Worker.remote(*params, n) for n in range(n_workers)]
         )
 
         start_time = time.time()
@@ -193,6 +189,7 @@ class Isofit:
         )
 
 
+@ray.remote(num_cpus=1)
 class Worker(object):
     def __init__(
         self,
@@ -200,8 +197,8 @@ class Worker(object):
         forward_model: ForwardModel,
         loglevel: str,
         logfile: str,
-        worker_id: int = None,
         total_workers: int = None,
+        worker_id: int = None,
     ):
         """
         Worker class to help run a subset of spectra.

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -43,9 +43,10 @@ class Isofit:
         config_file: isofit configuration file in JSON or YAML format
         level: logging level (ERROR, WARNING, INFO, DEBUG)
         logfile: file to write output logs to
+        autoshutdown: Enables calling ray.shutdown() on object deletion
     """
 
-    def __init__(self, config_file, level="INFO", logfile=None):
+    def __init__(self, config_file, level="INFO", logfile=None, autoshutdown=True):
         # Explicitly set the number of threads to be 1, so we more effectively
         # run in parallel
         os.environ["MKL_NUM_THREADS"] = "1"
@@ -85,17 +86,19 @@ class Isofit:
         ):
             rayargs["num_cpus"] = self.config.implementation.n_cores
 
+        self.autoshutdown = autoshutdown
         ray_initiate(rayargs)
 
         self.workers = None
 
     def __del__(self):
-        try:
-            ray.shutdown()
-            self.workers = None
-        except:
-            logging.error("Isofit Object Deletion unsuccessful")
-            return
+        if self.autoshutdown:
+            try:
+                ray.shutdown()
+                self.workers = None
+            except:
+                logging.error("Isofit Object Deletion unsuccessful")
+                return
 
     def run(self, row_column=None):
         """

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -121,9 +121,9 @@ def updatePoint(
         solar_irr - Not along the point dimension, presently clobbers with
                     every new input
     """
-    now = dt.now()
-    print(f"{id: 4} Opening: {now}")
     with SystemMutex("lock"):
+        now = dt.now()
+        print(f"{id: 4} Opening: {now}")
         with Dataset(file, "a") as nc:
             # Retrieves the index for a point value
             index = lambda key, val: np.argwhere(nc[key][:] == val)[0][0]

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -98,8 +98,11 @@ def initialize(
     return ds.stack(point=lut_grid).transpose("point", "wl")
 
 
+from datetime import datetime as dt
+
+
 def updatePoint(
-    file: str, lut_names: list = [], point: tuple = (), data: dict = {}
+    file: str, lut_names: list = [], point: tuple = (), data: dict = {}, id=-1
 ) -> None:
     """
     Updates a point in a LUT NetCDF
@@ -118,6 +121,8 @@ def updatePoint(
         solar_irr - Not along the point dimension, presently clobbers with
                     every new input
     """
+    now = dt.now()
+    print(f"{id: 4} Opening: {now}")
     with SystemMutex("lock"):
         with Dataset(file, "a") as nc:
             # Retrieves the index for a point value
@@ -174,6 +179,7 @@ def updatePoint(
                     else:
                         # Not a special case, save as-is
                         var[inds] = values
+    print(f"{id: 4} Release: {dt.now() - now}")
 
 
 def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -122,8 +122,8 @@ def updatePoint(
                     every new input
     """
     with SystemMutex("lock"):
-        now = dt.now()
-        print(f"{id: 4} Opening: {now}")
+        # now = dt.now()
+        # print(f"{id: 4} Opening: {now}")
         with Dataset(file, "a") as nc:
             # Retrieves the index for a point value
             index = lambda key, val: np.argwhere(nc[key][:] == val)[0][0]
@@ -179,7 +179,7 @@ def updatePoint(
                     else:
                         # Not a special case, save as-is
                         var[inds] = values
-    print(f"{id: 4} Release: {dt.now() - now}")
+    # print(f"{id: 4} Release: {dt.now() - now}")
 
 
 def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -98,11 +98,8 @@ def initialize(
     return ds.stack(point=lut_grid).transpose("point", "wl")
 
 
-from datetime import datetime as dt
-
-
 def updatePoint(
-    file: str, lut_names: list = [], point: tuple = (), data: dict = {}, id=-1
+    file: str, lut_names: list = [], point: tuple = (), data: dict = {}
 ) -> None:
     """
     Updates a point in a LUT NetCDF
@@ -122,8 +119,6 @@ def updatePoint(
                     every new input
     """
     with SystemMutex("lock"):
-        # now = dt.now()
-        # print(f"{id: 4} Opening: {now}")
         with Dataset(file, "a") as nc:
             # Retrieves the index for a point value
             index = lambda key, val: np.argwhere(nc[key][:] == val)[0][0]
@@ -179,7 +174,6 @@ def updatePoint(
                     else:
                         # Not a special case, save as-is
                         var[inds] = values
-    # print(f"{id: 4} Release: {dt.now() - now}")
 
 
 def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -263,7 +263,7 @@ class RadiativeTransferEngine:
         Enables key indexing for easier access to the numpy object store in
         self.lut[key]
         """
-        return self.lut[key].load().data
+        return self.lut[key].data
 
     @property
     def lut_interp_types(self):
@@ -294,7 +294,7 @@ class RadiativeTransferEngine:
         for key in self.alldim:
             self.luts[key] = common.VectorInterpolator(
                 grid_input=grid,
-                data_input=ds[key].load().data,
+                data_input=ds[key].data,
                 lut_interp_types=self.lut_interp_types,
                 version=self.interpolator_style,
             )
@@ -447,7 +447,8 @@ class RadiativeTransferEngine:
             luts.updatePoint(file=self.lut_path, data=post)
 
         # Reload the LUT now that it's populated
-        self.lut = luts.load(self.lut_path)
+        self.lut = luts.load(self.lut_path).load()
+        self.lut.close()
 
     def summarize(self, x_RT, *_):
         """

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -263,16 +263,11 @@ class RadiativeTransferEngine:
         Enables key indexing for easier access to the numpy object store in
         self.lut[key]
         """
-        return self.lut[key].data
+        return self.lut[key].load().data
 
     @property
     def lut_interp_types(self):
         return np.array([self.angular_lut_keys.get(key, "n") for key in self.lut_names])
-
-    def reload_lut(self):
-        """
-        Reloads self.lut and
-        """
 
     def build_interpolators(self):
         """
@@ -294,7 +289,7 @@ class RadiativeTransferEngine:
         for key in self.alldim:
             self.luts[key] = common.VectorInterpolator(
                 grid_input=grid,
-                data_input=ds[key].data,
+                data_input=ds[key].load().data,
                 lut_interp_types=self.lut_interp_types,
                 version=self.interpolator_style,
             )
@@ -447,8 +442,7 @@ class RadiativeTransferEngine:
             luts.updatePoint(file=self.lut_path, data=post)
 
         # Reload the LUT now that it's populated
-        self.lut = luts.load(self.lut_path).load()
-        self.lut.close()
+        self.lut = luts.load(self.lut_path)
 
     def summarize(self, x_RT, *_):
         """

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -638,8 +638,8 @@ def streamSimulation(
     if data:
         Logger.debug(f"Updating data point {point} for keys: {data.keys()}")
         now = dt.now()
-        print(f"{i: 4} Starting: {now}")
+        # print(f"{i: 4} Starting: {now}")
         luts.updatePoint(output, list(lut_names), point, data, i)
-        print(f"{i: 4} Finished: {now}, {dt.now() - now}")
+        # print(f"{i: 4} Finished: {now}, {dt.now() - now}")
     else:
         Logger.warning(f"No data was returned for point {point}")

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -632,7 +632,6 @@ def streamSimulation(
     # Save the results to our LUT format
     if data:
         Logger.debug(f"Updating data point {point} for keys: {data.keys()}")
-        now = dt.now()
         luts.updatePoint(output, list(lut_names), point, data)
     else:
         Logger.warning(f"No data was returned for point {point}")

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -599,6 +599,9 @@ class RadiativeTransferEngine:
         return data
 
 
+from datetime import datetime as dt
+
+
 @ray.remote
 def streamSimulation(
     point: np.array,
@@ -606,6 +609,7 @@ def streamSimulation(
     simmer: Callable,
     reader: Callable,
     output: str,
+    i=-1,
     max_buffer_time: float = 0.5,
 ):
     """Run a simulation for a single point and stream the results to a saved lut file.
@@ -632,6 +636,9 @@ def streamSimulation(
     # Save the results to our LUT format
     if data:
         Logger.debug(f"Updating data point {point} for keys: {data.keys()}")
-        luts.updatePoint(output, list(lut_names), point, data)
+        now = dt.now()
+        print(f"{i: 4} Starting: {now}")
+        luts.updatePoint(output, list(lut_names), point, data, i)
+        print(f"{i: 4} Finished: {now}, {dt.now() - now}")
     else:
         Logger.warning(f"No data was returned for point {point}")

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -437,10 +437,11 @@ class RadiativeTransferEngine:
                 for i, point in enumerate(self.points)
             ]
             # Delete job references as soon as they finish
-            while jobs:
-                [done], jobs = ray.wait(jobs)
-                result = ray.get(done)
-                del result, done
+            ray.get(jobs)
+            # while jobs:
+            #     [done], jobs = ray.wait(jobs)
+            #     result = ray.get(done)
+            #     del result, done
         else:
             Logger.debug("makeSim is disabled for this engine")
 

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -17,7 +17,6 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 
-import atexit
 import logging
 import multiprocessing
 import os
@@ -172,7 +171,6 @@ def analytical_line(
     }
 
     ray_initiate(ray_dict)
-    atexit.register(ray.shutdown)
 
     n_workers = n_cores
 
@@ -208,7 +206,6 @@ def analytical_line(
         f"{round(rdns[0]*rdns[1]/total_time,4)} spectra/s, "
         f"{round(rdns[0]*rdns[1]/total_time/n_workers,4)} spectra/s/core"
     )
-    ray.shutdown()
 
 
 @ray.remote(num_cpus=1)

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -178,16 +178,19 @@ def analytical_line(
         n_workers = multiprocessing.cpu_count()
 
     wargs = [
-        config,
-        ray.put(fm),
-        atm_file,
-        analytical_state_file,
-        analytical_state_unc_file,
-        rdn_file,
-        loc_file,
-        obs_file,
-        loglevel,
-        logfile,
+        ray.put(obj)
+        for obj in (
+            config,
+            fm,
+            atm_file,
+            analytical_state_file,
+            analytical_state_unc_file,
+            rdn_file,
+            loc_file,
+            obs_file,
+            loglevel,
+            logfile,
+        )
     ]
     workers = ray.util.ActorPool([Worker.remote(*wargs) for _ in range(n_workers)])
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -488,7 +488,6 @@ def apply_oe(args):
                 paths.h2o_config_path,
                 level="INFO",
                 logfile=args.log_file,
-                autoshutdown=False,
             )
             retrieval_h2o.run()
             del retrieval_h2o

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -485,7 +485,10 @@ def apply_oe(args):
             # Run modtran retrieval
             logging.info("Run ISOFIT initial guess")
             retrieval_h2o = isofit.Isofit(
-                paths.h2o_config_path, level="INFO", logfile=args.log_file
+                paths.h2o_config_path,
+                level="INFO",
+                logfile=args.log_file,
+                autoshutdown=False,
             )
             retrieval_h2o.run()
             del retrieval_h2o

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -17,7 +17,6 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 #
-import atexit
 import logging
 import time
 from typing import List
@@ -299,7 +298,6 @@ def atm_interpolation(
     # Initialize ray cluster
     start_time = time.time()
     ray_initiate({"ignore_reinit_error": True, "local_mode": n_cores == 1})
-    atexit.register(ray.shutdown)
 
     n_ray_cores = int(ray.available_resources()["CPU"])
     n_cores = min(n_ray_cores, n_input_lines)
@@ -366,4 +364,3 @@ def atm_interpolation(
 
     atm_img = atm_img.transpose((0, 2, 1))
     write_bil_chunk(atm_img, output_atm_file, 0, atm_img.shape)
-    ray.shutdown()

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -18,7 +18,6 @@
 # Author: David R Thompson, david.r.thompson@jpl.nasa.gov
 #
 
-import atexit
 import logging
 import time
 from types import SimpleNamespace
@@ -555,7 +554,6 @@ def empirical_line(
         rayargs["num_cpus"] = n_cores
 
     ray_initiate(rayargs)
-    atexit.register(ray.shutdown)
 
     n_ray_cores = ray.available_resources()["CPU"]
     n_cores = min(n_ray_cores, n_input_lines)

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -17,7 +17,6 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 
-import atexit
 import logging
 import multiprocessing
 import os
@@ -99,7 +98,6 @@ def main(args: SimpleNamespace) -> None:
     }
 
     ray.init(**rayargs)
-    atexit.register(ray.shutdown)
 
     line_breaks = np.linspace(0, rfls[0], n_workers, dtype=int)
     line_breaks = [

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -18,7 +18,6 @@
 # Author: David R Thompson, david.r.thompson@jpl.nasa.gov
 #
 
-import atexit
 import logging
 
 import numpy as np
@@ -176,7 +175,6 @@ def extractions(
         rayargs["num_cpus"] = n_cores
 
     ray_initiate(rayargs)
-    atexit.register(ray.shutdown)
 
     labelid = ray.put(labels)
     jobs = []
@@ -197,7 +195,6 @@ def extractions(
         if ret is not None:
             out[idx, :, 0] = ret
     del rreturn
-    ray.shutdown()
 
     meta["lines"] = str(nout)
     meta["bands"] = str(nb)
@@ -214,4 +211,3 @@ def extractions(
         type = "float64"
 
     write_bil_chunk(out, out_file, 0, out.shape, dtype=type)
-    ray.shutdown()

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -18,7 +18,6 @@
 # Author: David R Thompson, david.r.thompson@jpl.nasa.gov
 #
 
-import atexit
 import logging
 
 import numpy as np
@@ -209,7 +208,6 @@ def segment(
         rayargs["num_cpus"] = n_cores
 
     ray_initiate(rayargs)
-    atexit.register(ray.shutdown)
 
     # Iterate through image "chunks," segmenting as we go
     all_labels = np.zeros((nl, ns), dtype=np.int64)
@@ -254,7 +252,6 @@ def segment(
                 next_label += 1
             all_labels[lstart:lend, ...] = ordered_chunk_labels
     del rreturn
-    ray.shutdown()
 
     # Final file I/O
     logging.debug("Writing output")
@@ -271,4 +268,3 @@ def segment(
     lbl_mm = lbl_img.open_memmap(interleave="source", writable=True)
     lbl_mm[:, :] = np.array(all_labels, dtype=np.float32).reshape((nl, 1, ns))
     del lbl_mm
-    ray.shutdown()


### PR DESCRIPTION
# Description
Resolves the OOM errors we were hitting with the ray object store spilling and eventually dying. 

# Changes
- Moved the shared parameters of `streamSimulation` to ray object space prior to job creation so that they're not duplicated which was exploding the memory
- Fixed ray core dumping at the start of inversions and analytical line by limited `Worker` objects to 1 cpu
- Fixed simulations only utilizing 25% of each core due to the initial guess Isofit object shutting down the ray cluster then re-initializing for the full Isofit run