### PR TITLE
Remove pygrib dependency

### DIFF
--- a/isofit/utils/add_HRRR_profiles_to_modtran_config.py
+++ b/isofit/utils/add_HRRR_profiles_to_modtran_config.py
@@ -20,6 +20,7 @@
 
 import json
 import os
+import sys
 import time
 import urllib.request
 from copy import deepcopy
@@ -27,9 +28,16 @@ from datetime import date, timedelta
 
 import click
 import numpy as np
-import pygrib
 
 from isofit.core.common import json_load_ascii
+
+try:
+    import pygrib
+except:
+    raise ImportError(
+        "Missing dependency pygrib. Please install: https://jswhit.github.io/pygrib/installing.html"
+    )
+    sys.exit()
 
 
 class HRRR_to_MODTRAN_profiles:

--- a/isofit/utils/add_HRRR_profiles_to_modtran_config.py
+++ b/isofit/utils/add_HRRR_profiles_to_modtran_config.py
@@ -34,10 +34,7 @@ from isofit.core.common import json_load_ascii
 try:
     import pygrib
 except:
-    raise ImportError(
-        "Missing dependency pygrib. Please install: https://jswhit.github.io/pygrib/installing.html"
-    )
-    sys.exit()
+    pygrib = None
 
 
 class HRRR_to_MODTRAN_profiles:
@@ -305,6 +302,11 @@ def download_HRRR(
 
 
 def get_HRRR_data(filename):
+    if pygrib is None:
+        raise ImportError(
+            "Missing dependency pygrib. Please install: https://jswhit.github.io/pygrib/installing.html"
+        )
+
     grbs = pygrib.open(filename)
 
     msgs = [str(grb) for grb in grbs]
@@ -337,6 +339,11 @@ def get_HRRR_data(filename):
 @click.command(name="HRRR_to_modtran")
 @click.argument("config_file")
 def cli_HRRR_to_modtran(**kwargs):
+    if pygrib is None:
+        raise ImportError(
+            "Missing dependency pygrib. Please install: https://jswhit.github.io/pygrib/installing.html"
+        )
+
     """Add HRRR profiles to MODTRAN"""
 
     click.echo("Running adding HRRR profiles to MODTRAN")

--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -13,7 +13,6 @@ dependencies:
   - numpy>=1.20.0,<2.0.0
   - pandas>=0.24
   - pre-commit
-  - pygrib
   - pytest>=3.5.1
   - python-xxhash<3
   - pyyaml>=5.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
   netCDF4 < 1.7.1
   numpy >= 1.20, < 2.0.0
   pandas >= 0.24.0
-  pygrib
   pyyaml >= 5.3.2
   ray >= 1.2.0
   scikit-image >= 0.17.0


### PR DESCRIPTION
Simply removes `pygrib` from `setup.cfg` and the conda recipe. Adds a warning to the only script that uses it. 