### PR TITLE
Added INVERSION_WINDOWS to presolve and main configs

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -523,7 +523,7 @@ def apply_oe(args):
                 emulator_base=args.emulator_base,
                 uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
                 prebuilt_lut_path=args.prebuilt_lut,
-                inversion_windows= INVERSION_WINDOWS
+                inversion_windows=INVERSION_WINDOWS,
             )
 
             # Run modtran retrieval
@@ -626,7 +626,7 @@ def apply_oe(args):
             segmentation_size=args.segmentation_size,
             pressure_elevation=args.pressure_elevation,
             prebuilt_lut_path=args.prebuilt_lut,
-            inversion_windows= INVERSION_WINDOWS
+            inversion_windows=INVERSION_WINDOWS,
         )
 
         # Run modtran retrieval

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -523,6 +523,7 @@ def apply_oe(args):
                 emulator_base=args.emulator_base,
                 uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
                 prebuilt_lut_path=args.prebuilt_lut,
+                inversion_windows= INVERSION_WINDOWS
             )
 
             # Run modtran retrieval
@@ -625,6 +626,7 @@ def apply_oe(args):
             segmentation_size=args.segmentation_size,
             pressure_elevation=args.pressure_elevation,
             prebuilt_lut_path=args.prebuilt_lut,
+            inversion_windows= INVERSION_WINDOWS
         )
 
         # Run modtran retrieval


### PR DESCRIPTION
In `apply_oe`, EMIT and AVIRIS-3 have custom inversion windows that differ from the default windows, but they are not being used when generating configs. This PR adds the `INVERSION_WINDOWS` variable as an argument when calling `build_main_config` and `build_presolve_config`.