### PR TITLE
`isofit.root` replacement

### DIFF
--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -26,7 +26,7 @@ from isofit.utils.surface_model import cli_surface_model
 @click.option("-6s", "--sixs", help="Override path to SixS installation")
 @click.option("-mt", "--modtran", help="Override path to MODTRAN installation")
 @click.option("--save/--no-save", " /-S", is_flag=True, default=True)
-def cli(ctx, version, install_path, ini, section, save, **overrides):
+def cli(ctx, version, ini, section, save, **overrides):
     """\
     This houses the subcommands of ISOFIT
     """

--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -18,8 +18,16 @@ from isofit.utils.surface_model import cli_surface_model
 @click.group(invoke_without_command=True)
 @click.pass_context
 @click.option("-v", "--version", help="Print the current version", is_flag=True)
-@click.option("-p", "--path", help="Print the installation path", is_flag=True)
-def cli(ctx, version, path):
+@click.option("-i", "--install_path", help="Print the installation path", is_flag=True)
+@click.option("-b", "--base_path", help="Override the ISOFIT base-env path")
+@click.option("-e", "--environment", help="Override path to an env.toml file")
+@click.option("-d", "--data", help="Override path to data directory")
+@click.option("-t", "--examples", help="Override path to examples directory")
+@click.option("-em", "--srtmnet", help="Override path to sRTMnet installation")
+@click.option("-6s", "--sixs", help="Override path to SixS installation")
+@click.option("-mt", "--modtran", help="Override path to MODTRAN installation")
+@click.option("-s", "--save_env", is_flag=True, default=True)
+def cli(ctx, version, install_path, base_path, environment, save_env, **overrides):
     """\
     This houses the subcommands of ISOFIT
     """
@@ -27,8 +35,22 @@ def cli(ctx, version, path):
         if version:
             click.echo(isofit.__version__)
 
-        if path:
+        if install_path:
             click.echo(__path__[0])
+
+    else:
+        from isofit.core import env
+
+        if base_path:
+            env.updateBase(base_path)
+        env.loadEnv(env=environment)
+
+        for key, value in overrides.items():
+            if value:
+                env.setEnv(key, value)
+
+        if save_env:
+            env.dumpEnv(env=environment)
 
 
 # Subcommands live closer to the code and algorithms they are related to.

--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -19,15 +19,14 @@ from isofit.utils.surface_model import cli_surface_model
 @click.pass_context
 @click.option("-v", "--version", help="Print the current version", is_flag=True)
 @click.option("-i", "--install_path", help="Print the installation path", is_flag=True)
-@click.option("-b", "--base_path", help="Override the ISOFIT base-env path")
-@click.option("-e", "--environment", help="Override path to an env.toml file")
+@click.option("-t", "--toml", help="Override path to an env.toml file")
 @click.option("-d", "--data", help="Override path to data directory")
-@click.option("-t", "--examples", help="Override path to examples directory")
+@click.option("-e", "--examples", help="Override path to examples directory")
 @click.option("-em", "--srtmnet", help="Override path to sRTMnet installation")
 @click.option("-6s", "--sixs", help="Override path to SixS installation")
 @click.option("-mt", "--modtran", help="Override path to MODTRAN installation")
 @click.option("-s", "--save_env", is_flag=True, default=True)
-def cli(ctx, version, install_path, base_path, environment, save_env, **overrides):
+def cli(ctx, version, install_path, toml, save_env, **overrides):
     """\
     This houses the subcommands of ISOFIT
     """
