### PR TITLE
Ray cleanup

### DIFF
--- a/.imgspec/apply_glt.py
+++ b/.imgspec/apply_glt.py
@@ -132,7 +132,7 @@ def _write_bil_chunk(dat: np.array, outfile: str, line: int, shape: tuple, dtype
     outfile.close()
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 def apply_mosaic_glt_line(glt_filename: str, output_filename: str, rawspace_files: List, output_bands: np.array,
                           line_index: int, args: List):
     """

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -791,30 +791,3 @@ def ray_start(num_cores, num_cpus=2, memory_b=-1):
         base_args.append(address)
 
         result = subprocess.run(base_args, capture_output=True)
-
-
-def ray_terminate():
-    import subprocess
-
-    subprocess.call("ray stop", shell=True)
-
-
-def ray_initiate(raydict, num_cpus=1):
-
-    import ray
-
-    initialized = False
-    try:
-        initialized = ray.is_initialized()
-    except:
-        pass
-
-    if initialized:
-        return
-
-    try:
-        ray.init(**raydict)
-    except:
-        if "num_cpus" in raydict.keys():
-            del raydict["num_cpus"]
-        ray.init(**raydict)

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -29,7 +29,6 @@ import numpy as np
 
 from isofit import ray
 from isofit.configs import configs
-from isofit.core.common import ray_initiate
 from isofit.core.fileio import IO
 from isofit.core.forward import ForwardModel
 from isofit.inversion.inverse import Inversion
@@ -85,7 +84,7 @@ class Isofit:
         ):
             rayargs["num_cpus"] = self.config.implementation.n_cores
 
-        ray_initiate(rayargs)
+        ray.init(**rayargs)
 
         self.workers = None
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -588,7 +588,7 @@ class RadiativeTransferEngine:
         return data
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 def streamSimulation(
     point: np.array,
     lut_names: list,

--- a/isofit/test/test_wray.py
+++ b/isofit/test/test_wray.py
@@ -51,7 +51,7 @@ def test_classes(name="test", n=4):
     assert "isofit.wrappers.ray" in str(ray)
 
     name_id = ray.put(name)
-    worker = ray.remote(Worker)
+    worker = ray.remote()(Worker)
     workers = ray.util.ActorPool([worker.remote(name_id) for _ in range(n)])
 
     results = workers.map_unordered(lambda a, b: a.some_func.remote(b), range(n))

--- a/isofit/test/test_wray.py
+++ b/isofit/test/test_wray.py
@@ -6,6 +6,11 @@ def decorator(a, b):
     return a * b
 
 
+@ray.remote()
+def decorator_nocpu(a, b):
+    return a * b
+
+
 def test_decorators():
     """
     Tests decorator use cases of Ray
@@ -22,6 +27,9 @@ def test_decorators():
         assert res == ans, f"Failed {a}*{b}, got {res} expected {ans}"
 
     jobs = [decorator.remote(a, b) for a, b in cases.values()]
+    assert ray.get(jobs) == list(cases.keys())
+
+    jobs = [decorator_nocpu.remote(a, b) for a, b in cases.values()]
     assert ray.get(jobs) == list(cases.keys())
 
 

--- a/isofit/test/test_wray.py
+++ b/isofit/test/test_wray.py
@@ -1,7 +1,7 @@
 from isofit.wrappers import ray
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 def decorator(a, b):
     return a * b
 

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -30,7 +30,7 @@ from spectral.io import envi
 
 from isofit import ray
 from isofit.configs import configs
-from isofit.core.common import envi_header, load_spectrum, ray_initiate
+from isofit.core.common import envi_header, load_spectrum
 from isofit.core.fileio import write_bil_chunk
 from isofit.core.forward import ForwardModel
 from isofit.core.geometry import Geometry
@@ -170,7 +170,7 @@ def analytical_line(
         "num_cpus": n_cores,
     }
 
-    ray_initiate(ray_dict)
+    ray.init(**ray_dict)
 
     n_workers = n_cores
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -188,15 +188,12 @@ def apply_oe(args):
 
     use_superpixels = args.empirical_line or args.analytical_line
 
-    if not os.environ.get("ISOFIT_DEBUG"):
-        ray.init(
-            **{
-                "num_cpus": args.n_cores,
-                "_temp_dir": args.ray_temp_dir,
-                "include_dashboard": False,
-                "local_mode": args.n_cores == 1,
-            }
-        )
+    ray.init(
+        num_cpus=args.n_cores,
+        _temp_dir=args.ray_temp_dir,
+        include_dashboard=False,
+        local_mode=args.n_cores == 1,
+    )
 
     if args.sensor not in SUPPORTED_SENSORS:
         if args.sensor[:3] != "NA-":

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -28,12 +28,12 @@ from scipy.spatial import KDTree
 from spectral.io import envi
 
 from isofit import ray
-from isofit.core.common import envi_header, ray_initiate
+from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
 from isofit.core.forward import ForwardModel
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 def _run_chunk(
     start_line: int,
     stop_line: int,
@@ -294,7 +294,7 @@ def atm_interpolation(
 
     # Initialize ray cluster
     start_time = time.time()
-    ray_initiate({"ignore_reinit_error": True, "local_mode": n_cores == 1})
+    ray.init(**{"ignore_reinit_error": True, "local_mode": n_cores == 1})
 
     n_ray_cores = int(ray.available_resources()["CPU"])
     n_cores = min(n_ray_cores, n_input_lines)

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -18,6 +18,7 @@
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 #
 import logging
+import multiprocessing
 import time
 from typing import List
 
@@ -296,7 +297,7 @@ def atm_interpolation(
     start_time = time.time()
     ray.init(**{"ignore_reinit_error": True, "local_mode": n_cores == 1})
 
-    n_ray_cores = int(ray.available_resources()["CPU"])
+    n_ray_cores = multiprocessing.cpu_count()
     n_cores = min(n_ray_cores, n_input_lines)
 
     logging.info(f"Beginning atmospheric interpolation {n_cores} cores")

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -31,12 +31,12 @@ from spectral.io import envi
 
 from isofit import ray
 from isofit.configs import configs
-from isofit.core.common import envi_header, ray_initiate
+from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
 from isofit.core.instrument import Instrument
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 def _run_chunk(
     start_line: int,
     stop_line: int,
@@ -524,7 +524,7 @@ def empirical_line(
     ):
         rayargs["num_cpus"] = n_cores
 
-    ray_initiate(rayargs)
+    ray.init(**rayargs)
 
     n_ray_cores = multiprocessing.cpu_count()
     n_cores = min(n_ray_cores, n_input_lines)

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -127,7 +127,7 @@ def main(args: SimpleNamespace) -> None:
     )
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 def run_lines(
     rfl_file: str,
     output_cwc_file: str,

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -24,11 +24,11 @@ import numpy as np
 from spectral.io import envi
 
 from isofit import ray
-from isofit.core.common import envi_header, ray_initiate
+from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 def extract_chunk(
     lstart: int,
     lend: int,
@@ -174,7 +174,7 @@ def extractions(
     if ray_ip_head is None and ray_redis_password is None:
         rayargs["num_cpus"] = n_cores
 
-    ray_initiate(rayargs)
+    ray.init(**rayargs)
 
     labelid = ray.put(labels)
     jobs = []

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -27,10 +27,10 @@ from skimage.segmentation import slic
 from spectral.io import envi
 
 from isofit import ray
-from isofit.core.common import envi_header, ray_initiate
+from isofit.core.common import envi_header
 
 
-@ray.remote
+@ray.remote(num_cpus=1)
 def segment_chunk(
     lstart, lend, in_file, nodata_value, npca, segsize, logfile=None, loglevel="INFO"
 ):
@@ -207,7 +207,7 @@ def segment(
     if ray_ip_head is None and ray_redis_password is None:
         rayargs["num_cpus"] = n_cores
 
-    ray_initiate(rayargs)
+    ray.init(**rayargs)
 
     # Iterate through image "chunks," segmenting as we go
     all_labels = np.zeros((nl, ns), dtype=np.int64)

--- a/isofit/wrappers/ray.py
+++ b/isofit/wrappers/ray.py
@@ -50,7 +50,7 @@ def __getattr__(key):
     return lambda *a, **kw: None
 
 
-def remote(obj):
+def remote(obj, *args, **kwargs):
     return Remote(obj)
 
 

--- a/isofit/wrappers/ray.py
+++ b/isofit/wrappers/ray.py
@@ -14,6 +14,7 @@ $ ISOFIT_DEBUG=1 python isofit.py ...
 """
 
 import logging
+from types import FunctionType
 
 Logger = logging.getLogger("isofit/wrappers/ray")
 
@@ -54,6 +55,8 @@ def remote(*args, **kwargs):
     def wrap(obj):
         return Remote(obj)
 
+    if len(args) == 1 and isinstance(args[0], (FunctionType, object)):
+        return wrap(*args)
     return wrap
 
 

--- a/isofit/wrappers/ray.py
+++ b/isofit/wrappers/ray.py
@@ -50,8 +50,11 @@ def __getattr__(key):
     return lambda *a, **kw: None
 
 
-def remote(obj, *args, **kwargs):
-    return Remote(obj)
+def remote(*args, **kwargs):
+    def wrap(obj):
+        return Remote(obj)
+
+    return wrap
 
 
 def init(*args, **kwargs):


### PR DESCRIPTION
Attempt to cleanup ray initialization to not rely on external calls, now that the procedure has sorted out.  Main changes:

- remove ray_start function that made external ray start calls
- remove ray_shutdown function that made external ray stop calls
- add num_cpu=1 decorators to all ray.remote calls that didn't have them.

This deprecates #472 if accepted.  Removes the error:

```
(raylet) The autoscaler failed with the following error:
Terminated with signal 15
  File "/beegfs/store/shared/nostripe/conda-shared-envs/isofit_env/lib/python3.11/site-packages/ray/autoscaler/_private/monitor.py", line 709, in <module>
    monitor.run()
  File "/beegfs/store/shared/nostripe/conda-shared-envs/isofit_env/lib/python3.11/site-packages/ray/autoscaler/_private/monitor.py", line 584, in run
    self._run()
  File "/beegfs/store/shared/nostripe/conda-shared-envs/isofit_env/lib/python3.11/site-packages/ray/autoscaler/_private/monitor.py", line 438, in _run
    time.sleep(AUTOSCALER_UPDATE_INTERVAL_S)

```

To do: 

- [ ] performance testing