### PR TITLE
remove tensorflow

### DIFF
--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -224,6 +224,12 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         if self.engine_name == "sRTMnet" and self.emulator_aux_file is None:
             errors.append("The sRTMnet requires an emulator_aux_file to be specified.")
 
+        if self.engine_name == "sRTMnet" and self.emulator_file is not None:
+            if os.path.splitext(self.emulator_file)[1] != ".h5":
+                errors.append(
+                    "sRTMnet now requires the emulator_file to be of type .h5.  Please download an updated version from:\n https://zenodo.org/records/10831425"
+                )
+
         files = [
             self.earth_sun_distance_file,
             self.irradiance_file,

--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -21,7 +21,6 @@ dependencies:
   - scikit-learn>=0.19.1
   - scipy>=1.3.0
   - spectral>=0.19
-  - tensorflow
   - utm
   - xarray<2024.1.1
 


### PR DESCRIPTION
Removes the tensorflow dependency through an numpy implementation of sRTMnet.

Here's a quick validation test (class names don't match exactly due to local implementation).  Formal test can't be run with tf now purged:


```
x = np.random.random([1] + [v for v in model_tf.input_shape if v is not None])
ytf = model_tf.predict(x)

#ynew = apply_model(x, weights, biases)
model = mock_model('/Users/brodrick/isofit_support/sRTMnet_v120.h5')
ynew = model.predict(x)

import matplotlib.pyplot as plt
plt.plot(ytf.squeeze(),c='black', label='Random input raw')
plt.plot(ytf.squeeze() - ynew.squeeze(), label='tf vs np residual')
plt.legend()
```
![Screenshot 2024-03-18 at 8 26 51 AM](https://github.com/isofit/isofit/assets/23531204/e2e08ec1-adab-4faf-bd32-b3105fef6998)

Needs to wait for zenodo upload to complete, and then this should be ready.


