### PR TITLE
linear interpolation reversion

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -345,9 +345,9 @@ def invert_analytical(
             xk = C_rcond @ (M.T @ z + prprod)
             trajectory.append(xk)
 
-        if fm.full_glint:
-            trajectory.append(trajectory[-1][-2] * g_dir)
-            trajectory.append(trajectory[-1][-1] * g_dif)
+            if fm.full_glint:
+                trajectory.append(trajectory[-1][-2] * g_dir)
+                trajectory.append(trajectory[-1][-1] * g_dif)
 
         else:
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -291,23 +291,12 @@ def invert_analytical(
     else:
         x[fm.idx_surface] = x_alg[0]
 
-    trajectory = []
+    trajectory = [x]
     outside_ret_windows = np.ones(len(fm.idx_surface), dtype=bool)
     outside_ret_windows[winidx] = False
     outside_ret_windows = np.where(outside_ret_windows)[0]
 
-    x_surface, x_RT, x_instrument = fm.unpack(x)
-
-    Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
-
-    Sa = fm.Sa(x, geom)
-    Sa_surface = Sa[fm.idx_surface, :][:, fm.idx_surface]
-
-    Sa_inv = svd_inv_sqrt(Sa_surface, hash_table, hash_size)[0]
-
-    xa_full = fm.xa(x, geom)
-    xa_surface = xa_full[fm.idx_surface]
-
+    # Special glint stuff
     if fm.RT.glint_model:
         prprod = Sa_inv @ xa_surface
         # obtain needed RT vectors
@@ -324,19 +313,30 @@ def invert_analytical(
         g_dir = rho_ls * (t_down_dir / t_down_total)  # direct sky transmittance
         g_dif = rho_ls * (t_down_dif / t_down_total)  # diffuse sky transmittance
 
-        nl = len(r)
-        H = np.zeros((nl, nl + 2))
+        H = np.zeros((len(r), len(r) + 2))
         np.fill_diagonal(H, 1)
         H[:, -2] = g_dir
         H[:, -1] = g_dif
 
-        GIv = 1 / np.diag(Seps)
+    for n in range(num_iter):
+        x_surface, x_RT, x_instrument = fm.unpack(x)
 
-        xk = x[fm.idx_surface].copy()
-        trajectory.append(xk)
+        Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
 
-        for n in range(num_iter):
-            Dv = t1 / (1 - s * (xk[:nl] + xk[-2] * g_dir + xk[-1] * g_dif))
+        Sa = fm.Sa(x, geom)
+        Sa_surface = Sa[fm.idx_surface, :][:, fm.idx_surface]
+        Sa_surface = Sa_surface[winidx, :][:, winidx]
+        Sa_inv = svd_inv_sqrt(Sa_surface, hash_table, hash_size)[0]
+
+        xa_full = fm.xa(x, geom)
+        xa_surface = xa_full[fm.idx_surface]
+        xa = xa_surface[winidx]
+
+        if fm.RT.glint_model:
+            GIv = 1 / np.diag(Seps)
+            xk = x[fm.idx_surface].copy()
+            trajectory.append(xk)
+            Dv = t1 / (1 - s * (xk[: len(r)] + xk[-2] * g_dir + xk[-1] * g_dif))
             L = Dv.reshape((-1, 1)) * H
             M = GIv.reshape((-1, 1)) * L
             S = L.T @ M
@@ -349,8 +349,8 @@ def invert_analytical(
             trajectory.append(trajectory[-1][-2] * g_dir)
             trajectory.append(trajectory[-1][-1] * g_dif)
 
-    else:
-        for n in range(num_iter):
+        else:
+
             L_atm = fm.RT.get_L_atm(x_RT, geom)[winidx]
             L_tot = fm.calc_rdn(x, geom)[winidx]
 
@@ -361,8 +361,8 @@ def invert_analytical(
             C = Seps  # C = 'meas_Cov' = Seps
             L = dpotrf(C, 1)[0]
             P = dpotri(L, 1)[0]
-            P_rpr = Sa_inv[winidx, :][:, winidx]
-            mu_rpr = xa_surface[winidx]
+            P_rpr = Sa_inv
+            mu_rpr = xa
 
             priorprod = P_rpr @ mu_rpr
 
@@ -384,7 +384,7 @@ def invert_analytical(
             # xa_cond, Sa_cond = conditional_gaussian(xa_full, Sa, outside_ret_windows, winidx, mu)
             # full_mu[outside_ret_windows] = xa_cond
             if outside_ret_const is None:
-                full_mu[outside_ret_windows] = xa_surface[outside_ret_windows]
+                full_mu[outside_ret_windows] = xa[outside_ret_windows]
             else:
                 full_mu[outside_ret_windows] = outside_ret_const
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -59,19 +59,6 @@ class RadiativeTransferEngine:
         "surface_elevation_km",
     ]
 
-    # Informs the VectorInterpolator the units for a given key
-    angular_lut_keys = {
-        # Degrees
-        "observer_azimuth": "d",
-        "observer_zenith": "d",
-        "solar_azimuth": "d",
-        "solar_zenith": "d",
-        "relative_azimuth": "d",
-        # Radians
-        #   "key": "r",
-        # All other keys default to "n" = Not angular
-    }
-
     earth_sun_distance_path = os.path.join(
         isofit.root, "data", "earth_sun_distance.txt"
     )
@@ -279,10 +266,6 @@ class RadiativeTransferEngine:
         """
         return self.lut[key].load().data
 
-    @property
-    def lut_interp_types(self):
-        return np.array([self.angular_lut_keys.get(key, "n") for key in self.lut_names])
-
     def build_interpolators(self):
         """
         Builds the interpolators using the LUT store
@@ -303,7 +286,6 @@ class RadiativeTransferEngine:
             self.luts[key] = common.VectorInterpolator(
                 grid_input=grid,
                 data_input=ds[key].load().data,
-                lut_interp_types=self.lut_interp_types,
                 version=self.interpolator_style,
             )
 

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -67,7 +67,6 @@ class LUTSurface(Surface):
         self.lut_grid = [grid[0] for grid in model_dict["grids"][0]]
         self.lut_names = [l.strip() for l in model_dict["lut_names"]]
         self.statevec_names = [sv.strip() for sv in model_dict["statevec_names"]]
-        interp_types = np.array(["n" for n in self.lut_grid])
         self.data = model_dict["data"]
         self.wl = model_dict["wl"][0]
         self.n_wl = len(self.wl)
@@ -82,7 +81,7 @@ class LUTSurface(Surface):
         self.idx_lamb = np.empty(shape=0)
 
         # build the interpolator
-        self.itp = VectorInterpolator(self.lut_grid, self.data, interp_types)
+        self.itp = VectorInterpolator(self.lut_grid, self.data)
 
     def xa(self, x_surface, geom):
         """Mean of prior distribution."""

--- a/isofit/test/test_common.py
+++ b/isofit/test/test_common.py
@@ -155,10 +155,9 @@ def test_interpolators():
             30,
         )
     )
-    lut_interp_types = np.array(["n", "d", "d", "n"])
 
-    v_orig = VectorInterpolator(grid_input, data_input, lut_interp_types, version="rg")
-    v_new = VectorInterpolator(grid_input, data_input, lut_interp_types, version="mlg")
+    v_orig = VectorInterpolator(grid_input, data_input, version="rg")
+    v_new = VectorInterpolator(grid_input, data_input, version="mlg")
 
     input_test = np.random.random((100, len(grid_input)))
     for _n in range(len(grid_input)):

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -370,8 +370,8 @@ class LUTConfig:
     def get_grid_with_data(
         self, data_input: np.array, spacing: float, min_spacing: float
     ):
-        min_val = np.minimum(data_input)
-        max_val = np.maximum(data_input)
+        min_val = np.min(data_input)
+        max_val = np.max(data_input)
         return get_grid(min_val, max_val, spacing, min_spacing)
 
     def get_grid(

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1482,7 +1482,7 @@ def get_metadata_from_obs(
     mean_to_sun_azimuth = np.mean(to_sun_azimuth[valid]) % 360
     mean_to_sensor_zenith = 180 - np.mean(to_sensor_zenith[valid])
     mean_to_sun_zenith = np.mean(to_sun_zenith[valid])
-    mean_relative_azimuth = np.mean(relative_azimuth[valid]) % 360
+    mean_relative_azimuth = np.mean(relative_azimuth[valid])
 
     # geom_margin = EPS * 2.0
     to_sensor_zenith_lut_grid = lut_params.get_grid_with_data(

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -367,6 +367,13 @@ class LUTConfig:
             self.aot_550_spacing_min = self.aerosol_2_spacing_min
             self.aerosol_2_spacing = 0
 
+    def get_grid_with_data(
+        self, data_input: np.array, spacing: float, min_spacing: float
+    ):
+        min_val = np.minimum(data_input)
+        max_val = np.maximum(data_input)
+        return get_grid(min_val, max_val, spacing, min_spacing)
+
     def get_grid(
         self, minval: float, maxval: float, spacing: float, min_spacing: float
     ):
@@ -392,123 +399,6 @@ class LUTConfig:
             return None
         else:
             return grid
-
-    def get_angular_grid(
-        self,
-        angle_data_input: np.array,
-        spacing: float,
-        min_spacing: float,
-        units: str = "d",
-    ):
-        """Find either angular data 'center points' (num_points = 1), or a lut set that spans
-        angle variation in a systematic fashion.
-
-        Args:
-            angle_data_input: set of angle data to use to find center points
-            spacing: the desired angular spacing between points, or mean if -1
-            min_spacing: the minimum angular spacing between points allowed (if less, no grid)
-            units: specifies if data are in degrees (default) or radians
-
-        :Returns:
-            angular data center point or lut set spanning space
-
-        """
-        if spacing == 0:
-            logging.debug("Grid spacing set at 0, using no grid.")
-            return None
-
-        # Convert everything to radians so we don't have to track throughout
-        if units == "r":
-            angle_data = np.rad2deg(angle_data_input)
-        else:
-            angle_data = angle_data_input.copy()
-
-        spatial_data = np.hstack(
-            [
-                np.cos(np.deg2rad(angle_data)).reshape(-1, 1),
-                np.sin(np.deg2rad(angle_data)).reshape(-1, 1),
-            ]
-        )
-
-        # find which quadrants have data
-        quadrants = np.zeros((2, 2))
-        if np.any(np.logical_and(spatial_data[:, 0] > 0, spatial_data[:, 1] > 0)):
-            quadrants[1, 0] = 1
-        if np.any(np.logical_and(spatial_data[:, 0] > 0, spatial_data[:, 1] < 0)):
-            quadrants[1, 1] += 1
-        if np.any(np.logical_and(spatial_data[:, 0] < 0, spatial_data[:, 1] > 0)):
-            quadrants[0, 0] += 1
-        if np.any(np.logical_and(spatial_data[:, 0] < 0, spatial_data[:, 1] < 0)):
-            quadrants[0, 1] += 1
-
-        # Handle the case where angles are < 180 degrees apart
-        if np.sum(quadrants) < 3 and spacing != -1:
-            if np.sum(quadrants[1, :]) == 2:
-                # If angles cross the 0-degree line:
-                angle_spread = self.get_grid(
-                    np.min(angle_data + 180),
-                    np.max(angle_data + 180),
-                    spacing,
-                    min_spacing,
-                )
-                if angle_spread is None:
-                    return None
-                else:
-                    return angle_spread - 180
-            else:
-                # Otherwise, just space things out:
-                return self.get_grid(
-                    np.min(angle_data), np.max(angle_data), spacing, min_spacing
-                )
-        else:
-            if spacing >= 180:
-                logging.warning(
-                    f"Requested angle spacing is {spacing}, but obs angle divergence is"
-                    " > 180.  Tighter  spacing recommended"
-                )
-
-            # If we're greater than 180 degree spread, there's no universal answer. Try GMM.
-            if spacing == -1:
-                num_points = 1
-            else:
-                # This very well might overly space the grid, but we don't / can't know in general
-                num_points = int(np.ceil(360 / spacing))
-
-            # We initialize the GMM with a static seed for repeatability across runs
-            gmm = mixture.GaussianMixture(
-                n_components=num_points, covariance_type="full", random_state=1
-            )
-            if spatial_data.shape[0] == 1:
-                spatial_data = np.vstack([spatial_data, spatial_data])
-
-            # Protect memory against huge images
-            if spatial_data.shape[0] > 1e6:
-                use = np.linspace(0, spatial_data.shape[0] - 1, int(1e6), dtype=int)
-                spatial_data = spatial_data[use, :]
-
-            gmm.fit(spatial_data)
-            central_angles = np.degrees(np.arctan2(gmm.means_[:, 1], gmm.means_[:, 0]))
-            if num_points == 1:
-                return central_angles[0]
-
-            ca_quadrants = np.zeros((2, 2))
-            if np.any(np.logical_and(gmm.means_[:, 0] > 0, gmm.means_[:, 1] > 0)):
-                ca_quadrants[1, 0] = 1
-            elif np.any(np.logical_and(gmm.means_[:, 0] > 0, gmm.means_[:, 1] < 0)):
-                ca_quadrants[1, 1] += 1
-            elif np.any(np.logical_and(gmm.means_[:, 0] < 0, gmm.means_[:, 1] > 0)):
-                ca_quadrants[0, 0] += 1
-            elif np.any(np.logical_and(gmm.means_[:, 0] < 0, gmm.means_[:, 1] < 0)):
-                ca_quadrants[0, 1] += 1
-
-            if np.sum(ca_quadrants) < np.sum(quadrants):
-                logging.warning(
-                    f"GMM angles {central_angles} span"
-                    f" {np.sum(ca_quadrants)} quadrants, while data spans"
-                    f" {np.sum(ca_quadrants)} quadrants"
-                )
-
-            return central_angles
 
 
 class SerialEncoder(json.JSONEncoder):
@@ -548,123 +438,6 @@ def get_grid(minval: float, maxval: float, spacing: float, min_spacing: float):
         return None
     else:
         return grid
-
-
-def get_angular_grid(
-    angle_data_input: np.array, spacing: float, min_spacing: float, units: str = "d"
-):
-    """Find either angular data "center points" (num_points = 1), or a lut set that spans
-    angle variation in a systematic fashion.
-
-    Args:
-        angle_data_input: set of angle data to use to find center points
-        spacing: the desired angular spacing between points, or mean if -1
-        min_spacing: the minimum angular spacing between points allowed (if less, no grid)
-        units: specifies if data are in degrees (default) or radians
-
-    :Returns:
-        angular data center point or lut set spanning space
-    """
-    if spacing == 0:
-        logging.debug("Grid spacing set at 0, using no grid.")
-        return None
-
-    # Convert everything to radians so we don"t have to track throughout
-    if units == "r":
-        angle_data = np.rad2deg(angle_data_input)
-    else:
-        angle_data = angle_data_input.copy()
-
-    spatial_data = np.hstack(
-        [
-            np.cos(np.deg2rad(angle_data)).reshape(-1, 1),
-            np.sin(np.deg2rad(angle_data)).reshape(-1, 1),
-        ]
-    )
-
-    # find which quadrants have data
-    quadrants = np.zeros((2, 2))
-
-    if np.any(np.logical_and(spatial_data[:, 0] > 0, spatial_data[:, 1] > 0)):
-        quadrants[1, 0] = 1
-
-    if np.any(np.logical_and(spatial_data[:, 0] > 0, spatial_data[:, 1] < 0)):
-        quadrants[1, 1] += 1
-
-    if np.any(np.logical_and(spatial_data[:, 0] < 0, spatial_data[:, 1] > 0)):
-        quadrants[0, 0] += 1
-
-    if np.any(np.logical_and(spatial_data[:, 0] < 0, spatial_data[:, 1] < 0)):
-        quadrants[0, 1] += 1
-
-    # Handle the case where angles are < 180 degrees apart
-    if np.sum(quadrants) < 3 and spacing != -1:
-        if np.sum(quadrants[1, :]) == 2:
-            # If angles cross the 0-degree line:
-            angle_spread = get_grid(
-                np.min(angle_data + 180), np.max(angle_data + 180), spacing, min_spacing
-            )
-
-            if angle_spread is None:
-                return None
-            else:
-                return angle_spread - 180
-        else:
-            # Otherwise, just space things out:
-            return get_grid(
-                np.min(angle_data), np.max(angle_data), spacing, min_spacing
-            )
-    else:
-        if spacing >= 180:
-            logging.warning(
-                f"Requested angle spacing is {spacing}, but obs angle divergence is >"
-                " 180.  Tighter  spacing recommended"
-            )
-
-        # If we"re greater than 180 degree spread, there"s no universal answer. Try GMM.
-        if spacing == -1:
-            num_points = 1
-        else:
-            # This very well might overly space the grid, but we don"t / can"t know in general
-            num_points = int(np.ceil(360 / spacing))
-
-        # We initialize the GMM with a static seed for repeatability across runs
-        gmm = mixture.GaussianMixture(
-            n_components=num_points, covariance_type="full", random_state=1
-        )
-
-        if spatial_data.shape[0] == 1:
-            spatial_data = np.vstack([spatial_data, spatial_data])
-
-        # Protect memory against huge images
-        if spatial_data.shape[0] > 1e6:
-            use = np.linspace(0, spatial_data.shape[0] - 1, int(1e6), dtype=int)
-            spatial_data = spatial_data[use, :]
-
-        gmm.fit(spatial_data)
-        central_angles = np.degrees(np.arctan2(gmm.means_[:, 1], gmm.means_[:, 0]))
-
-        if num_points == 1:
-            return central_angles[0]
-
-        ca_quadrants = np.zeros((2, 2))
-
-        if np.any(np.logical_and(gmm.means_[:, 0] > 0, gmm.means_[:, 1] > 0)):
-            ca_quadrants[1, 0] = 1
-        elif np.any(np.logical_and(gmm.means_[:, 0] > 0, gmm.means_[:, 1] < 0)):
-            ca_quadrants[1, 1] += 1
-        elif np.any(np.logical_and(gmm.means_[:, 0] < 0, gmm.means_[:, 1] > 0)):
-            ca_quadrants[0, 0] += 1
-        elif np.any(np.logical_and(gmm.means_[:, 0] < 0, gmm.means_[:, 1] < 0)):
-            ca_quadrants[0, 1] += 1
-
-        if np.sum(ca_quadrants) < np.sum(quadrants):
-            logging.warning(
-                f"GMM angles {central_angles} span {np.sum(ca_quadrants)} quadrants, "
-                f"while data spans {np.sum(quadrants)} quadrants"
-            )
-
-        return central_angles
 
 
 def check_surface_model(surface_path: str, wl: np.array, paths: Pathnames) -> str:
@@ -1705,22 +1478,14 @@ def get_metadata_from_obs(
     mean_path_km = np.mean(path_km[valid])
     del path_km
 
-    mean_to_sensor_azimuth = (
-        lut_params.get_angular_grid(to_sensor_azimuth[valid], -1, 0) % 360
-    )
-    mean_to_sun_azimuth = (
-        lut_params.get_angular_grid(to_sun_azimuth[valid], -1, 0) % 360
-    )
-    mean_to_sensor_zenith = 180 - lut_params.get_angular_grid(
-        to_sensor_zenith[valid], -1, 0
-    )
-    mean_to_sun_zenith = lut_params.get_angular_grid(to_sun_zenith[valid], -1, 0)
-    mean_relative_azimuth = (
-        lut_params.get_angular_grid(relative_azimuth[valid], -1, 0) % 360
-    )
+    mean_to_sensor_azimuth = np.mean(to_sensor_azimuth[valid]) % 360
+    mean_to_sun_azimuth = np.mean(to_sun_azimuth[valid]) % 360
+    mean_to_sensor_zenith = 180 - np.mean(to_sensor_zenith[valid])
+    mean_to_sun_zenith = np.mean(to_sun_zenith[valid])
+    mean_relative_azimuth = np.mean(relative_azimuth[valid]) % 360
 
     # geom_margin = EPS * 2.0
-    to_sensor_zenith_lut_grid = lut_params.get_angular_grid(
+    to_sensor_zenith_lut_grid = lut_params.get_grid_with_data(
         to_sensor_zenith[valid],
         lut_params.to_sensor_zenith_spacing,
         lut_params.to_sensor_zenith_spacing_min,
@@ -1728,7 +1493,7 @@ def get_metadata_from_obs(
     if to_sensor_zenith_lut_grid is not None:
         to_sensor_zenith_lut_grid = np.sort(180 - to_sensor_zenith_lut_grid)
 
-    to_sun_zenith_lut_grid = lut_params.get_angular_grid(
+    to_sun_zenith_lut_grid = lut_params.get_grid_with_data(
         to_sun_zenith[valid],
         lut_params.to_sun_zenith_spacing,
         lut_params.to_sun_zenith_spacing_min,
@@ -1736,7 +1501,7 @@ def get_metadata_from_obs(
     if to_sun_zenith_lut_grid is not None:
         to_sun_zenith_lut_grid = np.sort(to_sun_zenith_lut_grid)
 
-    relative_azimuth_lut_grid = lut_params.get_angular_grid(
+    relative_azimuth_lut_grid = lut_params.get_grid_with_data(
         relative_azimuth[valid],
         lut_params.relative_azimuth_spacing,
         lut_params.relative_azimuth_spacing_min,
@@ -1828,11 +1593,8 @@ def get_metadata_from_loc(
         valid[-trim_lines:, :] = False
 
     # Grab zensor position and orientation information
-    mean_latitude = lut_params.get_angular_grid(loc_data[1, valid].flatten(), -1, 0)
-    mean_longitude = lut_params.get_angular_grid(
-        -1 * loc_data[0, valid].flatten(), -1, 0
-    )
-
+    mean_latitude = np.mean(loc_data[1, valid].flatten())
+    mean_longitude = np.mean(-1 * loc_data[0, valid].flatten())
     mean_elevation_km = np.mean(loc_data[2, valid]) / 1000.0
 
     # make elevation grid


### PR DESCRIPTION
Change all LUT interpolation to linear.  This includes removing the angluar components of the RTE, and updating all of the LUT table generation bounds to use a standard linear grid.  This makes everything faster and simpler.  It does continue to permit some inaccuracies for angular dimensions, but if the spacing is tight, this number is small.