### PR TITLE
Fix failing readthedocs build.

### DIFF
--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -22,6 +22,7 @@ dependencies:
   - scikit-learn>=0.19.1
   - scipy>=1.3.0
   - spectral>=0.19
+  - sphinx_rtd_theme
   - utm
   - xarray<2024.1.1
 


### PR DESCRIPTION
I recognized that ISOFIT's readthedocs build is currently failing since the `sphinx_rtd_theme` was missing in the environment file. I actually fixed [this a few months ago](https://github.com/isofit/isofit/pull/436/files), but it somehow disappeared from the `dev` branch again. As a consequence, our official documentation hasn't been updated to version 3 yet, causing issues like [this](https://github.com/isofit/isofit/issues/466#issuecomment-2050115847).

As soon as this PR is merged, I'll initiate a new version release to get the updated documentation running.