### PR TITLE
LUT Creation Improvements

### DIFF
--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -53,5 +53,8 @@ def shutdown_ray():
 # Auto call ray.shutdown when the python interpreter exits
 # ray itself also implements this, but there's no harm in calling it twice
 atexit.register(shutdown_ray)
-signal.signal(signal.SIGINT, shutdown_ray)  # ctrl+C
-signal.signal(signal.SIGTERM, shutdown_ray)  # kill
+try:
+    signal.signal(signal.SIGINT, shutdown_ray)  # ctrl
+    signal.signal(signal.SIGTERM, shutdown_ray)  # kill
+except:
+    pass

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -793,6 +793,9 @@ def ray_start(num_cores, num_cpus=2, memory_b=-1):
         result = subprocess.run(base_args, capture_output=True)
 
 
+from datetime import datetime as dtt
+
+
 class Track:
     """
     Tracks and reports the percentage complete for some arbitrary sized iterable.

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -791,3 +791,70 @@ def ray_start(num_cores, num_cpus=2, memory_b=-1):
         base_args.append(address)
 
         result = subprocess.run(base_args, capture_output=True)
+
+
+class Track:
+    """
+    Tracks and reports the percentage complete for some arbitrary sized iterable.
+
+    Borrowed from mlky
+    """
+
+    def __init__(self, total, step=5, print=print, reverse=False, message="complete"):
+        """
+        Parameters
+        ----------
+        total: int, iterable
+            Total items in iterable. If iterable, will call len() on it
+        step: float, default=0.05
+            Percentage step size to use for reporting, eg. 0.05 is every 5%
+        print: func, default=print
+            Print function to use, eg. logging.info
+        reverse: bool, default=False
+            Reverse the count such that 0 is 100%
+        message: str, default="complete"
+            Message to be included in the output
+        """
+        if hasattr(total, "__iter__"):
+            total = len(total)
+
+        self.step = step
+        self.total = total
+        self.print = print
+        self.start = dtt.now()
+        self.percent = step
+        self.reverse = reverse
+        self.message = message
+
+    def __call__(self, count):
+        """
+        Parameters
+        ----------
+        count: int, iterable
+            The current count of items finished. If iterable, will call len() on it
+
+        Returns
+        -------
+        bool
+            True if a percentage step was just crossed, False otherwise
+        """
+        if hasattr(count, "__iter__"):
+            count = len(count)
+
+        current = count / self.total
+        if self.reverse:
+            current = 1 - current
+        current *= 100
+
+        if current >= self.percent:
+            elap = dtt.now() - self.start
+            rate = elap / self.total
+            esti = 100 / self.percent * elap - elap
+
+            self.print(
+                f"{current:6.2f}% {self.message} (elapsed: {elap}, rate: {rate}, eta: {esti})"
+            )
+            self.percent += self.step
+
+            return True
+        return False

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -10,28 +10,7 @@ import numpy as np
 import xarray as xr
 from netCDF4 import Dataset
 
-# This resolves race/lock conditions with file opening in updatePoint()
-os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
-
 Logger = logging.getLogger(__file__)
-
-# TODO: Temporary locking lut files for updatePoint until a new solution is found
-import fcntl
-import hashlib
-
-
-class SystemMutex:
-    def __init__(self, name):
-        self.name = name
-
-    def __enter__(self):
-        lock_id = hashlib.md5(self.name.encode("utf8")).hexdigest()
-        self.fp = open(f"/tmp/.lock-{lock_id}.lck", "wb")
-        fcntl.flock(self.fp.fileno(), fcntl.LOCK_EX)
-
-    def __exit__(self, _type, value, tb):
-        fcntl.flock(self.fp.fileno(), fcntl.LOCK_UN)
-        self.fp.close()
 
 
 def initialize(
@@ -98,82 +77,22 @@ def initialize(
     return ds.stack(point=lut_grid).transpose("point", "wl")
 
 
-def updatePoint(
-    file: str, lut_names: list = [], point: tuple = (), data: dict = {}
-) -> None:
+def updatePoint(ds, point, data):
     """
