### PR TITLE
Update to 6s, sRTMnet, and KF to correctly respect relative azimuth angle.

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -113,7 +113,7 @@ class VectorInterpolator:
             # at the specific angle_loc axes.  We'll use broadcast_to to do
             # this, but we need to do it on the last dimension.  So start by
             # temporarily moving the target axes there, then broadcasting
-            data = np.array(data)
+            # data = np.array(data)
             data = np.swapaxes(data, -1, angle_loc)
             data_dim = list(np.shape(data))
             data_dim.append(data_dim[-1])

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -113,7 +113,7 @@ class VectorInterpolator:
             # at the specific angle_loc axes.  We'll use broadcast_to to do
             # this, but we need to do it on the last dimension.  So start by
             # temporarily moving the target axes there, then broadcasting
-            # data = np.array(data)
+            data = np.array(data)
             data = np.swapaxes(data, -1, angle_loc)
             data_dim = list(np.shape(data))
             data_dim.append(data_dim[-1])

--- a/isofit/radiative_transfer/kernel_flows.py
+++ b/isofit/radiative_transfer/kernel_flows.py
@@ -203,16 +203,16 @@ class KernelFlowsRT(RadiativeTransferEngine):
         try:
             KEYMAPPING[7]["default"] = template["MODTRAN"][0]["MODTRANINPUT"][
                 "GEOMETRY"
-            ]["TRUEAZ"]
+            ]["PARM1"]
         except:
             logging.info("No relative_azimuth default in template")
 
         try:
-            KEYMAPPING[8]["default"] = template["MODTRAN"][0]["MODTRANINPUT"][
+            KEYMAPPING[9]["default"] = template["MODTRAN"][0]["MODTRANINPUT"][
                 "GEOMETRY"
-            ]["PARM1"]
+            ]["TRUEAZ"]
         except:
-            logging.info("No solar_azimuth default in template")
+            logging.info("No observer_azimuth default in template")
 
         # defining some input transformations
         self.input_transfs = [

--- a/isofit/radiative_transfer/sRTMnet.py
+++ b/isofit/radiative_transfer/sRTMnet.py
@@ -248,7 +248,9 @@ def build_sixs_config(engine_config):
     # so we don't care if we do OBSZEN + or - RELAZ.
     # In addition, sRTMnet was only trained on RELAZ = 0°,
     # so providing different values here would have no implications.
-    solar_azimuth = observer_azimuth + relative_azimuth
+    solar_azimuth = np.minimum(
+        observer_azimuth + relative_azimuth, observer_azimuth - relative_azimuth
+    )
     solar_zenith = data["GEOMETRY"]["PARM2"]
 
     # Tweak parameter values for sRTMnet

--- a/isofit/radiative_transfer/six_s.py
+++ b/isofit/radiative_transfer/six_s.py
@@ -217,7 +217,7 @@ class SixSRT(RadiativeTransferEngine):
 
         # Assume geometry values are provided by the config
         vals.update(
-            solzen=41.45,
+            solzen=self.engine_config.solzen,
             viewzen=self.engine_config.viewzen,
             solaz=self.engine_config.solaz,
             viewaz=self.engine_config.viewaz,

--- a/isofit/radiative_transfer/six_s.py
+++ b/isofit/radiative_transfer/six_s.py
@@ -217,7 +217,7 @@ class SixSRT(RadiativeTransferEngine):
 
         # Assume geometry values are provided by the config
         vals.update(
-            solzen=self.engine_config.solzen,
+            solzen=41.45,
             viewzen=self.engine_config.viewzen,
             solaz=self.engine_config.solaz,
             viewaz=self.engine_config.viewaz,

--- a/isofit/radiative_transfer/six_s.py
+++ b/isofit/radiative_transfer/six_s.py
@@ -244,6 +244,12 @@ class SixSRT(RadiativeTransferEngine):
         if "observer_zenith" in vals:
             vals["viewzen"] = 180 - vals["observer_zenith"]
 
+        if "relative_azimuth" in vals:
+            vals["solaz"] = np.minimum(
+                vals["viewaz"] + vals["relative_azimuth"],
+                vals["viewaz"] - vals["relative_azimuth"],
+            )
+
         if self.modtran_emulation:
             if "AERFRAC_2" in vals:
                 vals["AOT550"] = vals["AERFRAC_2"]


### PR DESCRIPTION
This PR adds the calculation of the solar azimuth angle based on given view and relative azimuths to the 6s config module. In addition, it implements a small fix to prevent the solar azimuth angle from taking values larger than 360°, and updates the key mapping in `kernel_flows.py` to respect IPARM 12.