### PR TITLE
Small patch to surface model built on runtime.

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 from datetime import datetime
 from os.path import exists, join
+from shutil import copyfile
 from types import SimpleNamespace
 
 import click
@@ -364,6 +365,10 @@ def apply_oe(args):
     paths.surface_path = tmpl.check_surface_model(
         surface_path=args.surface_path, wl=wl, paths=paths
     )
+
+    # re-stage surface model if needed
+    if paths.surface_path != args.surface_path:
+        copyfile(paths.surface_path, paths.surface_working_path)
 
     (
         mean_latitude,


### PR DESCRIPTION
Thanks to Dave Knapp from ASO, we discovered a bug with the new option of building the surface model on runtime. It previously staged just the .json config dict to the working directory, and not the built model. This led the code to fail due to a .mat file value error. This PR fixes the issue.