-    Updates a point in a LUT NetCDF
+    Updates a point in a LUT Dataset.
 
     Parameters
     ----------
-    lut_names: list
-        List of str (lut_names)
-    point: tuple
-        Point values
+    ds: xr.Dataset
+        The working LUT Dataset.
+    point: dict
+        Dictionary of point dimensions to coordinate value to update on.
     data: dict
-        Input data to write. Aside from the following special keys, all keys in
-        the dict should have the shape (len(wl), len(points)). Special keys:
-               wl - This is set at lut initialization, will assert np.isclose
-                    the existing lut[wl] against data[wl]
-        solar_irr - Not along the point dimension, presently clobbers with
-                    every new input
+        Input data to write at a point.
     """
-    with SystemMutex("lock"):
-        with Dataset(file, "a") as nc:
-            # Retrieves the index for a point value
-            index = lambda key, val: np.argwhere(nc[key][:] == val)[0][0]
-
-            # Assume all keys will have the same dimensions in the same order, so just use a random key
-            key, _ = max(nc.variables.items(), key=lambda pair: len(pair[1].dimensions))
-
-            # nc[key].dimensions is ordered, nc.dimensions may be out of order
-            dims = nc[key].dimensions
-            inds = [-1] * len(dims)
-            for i, dim in enumerate(dims):
-                if dim == "wl":
-                    # Wavelength uses all values
-                    inds[i] = slice(None)
-                elif dim in lut_names:
-                    # Retrieve the index of this point value
-                    inds[i] = index(dim, point[lut_names.index(dim)])
-                else:
-                    # Default to using the first index if key not in the lut_names
-                    # This should only happen if you were updating an existing LUT with fewer point dimensions than exists
-                    # REVIEW: Should we support this edge case? If we do, ought to add a `defaults={dim: index}` to control
-                    # what the default index for dims are
-                    # REVIEW: rte.postSim() may call this with lut_names=[], causing this to be hit each time
-                    Logger.debug(
-                        f"Defaulting to index 0 for dimension {dim!r} because it is not in the lut_names: {lut_names}"
-                    )
-                    inds[i] = 0
-
-            Logger.debug(f"Writing to point {point!r}, resolved indices: {inds!r}")
-
-            # Now insert the values at this point
-            for key, values in data.items():
-                if key not in nc.variables:
-                    Logger.error(f"Key doesn't exist in LUT file, skipping: {key}")
-
-                elif key == "wl":
-                    assert np.isclose(nc[key][:], values).all(), (
-                        f"Input data wavelengths do not match existing wavelengths for file: {file}\n"
-                        + f"Expected: {nc[key][:]}\n"
-                        + f"Received: {values}"
-                    )
-                else:
-                    var = nc[key]
-                    dim = len(var.dimensions)
-
-                    # REVIEW: parallel safe to clobber?
-                    if dim == 0:
-                        # Constant/scalar value
-                        var.assignValue(values)
-                    elif dim == 1:
-                        # Not on the point dimension
-                        var[:] = values
-                    else:
-                        # Not a special case, save as-is
-                        var[inds] = values
+    point = ds.loc[point]
+    for key, value in data.items():
+        point[key][:] = value
 
 
 def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -40,6 +40,7 @@ class Keys:
         "thermal_upwelling",
         "thermal_downwelling",
     ]
+
     # These keys are filled with zeros instead of NaNs
     zeros = [
         "transm_down_dir",

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -14,7 +14,9 @@ from netCDF4 import Dataset
 Logger = logging.getLogger(__file__)
 
 
-class Create:
+# Statically store expected keys of the LUT file
+class Keys:
+
     # Constants, not along any dimension
     consts = [
         "coszen",
@@ -45,6 +47,9 @@ class Create:
         "transm_up_dir",
         "transm_up_dif",
     ]
+
+
+class Create:
 
     def __init__(
         self,
@@ -86,14 +91,10 @@ class Create:
 
         self.sizes = {key: len(val) for key, val in grid.items()}
 
-        if consts:
-            self.consts += consts
-        if onedim:
-            self.onedim += onedim
-        if alldim:
-            self.alldim += alldim
-        if zeros:
-            self.zeros += zeros
+        self.consts = Keys.consts + consts
+        self.onedim = Keys.onedim + onedim
+        self.alldim = Keys.alldim + alldim
+        self.zeros = Keys.zeros + zeros
 
         # Save ds for backwards compatibility (to work with extractGrid, extractPoints)
         self.ds = self.initialize()

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -61,7 +61,7 @@ class Create:
         onedim: List[str] = [],
         alldim: List[str] = [],
         zeros: List[str] = [],
-        reduce: bool = True,
+        reduce: bool = ["fwhm"],
     ):
         """
         Prepare a LUT netCDF
