### PR TITLE
Update resampling of prebuilt LUT.

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -639,10 +639,12 @@ def resample_spectrum(
         ]
     )
 
+    # replace any NaNs in the LUT before resampling
+    x_raw[np.isnan(x_raw)] = 0.0
+
     if fill is False:
         if len(x.shape) > 1:
-            return np.array([np.nansum(H * y[np.newaxis, :], axis=1) for y in x])
-            # return np.dot(H, x_raw).transpose()
+            return np.dot(H, x_raw).transpose()
         else:
             return np.dot(H, x_raw).ravel()
     else:

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -624,6 +624,13 @@ def resample_spectrum(
         np.array: interpolated radiance vector
 
     """
+    # check if x is vector or matrix
+    if len(x.shape) > 1:
+        x_raw = x.copy()
+        x_raw = x_raw.transpose()
+    else:
+        x_raw = x.copy()
+        x_raw = x_raw.reshape((len(x), 1))
 
     H = np.array(
         [
@@ -631,10 +638,14 @@ def resample_spectrum(
             for wi, fwhmi in zip(wl2, fwhm2)
         ]
     )
+
     if fill is False:
-        return np.dot(H, x[:, np.newaxis]).ravel()
+        if len(x.shape) > 1:
+            return np.dot(H, x_raw).transpose()
+        else:
+            return np.dot(H, x_raw).ravel()
     else:
-        xnew = np.dot(H, x[:, np.newaxis]).ravel()
+        xnew = np.dot(H, x_raw).ravel()
         good = np.isfinite(xnew)
         for i, xi in enumerate(xnew):
             if not good[i]:

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -170,15 +170,18 @@ class RadiativeTransferEngine:
                 )
 
             # if necessary, resample prebuilt LUT to desired instrument spectral response
-            if not all(wl == self.lut.wl):
-                conv = xr.Dataset(coords={"wl": wl, "point": self.lut.point})
+            if not len(wl) == len(self.lut.wl) or all(wl == self.lut.wl):
+                conv = xr.Dataset(coords={"wl": wl, "point": self.lut.points})
                 for quantity in self.lut:
-                    conv[quantity] = (
-                        ("wl", "point"),
-                        common.resample_spectrum(
-                            self.lut[quantity].data, self.lut.wl, wl, fwhm
-                        ),
-                    )
+                    if quantity in luts.Keys.alldim.keys():
+                        conv[quantity] = (
+                            ("wl", "point"),
+                            common.resample_spectrum(
+                                self.lut[quantity].data, self.lut.wl, wl, fwhm
+                            ),
+                        )
+                    else:
+                        conv[quantity] = self.lut[quantity].data
                 self.lut = conv
 
         else:

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -171,17 +171,16 @@ class RadiativeTransferEngine:
 
             # if necessary, resample prebuilt LUT to desired instrument spectral response
             if not len(wl) == len(self.lut.wl) or all(wl == self.lut.wl):
-                conv = xr.Dataset(coords={"wl": wl, "point": self.lut.points})
+                conv = xr.Dataset(coords={"point": self.lut.point, "wl": wl})
                 for quantity in self.lut:
                     if quantity in luts.Keys.alldim.keys():
                         conv[quantity] = (
-                            ("wl", "point"),
+                            ("point", "wl"),
                             common.resample_spectrum(
                                 self.lut[quantity].data, self.lut.wl, wl, fwhm
                             ),
                         )
-                    else:
-                        conv[quantity] = self.lut[quantity].data
+
                 self.lut = conv
 
         else:

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -177,7 +177,10 @@ class RadiativeTransferEngine:
 
             # if necessary, resample prebuilt LUT to desired instrument spectral response
             if not len(wl) == len(self.lut.wl) or all(wl == self.lut.wl):
-                conv = xr.Dataset(coords={"point": self.lut.point, "wl": wl})
+                conv = xr.Dataset(
+                    coords={"point": self.lut.point, "wl": wl},
+                    attrs={"RT_mode": self.rt_mode},
+                )
                 for quantity in self.lut:
                     if quantity in luts.Keys.alldim.keys():
                         conv[quantity] = (

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -159,6 +159,12 @@ class RadiativeTransferEngine:
             self.lut = luts.load(lut_path, subset=engine_config.lut_names)
             self.lut_grid = lut_grid or luts.extractGrid(self.lut)
             self.points, self.lut_names = luts.extractPoints(self.lut)
+
+            # remove 'point' if added to lut_names after subsetting
+            if "point" in self.lut_names:
+                remove = np.where(self.lut_names == "point")
+                self.lut_names = np.delete(self.lut_names, remove)
+
             # Enable special modes - argument: get from prebuilt LUT netCDF if available
             self.rt_mode = self.lut.attrs.get("RT_mode", "transm")
             if self.rt_mode not in ["transm", "rdn"]:
@@ -180,6 +186,17 @@ class RadiativeTransferEngine:
                                 self.lut[quantity].data, self.lut.wl, wl, fwhm
                             ),
                         )
+                    if quantity == "solar_irr":
+                        conv[quantity] = (
+                            "wl",
+                            common.resample_spectrum(
+                                self.lut[quantity].data, self.lut.wl, wl, fwhm
+                            ),
+                        )
+                    if quantity == "fwhm":
+                        conv[quantity] = ("wl", fwhm)
+                    if quantity in luts.Keys.consts.keys():
+                        conv[quantity] = self.lut[quantity].data
 
                 self.lut = conv
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -177,6 +177,7 @@ class RadiativeTransferEngine:
 
             # if necessary, resample prebuilt LUT to desired instrument spectral response
             if not len(wl) == len(self.lut.wl) or all(wl == self.lut.wl):
+                Logger.info(f"Resampling LUT to instrument spectral response.")
                 conv = xr.Dataset(
                     coords={"point": self.lut.point, "wl": wl},
                     attrs={"RT_mode": self.rt_mode},


### PR DESCRIPTION
This PR updates the resampling of a high-resolution prebuilt LUT to the desired instrument spectral response. @pgbrodrick and @jammont, it works now on my end but feel free to test and suggest improvements.

Also, Nimrod's universal LUT contains a few NaNs throughout all simulated quantities, so that the inversion using this table currently crashes (at least, I'm assuming that that's the issue). While we already have a mechanism in play to detect these NaNs in the LUT (throwing a logger warning), we might also need a function that somehow eliminates these values on runtime by replacing them with a reasonable fill value. Open to thoughts here!