### PR TITLE
Remove custom version of ray shutdown from ISOFIT's init.

### DIFF
--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -27,10 +27,8 @@ __version__ = importlib.metadata.version(__package__ or __name__)
 
 warnings_enabled = False
 
-import atexit
 import logging
 import os
-import signal
 
 Logger = logging.getLogger("isofit")
 
@@ -41,20 +39,3 @@ if os.environ.get("ISOFIT_DEBUG"):
     from .wrappers import ray
 else:
     import ray
-
-
-def shutdown_ray():
-    try:
-        ray.shutdown()
-    except:
-        pass
-
-
-# Auto call ray.shutdown when the python interpreter exits
-# ray itself also implements this, but there's no harm in calling it twice
-atexit.register(shutdown_ray)
-try:
-    signal.signal(signal.SIGINT, shutdown_ray)  # ctrl
-    signal.signal(signal.SIGTERM, shutdown_ray)  # kill
-except:
-    pass


### PR DESCRIPTION
When trying to exit a command line ray processing, the following error started to appear and let the control-c command run in a forever-loop:

> ^CTypeError: shutdown_ray() takes 0 positional arguments but 2 were given
> Exception ignored in: 'ray._raylet.check_signals'
> Traceback (most recent call last):
>   File "/Users/bohn/mambaforge/envs/isofit_env_3x/lib/python3.10/site-packages/ray/_private/worker.py", line 2847, in wait
>     ready_ids, remaining_ids = worker.core_worker.wait(
> TypeError: shutdown_ray() takes 0 positional arguments but 2 were given

To resolve this issue, I removed the custom `shutdown_ray()` function in ISOFIT's `init.py`. Tests confirmed that control-c then works as expected again when exiting ray processes. Also, running a final `ray stop` showed no active zombie ray processes anymore.