@@ -82,8 +82,9 @@ class Create:
             List of multi-dimensional data. Appends to the current Create.alldim list.
         zeros : List[str], optional, default=[]
             List of zero values. Appends to the current Create.zeros list.
-        reduce : bool, default=True
-            Reduces the initialized Dataset by dropping the variables to reduce overall memory usage
+        reduce : bool or list, optional, default=['fwhm']
+            Reduces the initialized Dataset by dropping the variables to reduce overall memory usage.
+            If True, drops all variables. If list, drop everything but these.
         """
         self.file = file
         self.wl = wl
@@ -102,7 +103,14 @@ class Create:
 
         # Remove variables to reduce memory footprint
         if reduce:
-            self.ds = self.ds.drop_vars(self.ds)
+            # Drop all variables
+            drop = set(self.ds)
+
+            # Remove these from the drop list
+            if isinstance(reduce, list):
+                drop -= set(reduce)
+
+            self.ds = self.ds.drop_vars(drop)
 
     def initialize(self) -> None:
         """

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -168,7 +168,9 @@ class Create:
         List[int]
             Mapped point values to index positions.
         """
-        return [np.where(grid[dim] == val)[0][0] for dim, val in zip(grid, point)]
+        return [
+            np.where(self.grid[dim] == val)[0][0] for dim, val in zip(self.grid, point)
+        ]
 
     def queuePoint(self, point: np.ndarray, data: dict) -> None:
         """

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -144,7 +144,7 @@ class Create:
         ds.to_netcdf(self.file, mode="w", compute=False, engine="netcdf4")
 
         # Create the point dimension
-        ds.stack(point=self.grid).transpose("point", "wl")
+        ds = ds.stack(point=self.grid).transpose("point", "wl")
 
         # Save to obj for backwards compatibility (to work with extractGrid, extractPoints)
         self.point = ds.point

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -142,7 +142,7 @@ class Create:
         ds.to_netcdf(self.file, mode="w", compute=False, engine="netcdf4")
 
         # Create the point dimension
-        return ds.stack(point=lut_grid).transpose("point", "wl")
+        return ds.stack(point=self.grid).transpose("point", "wl")
 
     def pointIndices(self, point: np.ndarray) -> List[int]:
         """

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -66,7 +66,7 @@ class Create:
         wl : np.ndarray
             The wavelength array.
         grid : dict
-            The LUT grid, formatted as {str: np.ndarray}.
+            The LUT grid, formatted as {str: Iterable}.
         consts : List[str], optional, default=[]
             List of constant values. Appends to the current Create.consts list.
         onedim : List[str], optional, default=[]
@@ -81,7 +81,7 @@ class Create:
         self.grid = grid
         self.hold = []
 
-        self.sizes = {key: val.size for key, val in grid.items()}
+        self.sizes = {key: len(val) for key, val in grid.items()}
 
         if consts:
             self.consts += consts

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -226,6 +226,22 @@ class Create:
         """
         return getattr(self.ds, key)
 
