### PR TITLE
Graceful shutdown

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -796,6 +796,9 @@ def ray_start(num_cores, num_cpus=2, memory_b=-1):
 def ray_terminate():
     import subprocess
 
+    import ray
+
+    ray.shutdown()
     subprocess.call("ray stop", shell=True)
 
 


### PR DESCRIPTION
The external ray stop call was causing some odd external failures...this gives a more graceful behavior.  Wait for #468.