@@ -41,16 +40,14 @@ def cli(ctx, version, install_path, base_path, environment, save_env, **override
     else:
         from isofit.core import env
 
-        if base_path:
-            env.updateBase(base_path)
-        env.loadEnv(env=environment)
+        env.loadEnv(env=toml)
 
         for key, value in overrides.items():
             if value:
-                env.setEnv(key, value)
+                env.changePath(key, value)
 
         if save_env:
-            env.dumpEnv(env=environment)
+            env.dumpEnv(env=toml)
 
 
 # Subcommands live closer to the code and algorithms they are related to.

--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -18,36 +18,32 @@ from isofit.utils.surface_model import cli_surface_model
 @click.group(invoke_without_command=True)
 @click.pass_context
 @click.option("-v", "--version", help="Print the current version", is_flag=True)
-@click.option("-i", "--install_path", help="Print the installation path", is_flag=True)
-@click.option("-t", "--toml", help="Override path to an env.toml file")
+@click.option("-i", "--ini", help="Override path to an isofit.ini file")
+@click.option("-s", "--section", help="Switches which section of the ini to use")
 @click.option("-d", "--data", help="Override path to data directory")
 @click.option("-e", "--examples", help="Override path to examples directory")
 @click.option("-em", "--srtmnet", help="Override path to sRTMnet installation")
 @click.option("-6s", "--sixs", help="Override path to SixS installation")
 @click.option("-mt", "--modtran", help="Override path to MODTRAN installation")
-@click.option("-s", "--save_env", is_flag=True, default=True)
-def cli(ctx, version, install_path, toml, save_env, **overrides):
+@click.option("--save/--no-save", " /-S", is_flag=True, default=True)
+def cli(ctx, version, install_path, ini, section, save, **overrides):
     """\
     This houses the subcommands of ISOFIT
     """
     if ctx.invoked_subcommand is None:
         if version:
             click.echo(isofit.__version__)
-
-        if install_path:
-            click.echo(__path__[0])
-
     else:
         from isofit.core import env
 
-        env.loadEnv(env=toml)
+        env.loadConf(ini, section)
 
         for key, value in overrides.items():
             if value:
                 env.changePath(key, value)
 
-        if save_env:
-            env.dumpEnv(env=toml)
+        if save:
+            env.dumpConf(ini)
 
 
 # Subcommands live closer to the code and algorithms they are related to.

--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -25,7 +25,9 @@ from isofit.utils.surface_model import cli_surface_model
 @click.option("-em", "--srtmnet", help="Override path to sRTMnet installation")
 @click.option("-6s", "--sixs", help="Override path to SixS installation")
 @click.option("-mt", "--modtran", help="Override path to MODTRAN installation")
-@click.option("--save/--no-save", " /-S", is_flag=True, default=True)
+@click.option(
+    "--save/--no-save", " /-S", is_flag=True, default=True, help="Save the ini file"
+)
 def cli(ctx, version, ini, section, save, **overrides):
     """\
     This houses the subcommands of ISOFIT
@@ -36,14 +38,14 @@ def cli(ctx, version, ini, section, save, **overrides):
     else:
         from isofit.core import env
 
-        env.loadConf(ini, section)
+        env.load(ini, section)
 
         for key, value in overrides.items():
             if value:
                 env.changePath(key, value)
 
         if save:
-            env.dumpConf(ini)
+            env.save(ini)
 
 
 # Subcommands live closer to the code and algorithms they are related to.

--- a/isofit/core/env.py
+++ b/isofit/core/env.py
@@ -1,12 +1,12 @@
 import logging
 from configparser import ConfigParser
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, List, Optional, Tuple
 
 Logger = logging.getLogger(__file__)
 
 INI: Path = Path.home() / ".isofit/isofit.ini"
-KEYS: list[str] = ["data", "examples", "srtmnet", "sixs", "modtran"]
+KEYS: List[str] = ["data", "examples", "srtmnet", "sixs", "modtran"]
 CONFIG: ConfigParser = ConfigParser()
 SECTION: str = "DEFAULT"
 
@@ -30,6 +30,32 @@ def __getattr__(key: str) -> Optional[str]:
         The value associated with the key if it exists in DATA, otherwise None.
     """
     return CONFIG[SECTION].get(key)
+
+
+def mkdir(path: str, isdir: bool = False) -> None:
+    """
+    Create a directory at the given path.
+
+    Parameters
+    ----------
+    path : str
+        The path where the directory should be created.
+    isdir : bool, optional
+        Flag indicating if the provided path points to a directory.
+        If False, the directory will be created at the parent of the provided path.
+        Defaults to False.
+    """
+    path = Path(path)
+    if not isdir:
+        path = path.parent
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def items() -> Iterable[Tuple[str, str]]:
+    """
+    Passthrough to the items() function on the working section of the config.
+    """
+    return CONFIG[SECTION].items()
 
 
 def changeSection(section: str) -> None:
@@ -85,7 +111,7 @@ def load(ini: Optional[str] = None, section: Optional[str] = None) -> None:
         Logger.info(f"ini does not exist, falling back to defaults: {INI}")
 
 
-def save(ini: Optional[str] = None, mkdir: bool = True) -> None:
+def save(ini: Optional[str] = None) -> None:
     """
     Save CONFIG variables to the INI (ini) file.
 
@@ -94,15 +120,12 @@ def save(ini: Optional[str] = None, mkdir: bool = True) -> None:
     ini : str or Path, optional
         The path to save the config variables to. If None, the default INI file path is used.
         If provided, sets the global INI for the remainder of the session.
-    mkdir : bool, optional
-        Whether to create directories in the path if they do not exist. Default is True.
     """
     global INI
     if ini:
         INI = Path(ini)
 
-    if mkdir:
-        INI.parent.mkdir(parents=True, exist_ok=True)
+    mkdir(INI)
 
     try:
         with open(INI, "w") as file:

--- a/isofit/core/env.py
+++ b/isofit/core/env.py
@@ -17,7 +17,7 @@ for key in KEYS:
 
 def __getattr__(key: str) -> Optional[str]:
     """
-    Retrieves a value from DATA if the key doesn't exist on the module already.
+    Retrieves a value from CONFIG[SECTION] if the key doesn't exist on the module already.
 
     Parameters
     ----------
@@ -27,7 +27,7 @@ def __getattr__(key: str) -> Optional[str]:
     Returns
     -------
     str or None
-        The value associated with the key if it exists in DATA, otherwise None.
+        The value associated with the key if it exists in CONFIG[SECTION], otherwise None.
     """
     return CONFIG[SECTION].get(key)
 
@@ -73,7 +73,7 @@ def changeSection(section: str) -> None:
 
 def changePath(key: str, value: str) -> None:
     """
-    Change the path associated with the specified key in the DATA dictionary.
+    Change the path associated with the specified key in the CONFIG[SECTION].
 
     Parameters
     ----------

--- a/isofit/core/env.py
+++ b/isofit/core/env.py
@@ -1,0 +1,138 @@
+"""
+Constructs and stores environment options for ISOFIT
+"""
+
+import logging
+from copy import copy
+from pathlib import Path
+
+import toml
+
+Logger = logging.getLogger(__file__)
+
+BASE = Path.home() / ".isofit"
+DATA = {
+    "env": BASE / "env.toml",
+    "data": BASE / "data",
+    "examples": BASE / "examples",
+    "srtmnet": BASE / "sRTMnet",
+    "sixs": BASE / "sixs",
+    "modtran": BASE / "modtran",
+}
+
+
+def __getattr__(key):
+    """
+    Retrieves a key from DATA if it exists, otherwise raises an exception
+    """
+    if key in DATA:
+        return DATA[key]
+
+
+def setEnv(key, value):
+    """ """
+    if key in DATA:
+        DATA[key] = Path(value).absolute()
+    elif key == "base":
+        updateBase(value)
+    else:
+        Logger.error(f"Key is not a valid option: {key}")
+
+
+def updateBase(value):
+    """ """
+    global BASE
+
+    new = Path(value)
+
+    # Update the value if it was the default
+    # If this value is already different, do not change
+    for key, value in DATA.items():
+        if value == BASE / value.name:
+            DATA[key] = new / value.name
+
+    # Update the base
+    BASE = new
+
+
+def keys():
+    """
+    Passthrough
+    """
+    return DATA.keys()
+
+
+def items():
+    """
+    Passthrough
+    """
+    return DATA.items()
+
+
+def dump():
+    """ """
+    # TOML doesn't support PosixPath, cast back to str
+    data = copy(DATA)
+    for key, val in data.items():
+        if isinstance(val, Path):
+            data[key] = str(val)
+
+    return data
+
+
+def mkdir(path=None):
+    """ """
+    path = Path(path)
+    if not (base := path.parent).exists():
+        base.mkdir(parents=True, exist_ok=True)
+
+
+def loadEnv(base=None, env=None):
+    """
+    Loads an environment file
+
+    Parameters
+    ----------
+    base: str
+        Override the base directory
+    env: str
+        Override the environment file path
+    """
+    base = Path(base or BASE)
+    if not (env := env or DATA["env"]):
+        env = base / "env.toml"
+
+    load = DATA
+    if Path(env).exists():
+        load.update(toml.load(env))
+    else:
+        env = "defaults"
+
+    for key in keys():
+        val = Path(load.get(key))
+        setEnv(key, val)
+
+    Logger.debug(f"Loaded env from: {env}")
+
+
+def dumpEnv(base=None, env=None):
+    """
+    Dumps to an environment file
+
+    Parameters
+    ----------
+    base: str
+        Override the base directory
+    env: str
+        Override the environment file path
+    """
+    base = Path(base or BASE)
+    if not (env := env or DATA["env"]):
+        env = base / "env.toml"
+
+    # Make sure the parent directories exist
+    mkdir(env)
+    with open(env, "w") as file:
+        toml.dump(dump(), file)
+
+    Logger.debug(f"Writing env to: {env}")

--- a/isofit/test/test_env.py
+++ b/isofit/test/test_env.py
@@ -8,7 +8,7 @@ from isofit.core import env
 
 
 def test_getattr_existing_key():
-    assert env.data == str(env.HOME / ".isofit/data")
+    assert env.data == env.DATA["data"]
 
 
 def test_changePath():

--- a/isofit/test/test_env.py
+++ b/isofit/test/test_env.py
@@ -21,7 +21,7 @@ def test_changePath():
 
 @patch("builtins.open", new_callable=mock_open)
 def test_loadEnv_file_exists(mock_open):
-    path = "/abc.toml"
+    path = "/abc.ini"
     data = {f"/abc/{key}" for key in env.KEYS}
 
     with patch("pathlib.Path.exists", return_value=True), patch.object(

--- a/isofit/test/test_env.py
+++ b/isofit/test/test_env.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+import toml
+
+from isofit.core import env
+
+
+def test_getattr_existing_key():
+    assert env.data == str(env.HOME / ".isofit/data")
+
+
+def test_changePath():
+    key = "data"
+    val = "/abc"
+    env.changePath(key, val)
+
+    assert env.DATA[key] == val
+
+
+@patch("builtins.open", new_callable=mock_open)
+def test_loadEnv_file_exists(mock_open):
+    path = "/abc.toml"
+    data = {f"/abc/{key}" for key in env.KEYS}
+
+    with patch("pathlib.Path.exists", return_value=True), patch(
+        "toml.load", return_value=data
+    ):
+        env.loadEnv(path)
+
+    mock_open.assert_called_once_with(path, "r")
+    assert env.DATA == data
+    assert env.TOML == Path(path)
+
+
+@patch("builtins.open", new_callable=mock_open)
+def test_loadEnv_file_not_exists(mock_open):
+    path = "/abc.toml"
+    with patch("pathlib.Path.exists", return_value=False):
+        env.loadEnv(path)
+
+    # loadEnv changes TOML for the remainder of the session
+    assert env.TOML == Path(path)
+
+
+@patch("builtins.open", new_callable=mock_open)
+def test_saveEnv(mock_open):
+    path = "/test/save_env_test.toml"
+    with patch("pathlib.Path.parent.mkdir") as mock_mkdir:
+        env.saveEnv(path)
+
+        mock_mkdir.assert_called_once()
+
+        # saveEnv changes TOML for the remainder of the session
+        assert env.TOML == Path(path)

--- a/isofit/test/test_env.py
+++ b/isofit/test/test_env.py
@@ -12,31 +12,31 @@ def test_getattr_existing_key():
 
 
 def test_changePath():
-    key = "data"
-    val = "/abc"
-    env.changePath(key, val)
+    expected = {}
+    for key in env.KEYS:
+        expected[key] = (val := f"/test/{key}")
+        env.changePath(key, val)
 
-    assert env.CONFIG["DEFAULT"][key] == val
+    assert env.CONFIG["DEFAULT"] == expected
 
 
-@patch("builtins.open", new_callable=mock_open)
+@patch("builtins.open")
 def test_loadEnv_file_exists(mock_open):
-    path = "/abc.ini"
-    data = {f"/abc/{key}" for key in env.KEYS}
+    path = "test.ini"
+    data = {key: f"/test/{key}" for key in env.KEYS}
 
     with patch("pathlib.Path.exists", return_value=True), patch.object(
         env.CONFIG, "read", return_value=None
     ):
         env.load(path)
 
-    mock_open.assert_called_once_with(path, "r")
     assert dict(env.CONFIG["DEFAULT"]) == data
     assert env.INI == Path(path)
 
 
-@patch("builtins.open", new_callable=mock_open)
+@patch("builtins.open")
 def test_loadEnv_file_not_exists(mock_open):
-    path = "/abc.ini"
+    path = "test.ini"
     with patch("pathlib.Path.exists", return_value=False):
         env.load(path)
 
@@ -44,15 +44,11 @@ def test_loadEnv_file_not_exists(mock_open):
     assert env.INI == Path(path)
 
 
-@patch("builtins.open", new_callable=mock_open)
+@patch("builtins.open")
 def test_saveEnv(mock_open):
-    path = "/abc.ini"
-    with patch.object(env.CONFIG, "write") as mock_write, patch(
-        "pathlib.Path.parent.mkdir"
-    ) as mock_mkdir:
+    path = "test.ini"
+    with patch.object(env.CONFIG, "write"), patch("pathlib.Path.mkdir"):
         env.save(path)
-
-        mock_mkdir.assert_called_once()
 
         # save changes INI for the remainder of the session
         assert env.INI == Path(path)

--- a/isofit/utils/downloads.py
+++ b/isofit/utils/downloads.py
@@ -8,11 +8,12 @@ import os
 import urllib.request
 from email.message import EmailMessage
 from functools import partial
+from pathlib import Path
 from zipfile import ZipFile
 
 import click
 
-import isofit
+from isofit.core import env
 
 
 def release_metadata(org, repo, tag="latest"):
@@ -124,6 +125,39 @@ def unzip(file, path=None, rename=None, overwrite=False, cleanup=True):
     return outp
 
 
+def prepare_output(output, default):
+    """
+    Prepares the output path by ensuring the parents exist and itself doesn't presently exist.
+
+    Parameters
+    ----------
+    output: str | None
+        Path to download to
+    default: str
+        Default path defined by the ini file
+    """
+    if not output:
+        output = default
+
+    output = Path(output)
+
+    click.echo(f"Output as: {output}")
+
+    if output.exists():
+        click.echo(
+            f"Path already exists, please remove it if you would like to redownload"
+        )
+        return
+
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        click.echo(f"Failed to create output directory: {e}")
+        return
+
+    return output
+
+
 # Main command
 
 
@@ -137,7 +171,7 @@ def cli_download():
 
 # Shared click options
 
-output = partial(click.option, "-o", "--output", default=isofit.root, show_default=True)
+output = partial(click.option, "-o", "--output")
 tag = click.option(
     "-t", "--tag", default=f"latest", help="Release tag to pull", show_default=True
 )
@@ -146,22 +180,77 @@ tag = click.option(
 # Subcommands
 
 
-@cli_download.command(name="data")
-@output(help="Root directory to download data files to, ie. [path]/data")
-@tag
-def data(output, tag):
-    """\
+def download_data(output=None, tag="latest"):
+    """
     Downloads the extra ISOFIT data files from the repository https://github.com/isofit/isofit-data.
+
+    Parameters
+    ----------
+    output: str | None
+        Path to output as. If None, defaults to the ini path.
+    tag: str
+        Release tag to pull from the github.
     """
     click.echo(f"Downloading ISOFIT data")
+
+    output = prepare_output(output, env.data)
+    if not output:
+        return
 
     metadata = release_metadata("isofit", "isofit-data", tag)
 
     click.echo(f"Pulling release {metadata['tag_name']}")
-    zipfile = download_file(metadata["zipball_url"], f"{output}/isofit-data.zip")
+    zipfile = download_file(metadata["zipball_url"], output.parent / "isofit-data.zip")
 
     click.echo(f"Unzipping {zipfile}")
-    avail = unzip(zipfile, path=output, rename="data")
+    avail = unzip(zipfile, path=output.parent, rename=output.name)
+
+    click.echo(f"Done, now available at: {avail}")
+
+
+@cli_download.command(name="data")
+@output(help="Root directory to download data files to, ie. [path]/data")
+@tag
+def cli_data(**kwargs):
+    """\
+    Downloads the extra ISOFIT data files from the repository https://github.com/isofit/isofit-data.
+
+    Run `isofit download paths` to see default path locations.
+    There are two ways to specify output directory:
+        - `isofit --data /path/data download data`: Override the ini file. This will save the provided path for future reference.
+        - `isofit download data --output /path/data`: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
+    It is recommended to use the first style so the download path is remembered in the future.
+    """
+    download_data(**kwargs)
+
+
+def download_examples(output=None, tag="latest"):
+    """
+    Downloads the ISOFIT examples from the repository https://github.com/isofit/isofit-tutorials.
+
+    Parameters
+    ----------
+    output: str | None
+        Path to output as. If None, defaults to the ini path.
+    tag: str
+        Release tag to pull from the github.
+    """
+
+    click.echo(f"Downloading ISOFIT examples")
+
+    output = prepare_output(output, env.examples)
+    if not output:
+        return
+
+    metadata = release_metadata("isofit", "isofit-tutorials", tag)
+
+    click.echo(f"Pulling release {metadata['tag_name']}")
+    zipfile = download_file(
+        metadata["zipball_url"], output.parent / "isofit-tutorials.zip"
+    )
+
+    click.echo(f"Unzipping {zipfile}")
+    avail = unzip(zipfile, path=output.parent, rename=output.name)
 
     click.echo(f"Done, now available at: {avail}")
 
@@ -169,18 +258,47 @@ def data(output, tag):
 @cli_download.command(name="examples")
 @output(help="Root directory to download ISOFIT examples to, ie. [path]/examples")
 @tag
-def examples(output, tag):
+def cli_data(**kwargs):
     """\
     Downloads the ISOFIT examples from the repository https://github.com/isofit/isofit-tutorials.
+
+    Run `isofit download paths` to see default path locations.
+    There are two ways to specify output directory:
+        - `isofit --examples /path/examples download examples`: Override the ini file. This will save the provided path for future reference.
+        - `isofit download examples --output /path/examples`: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
+    It is recommended to use the first style so the download path is remembered in the future.
     """
-    click.echo(f"Downloading ISOFIT examples")
+    download_examples(**kwargs)
 
-    metadata = release_metadata("isofit", "isofit-tutorials", tag)
 
-    click.echo(f"Pulling release {metadata['tag_name']}")
-    zipfile = download_file(metadata["zipball_url"], f"{output}/isofit-tutorials.zip")
+@cli_download.command(name="all")
+def download_all():
+    """\
+    Downloads all ISOFIT extra dependencies to the locations specified in the isofit.ini file using latest tags.
+    """
+    download_data(env.data, tag="latest")
+    download_examples(env.examples, tag="latest")
 
-    click.echo(f"Unzipping {zipfile}")
-    avail = unzip(zipfile, path=output, rename="examples")
 
-    click.echo(f"Done, now available at: {avail}")
+@cli_download.command(name="paths")
+def preview_paths():
+    """\
+    Preview download path locations. Paths can be changed from the default by using the overrides on the `isofit` command. See more via `isofit --help`
+
+    \b
+    Example:
+    Change the default `data` and `examples` paths
+    $ isofit --data /path/to/data --examples /different/path/examples download paths
+        Download paths will default to:
+        - data = /path/to/data
+        - examples = /different/path/examples
+    \b
+    These will be saved and may be reviewed:
+    $ isofit download paths
+        Download paths will default to:
+        - data = /path/to/data
+        - examples = /different/path/examples
+    """
+    click.echo("Download paths will default to:")
+    for key, path in env.items():
+        click.echo(f"- {key} = {path}")

--- a/isofit/utils/downloads.py
+++ b/isofit/utils/downloads.py
@@ -258,7 +258,7 @@ def download_examples(output=None, tag="latest"):
 @cli_download.command(name="examples")
 @output(help="Root directory to download ISOFIT examples to, ie. [path]/examples")
 @tag
-def cli_data(**kwargs):
+def cli_examples(**kwargs):
     """\
     Downloads the ISOFIT examples from the repository https://github.com/isofit/isofit-tutorials.
 


### PR DESCRIPTION
# Description
Attempts to replace the `isofit.root` variable that is used to discover various paths such as tests, data, and examples, with a more flexible `isofit.ini` file that will by default be stored at a user's `~/.isofit/`.

Closes #465

# Changes
- Implements module `isofit/core/env.py` which houses the functions for managing this "environment" directory
  - Uses ConfigParser `ini` files to store path information to persist between runs
  - This path can be changed via the CLI in case a user doesn't/can't use the default location
- Expands the `isofit` CLI with override flags to enable setting a value for the run
  - Examples:
    - `isofit --ini /some/other/path/env.ini apply_oe ...`
    - `isofit --data ./data download data` create `./data`, save it in `~/.isofit/isofit.ini` and download the data to it
    - `isofit --srtmnet /path/to/srtmnet apply_oe ...` by default will `--save` this path to `~/.isofit/isofit.ini` so future calls will use it
- ISOFIT will autocreate this directory on first invocation of the CLI. If overrides are provided, by default update the env with the new values
- Downloads CLI has been updated to default to the paths provided by the ini. A user may override the path one of two ways:
  - `isofit --data /path/data download data`: Use the override flag to override the ini file. This will save the provided path for future reference.
  - `isofit download data --output /path/data`: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
- Added `isofit download paths` to preview the paths saved in the ini file
  - The override CLI can change these paths prior to a user executing the actual downloads
- Added `isofit download all` to download the `latest` release for both `data` and `examples`

# TODO
- [x] Update `download.py` to use this
- [x] Tests