+    def __getitem__(self, key: str) -> Any:
+        """
+        Passthrough to __getitem__ on the underlying 'ds' attribute.
+
+        Parameters
+        ----------
+        key : str
+            The name of the item to retrieve.
+
+        Returns
+        -------
+        Any
+            The value of the item retrieved from the 'ds' attribute.
+        """
+        return self.ds[key]
+
     def __repr__(self) -> str:
         return f"LUT(wl={self.wl.size}, grid={self.grid})"
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -182,7 +182,7 @@ class RadiativeTransferEngine:
             self.lut = luts.Create(
                 file=self.lut_path,
                 wl=wl,
-                lut_grid=self.lut_grid,
+                grid=self.lut_grid,
                 onedim=[("fwhm", fwhm)],
             )
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -259,7 +259,7 @@ class RadiativeTransferEngine:
         grid = [ds[key].data for key in self.lut_names]
 
         # Create the unique
-        for key in self.lut.alldim:
+        for key in luts.Keys.alldim:
             self.luts[key] = common.VectorInterpolator(
                 grid_input=grid,
                 data_input=ds[key].load().data,

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -177,8 +177,6 @@ class RadiativeTransferEngine:
 
             Logger.debug(f"Writing store to: {self.lut_path}")
             self.lut_grid = lut_grid
-            self.lut_names = list(lut_grid)
-            self.points = common.combos(lut_grid.values())
 
             Logger.info(f"Initializing LUT file")
             self.lut = luts.Create(
@@ -187,6 +185,9 @@ class RadiativeTransferEngine:
                 grid=self.lut_grid,
                 onedim=[("fwhm", fwhm)],
             )
+
+            # Retrieve points and names from the now existing lut dataset
+            self.points, self.lut_names = luts.extractPoints(self.lut)
 
             # Create and populate a LUT file
             self.runSimulations()

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -177,6 +177,8 @@ class RadiativeTransferEngine:
 
             Logger.debug(f"Writing store to: {self.lut_path}")
             self.lut_grid = lut_grid
+            self.lut_names = list(lut_grid)
+            self.points = common.combos(lut_grid.values())
 
             Logger.info(f"Initializing LUT file")
             self.lut = luts.Create(
@@ -185,9 +187,6 @@ class RadiativeTransferEngine:
                 grid=self.lut_grid,
                 onedim=[("fwhm", fwhm)],
             )
-
-            # Retrieve points and names from the now existing lut dataset
-            self.points, self.lut_names = luts.extractPoints(self.lut)
 
             # Create and populate a LUT file
             self.runSimulations()


### PR DESCRIPTION
# Description

I've been running tests in the background for a few architectures to improve the LUT netCDF creation performance. I've tested:
- Mutex: Our current implementation
- Stream: Using a writer queue, simulations return values back to the original ray call to be saved
- Dump: Flushing each point simulation to its own file then merging at the end. This did not scale well when points entered the thousands, so I did not complete tests for this
- Zarr: Not tested too well. This is not a direction the team desires to go so I didn't go far with it, but it still ought to be mentioned as a potential direction to explore

Of these, stream has performed the best. The tests performed measured the overhead incurred by each method by keeping the simulation portion negligible in processing time.

<img width="670" alt="image" src="https://github.com/isofit/isofit/assets/114623191/4c68987c-d408-447d-b4f1-504ec1ad4df9">

Mutex indicates an exponential growth with number of points while streaming is linear. Zooming in to show it a bit better:

<img width="670" alt="image" src="https://github.com/isofit/isofit/assets/114623191/e67685e3-a7ff-4bfb-a169-d0165e503b77">

The above indicates the streaming method to have negligible overhead compared to the significant mutex implementation.

Additional notes:
- I've noticed a potential flaw in the mutex version when utilizing ray over multiple nodes. The lock presently writes to a `/tmp` file, which means each node would have its own lock. This could potentially corrupt the netCDF file (as indicated from previous lock-less writing tests in the past).
- The streaming method will hold the data in memory. We may need to implement the ability to periodically flush to disk.
  - Memory usage between architectures has not been tested