### PR TITLE
[Minor] Include names of supported sensors in the "invalid sensor" error message

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -199,7 +199,7 @@ def apply_oe(args):
 
     if args.sensor not in SUPPORTED_SENSORS:
         if args.sensor[:3] != "NA-":
-            errstr = 'Argument error: sensor must be one of {SUPP_SENSORS} or "NA-*"'
+            errstr = f'Argument error: sensor must be one of {SUPPORTED_SENSORS} or "NA-*"'
             raise ValueError(errstr)
 
     if args.num_neighbors is not None and len(args.num_neighbors) > 1:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -199,7 +199,9 @@ def apply_oe(args):
 
     if args.sensor not in SUPPORTED_SENSORS:
         if args.sensor[:3] != "NA-":
-            errstr = f'Argument error: sensor must be one of {SUPPORTED_SENSORS} or "NA-*"'
+            errstr = (
+                f'Argument error: sensor must be one of {SUPPORTED_SENSORS} or "NA-*"'
+            )
             raise ValueError(errstr)
 
     if args.num_neighbors is not None and len(args.num_neighbors) > 1:


### PR DESCRIPTION
This PR ensures we print the names of the supported sensors when `apply_oe` is called with an unsupported sensor name.