### PR TITLE
Use background reflectance in analytical line

### DIFF
--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -279,6 +279,12 @@ class Worker(object):
         rt_state = envi.open(envi_header(self.RT_state_file)).open_memmap(
             interleave="bip"
         )
+        if self.subs_state_file is not None:
+            subs_state = envi.open(envi_header(self.subs_state_file)).open_memmap(
+                interleave="bip"
+            )
+        if self.lbl_file is not None:
+            lbl = envi.open(envi_header(self.lbl_file)).open_memmap(interleave="bil")
 
         start_line, stop_line = startstop
         output_state = (
@@ -303,6 +309,12 @@ class Worker(object):
                     continue
                 x_RT = rt_state[r, c, self.fm.idx_RT - len(self.fm.idx_surface)]
                 geom = Geometry(obs=obs[r, c, :], loc=loc[r, c, :])
+                if self.subs_state_file is not None and self.lbl_file is not None:
+                    reference_location = lbl[r, c, 0]
+                    background_rho = subs_state[
+                        reference_location, c, self.fm.idx_surface
+                    ]
+                    geom.bg_rfl = background_rho
 
                 states, unc = invert_analytical(
                     self.iv.fm,


### PR DESCRIPTION
I've been making the argument for this as a rationale for the one-step convergence of AOE for some time, but the implementation differed slightly because of how buried things were.  However, with the new RTM formalism, this is a pretty straightforward implementation.

The biggest issue - for group discussion - is how to [handle intersections of the if statements in radiative_transfer.py](https://github.com/isofit/isofit/blob/af4718d7793ed4ad93508496a02486fa88ae436d/isofit/radiative_transfer/radiative_transfer.py#L175-L232).  As currently implemented, the use of the background_rfl will supersede topography and glint.