### PR TITLE
Clean up and simplification of radiative transfer module

### DIFF
--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -79,13 +79,6 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         self.treat_as_emissive = False
         """bool: Run the simulation in emission mode"""
 
-        self._topography_model_type = bool
-        self.topography_model = False
-        """
-        Flag to indicated whether to use a topographic-flux (topoflux)
-        implementation of the forward model.
-        """
-
         self._glint_model_type = bool
         self.glint_model = False
         """

--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -79,6 +79,13 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         self.treat_as_emissive = False
         """bool: Run the simulation in emission mode"""
 
+        self._topography_model_type = bool
+        self.topography_model = False
+        """
+        Flag to indicated whether to use a topographic-flux (topoflux)
+        implementation of the forward model.
+        """
+
         self._glint_model_type = bool
         self.glint_model = False
         """

--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -370,6 +370,21 @@ class RadiativeTransferConfig(BaseConfigSection):
             if np.unique(item).size < len(item):
                 errors.append(f"Detected duplicate values in lut_grid item {key}")
 
+        if self.topography_model:
+            for rtm in self.radiative_transfer_engines:
+                if rtm.engine_name != "modtran":
+                    errors.append(
+                        "All self.forward_model.radiative_transfer.radiative_transfer_engines"
+                        ' must be of type "modtran" if forward_model.topograph_model is'
+                        " set to True"
+                    )
+                if rtm.multipart_transmittance is False:
+                    errors.append(
+                        "All self.forward_model.radiative_transfer.radiative_transfer_engines"
+                        " must have multipart_transmittance set as True if"
+                        " forward_model.topograph_model is set to True"
+                    )
+
         for rte in self.radiative_transfer_engines:
             errors.extend(rte.check_config_validity())
 

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -312,12 +312,14 @@ class ForwardModel:
 
         # Get partials of reflectance and upsample
         _, L_down_dir, L_down_dif = self.RT.get_L_down_transmitted(x_RT, geom)
-        rfl = self.surface.calc_rfl(x_surface, geom, L_down_dir, L_down_dif)
-        rho_dir_dir_hi = self.upsample(self.surface.wl, rfl[0])
-        rho_dif_dir_hi = self.upsample(self.surface.wl, rfl[1])
+        rho_dir_dir, rho_dif_dir = self.surface.calc_rfl(
+            x_surface, geom, L_down_dir, L_down_dif
+        )
+        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
+        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
         Ls = self.surface.calc_Ls(x_surface, geom)
         Ls_hi = self.upsample(self.surface.wl, Ls)
-        rdn_hi = self.calc_rdn(x, geom, rfl[0], rfl[1], Ls=Ls)
+        rdn_hi = self.calc_rdn(x, geom, rho_dir_dir, rho_dif_dir, Ls=Ls)
 
         drdn_dRTb = self.RT.drdn_dRTb(x_RT, rho_dir_dir_hi, rho_dif_dir_hi, Ls_hi, geom)
         dmeas_dRTb = self.instrument.sample(x_instrument, self.RT.wl, drdn_dRTb.T).T

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -195,7 +195,7 @@ class ForwardModel:
         x_surface, x_RT, x_instrument = self.unpack(x)
 
         if rfl_dir is None or rfl_dif is None:
-            L_down_dir, L_down_dif = self.RT.get_L_down(x_RT, geom)
+            _, L_down_dir, L_down_dif = self.RT.get_L_down_transmitted(x_RT, geom)
             rfl_dir, rfl_dif = self.surface.calc_rfl(
                 x_surface, geom, L_down_dir, L_down_dif
             )
@@ -256,7 +256,7 @@ class ForwardModel:
         x_surface, x_RT, x_instrument = self.unpack(x)
 
         # Get partials of reflectance WRT surface state variables, upsample
-        L_down_dir, L_down_dif = self.RT.get_L_down(x_RT, geom)
+        _, L_down_dir, L_down_dif = self.RT.get_L_down_transmitted(x_RT, geom)
         rfl_dir, rfl_dif = self.surface.calc_rfl(
             x_surface, geom, L_down_dir, L_down_dif
         )
@@ -311,7 +311,7 @@ class ForwardModel:
         x_surface, x_RT, x_instrument = self.unpack(x)
 
         # Get partials of reflectance and upsample
-        L_down_dir, L_down_dif = self.RT.get_L_down(x_RT, geom)
+        _, L_down_dir, L_down_dif = self.RT.get_L_down_transmitted(x_RT, geom)
         rfl = self.surface.calc_rfl(x_surface, geom, L_down_dir, L_down_dif)
         rfl_dir_hi = self.upsample(self.surface.wl, rfl[0])
         rfl_dif_hi = self.upsample(self.surface.wl, rfl[1])

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -195,9 +195,9 @@ class ForwardModel:
         x_surface, x_RT, x_instrument = self.unpack(x)
 
         if rfl_dir is None or rfl_dif is None:
-            E_down_dir, E_down_dif = self.RT.get_E_down(x_RT, geom)
+            L_down_dir, L_down_dif = self.RT.get_L_down(x_RT, geom)
             rfl_dir, rfl_dif = self.surface.calc_rfl(
-                x_surface, geom, E_down_dir, E_down_dif
+                x_surface, geom, L_down_dir, L_down_dif
             )
         if Ls is None:
             Ls = self.surface.calc_Ls(x_surface, geom)
@@ -256,9 +256,9 @@ class ForwardModel:
         x_surface, x_RT, x_instrument = self.unpack(x)
 
         # Get partials of reflectance WRT surface state variables, upsample
-        E_down_dir, E_down_dif = self.RT.get_E_down(x_RT, geom)
+        L_down_dir, L_down_dif = self.RT.get_L_down(x_RT, geom)
         rfl_dir, rfl_dif = self.surface.calc_rfl(
-            x_surface, geom, E_down_dir, E_down_dif
+            x_surface, geom, L_down_dir, L_down_dif
         )
         drfl_dsurface = self.surface.drfl_dsurface(x_surface, geom)
         rfl_dir_hi = self.upsample(self.surface.wl, rfl_dir)
@@ -311,8 +311,8 @@ class ForwardModel:
         x_surface, x_RT, x_instrument = self.unpack(x)
 
         # Get partials of reflectance and upsample
-        E_down_dir, E_down_dif = self.RT.get_E_down(x_RT, geom)
-        rfl = self.surface.calc_rfl(x_surface, geom, E_down_dir, E_down_dif)
+        L_down_dir, L_down_dif = self.RT.get_L_down(x_RT, geom)
+        rfl = self.surface.calc_rfl(x_surface, geom, L_down_dir, L_down_dif)
         rfl_dir_hi = self.upsample(self.surface.wl, rfl[0])
         rfl_dif_hi = self.upsample(self.surface.wl, rfl[1])
         Ls = self.surface.calc_Ls(x_surface, geom)

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -288,7 +288,7 @@ class ForwardModel:
             x_instrument, self.RT.wl, drdn_dsurface.T
         ).T
         dmeas_dRT = self.instrument.sample(x_instrument, self.RT.wl, drdn_dRT.T).T
-        rdn_hi = self.calc_rdn(x, geom, rfl_dir_hi, rfl_dif_hi, Ls=Ls)
+        rdn_hi = self.calc_rdn(x, geom, rfl_dir, rfl_dif, Ls=Ls)
         dmeas_dinstrument = self.instrument.dmeas_dinstrument(
             x_instrument, self.RT.wl, rdn_hi
         )
@@ -317,7 +317,7 @@ class ForwardModel:
         rfl_dif_hi = self.upsample(self.surface.wl, rfl[1])
         Ls = self.surface.calc_Ls(x_surface, geom)
         Ls_hi = self.upsample(self.surface.wl, Ls)
-        rdn_hi = self.calc_rdn(x, geom, rfl_dir_hi, rfl_dif_hi, Ls=Ls_hi)
+        rdn_hi = self.calc_rdn(x, geom, rfl[0], rfl[1], Ls=Ls)
 
         drdn_dRTb = self.RT.drdn_dRTb(x_RT, rfl_dir_hi, rfl_dif_hi, Ls_hi, geom)
         dmeas_dRTb = self.instrument.sample(x_instrument, self.RT.wl, drdn_dRTb.T).T

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -274,7 +274,6 @@ class ForwardModel:
         # Derivatives of RTM radiance
         drdn_dRT, drdn_dsurface = self.RT.drdn_dRT(
             x_RT,
-            x_surface,
             rho_dir_dir_hi,
             rho_dif_dir_hi,
             drfl_dsurface_hi,

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -273,7 +273,14 @@ class ForwardModel:
 
         # Derivatives of RTM radiance
         drdn_dRT, drdn_dsurface = self.RT.drdn_dRT(
-            x_RT, x_surface, rfl_hi, drfl_dsurface_hi, Ls_hi, dLs_dsurface_hi, geom
+            x_RT,
+            x_surface,
+            rfl_dir_hi,
+            rfl_dif_hi,
+            drfl_dsurface_hi,
+            Ls_hi,
+            dLs_dsurface_hi,
+            geom,
         )
 
         # Derivatives of measurement, avoiding recalculation of rfl, Ls
@@ -281,7 +288,7 @@ class ForwardModel:
             x_instrument, self.RT.wl, drdn_dsurface.T
         ).T
         dmeas_dRT = self.instrument.sample(x_instrument, self.RT.wl, drdn_dRT.T).T
-        rdn_hi = self.calc_rdn(x, geom, rfl=(rfl_dir_hi, rfl_dif_hi), Ls=Ls)
+        rdn_hi = self.calc_rdn(x, geom, rfl_dir_hi, rfl_dif_hi, Ls=Ls)
         dmeas_dinstrument = self.instrument.dmeas_dinstrument(
             x_instrument, self.RT.wl, rdn_hi
         )

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -193,14 +193,18 @@ class ForwardModel:
         so we upsample surface terms.
         """
         x_surface, x_RT, x_instrument = self.unpack(x)
+
         if rfl is None:
-            rfl = self.surface.calc_rfl(x_surface, geom)
+            E_down_dir, E_down_dif = self.RT.get_E_down(x_RT, geom)
+            rfl = self.surface.calc_rfl(x_surface, E_down_dir, E_down_dif, geom)
         if Ls is None:
             Ls = self.surface.calc_Ls(x_surface, geom)
 
-        rfl_hi = self.upsample(self.surface.wl, rfl)
+        rfl_dir_hi = self.upsample(self.surface.wl, rfl[0])
+        rfl_dif_hi = self.upsample(self.surface.wl, rfl[1])
         Ls_hi = self.upsample(self.surface.wl, Ls)
-        return self.RT.calc_rdn(x_RT, x_surface, rfl_hi, Ls_hi, geom)
+
+        return self.RT.calc_rdn(x_RT, rfl_dir_hi, rfl_dif_hi, Ls_hi, geom)
 
     def calc_meas(self, x, geom, rfl=None, Ls=None):
         """Calculate the model observation at instrument wavelengths."""

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -197,7 +197,7 @@ class ForwardModel:
         if rfl_dir is None or rfl_dif is None:
             E_down_dir, E_down_dif = self.RT.get_E_down(x_RT, geom)
             rfl_dir, rfl_dif = self.surface.calc_rfl(
-                x_surface, E_down_dir, E_down_dif, geom
+                x_surface, geom, E_down_dir, E_down_dif
             )
         if Ls is None:
             Ls = self.surface.calc_Ls(x_surface, geom)
@@ -258,7 +258,7 @@ class ForwardModel:
         # Get partials of reflectance WRT surface state variables, upsample
         E_down_dir, E_down_dif = self.RT.get_E_down(x_RT, geom)
         rfl_dir, rfl_dif = self.surface.calc_rfl(
-            x_surface, E_down_dir, E_down_dif, geom
+            x_surface, geom, E_down_dir, E_down_dif
         )
         drfl_dsurface = self.surface.drfl_dsurface(x_surface, geom)
         rfl_dir_hi = self.upsample(self.surface.wl, rfl_dir)
@@ -312,7 +312,7 @@ class ForwardModel:
 
         # Get partials of reflectance and upsample
         E_down_dir, E_down_dif = self.RT.get_E_down(x_RT, geom)
-        rfl = self.surface.calc_rfl(x_surface, E_down_dir, E_down_dif, geom)
+        rfl = self.surface.calc_rfl(x_surface, geom, E_down_dir, E_down_dif)
         rfl_dir_hi = self.upsample(self.surface.wl, rfl[0])
         rfl_dif_hi = self.upsample(self.surface.wl, rfl[1])
         Ls = self.surface.calc_Ls(x_surface, geom)

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -184,7 +184,7 @@ class Isofit:
         )
 
 
-@ray.remote(num_cpus=1)
+# @ray.remote(num_cpus=1)
 class Worker(object):
     def __init__(
         self,

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -184,7 +184,7 @@ class Isofit:
         )
 
 
-# @ray.remote(num_cpus=1)
+@ray.remote(num_cpus=1)
 class Worker(object):
     def __init__(
         self,

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -305,9 +305,11 @@ def invert_analytical(
         prprod = Sa_inv[winglintidx, :][:, winglintidx] @ xa_surface[winglintidx]
         # obtain needed RT vectors
         r = fm.RT.get_L_atm(x_RT, geom)[winidx]  # path radiance
-        L_down_total, L_down_dir, L_down_dif = fm.RT.get_L_down_transmitted(x_RT, geom)[
-            winidx
-        ]  # total (down * up, direct + diffuse), direct, and diffuse downward radiance
+        # total (down * up, direct + diffuse), direct, and diffuse downward radiance
+        L_down_total, L_down_dir, L_down_dif = fm.RT.get_L_down_transmitted(x_RT, geom)
+        L_down_total = L_down_total[winidx]
+        L_down_dir = L_down_dir[winidx]
+        L_down_dif = L_down_dif[winidx]
         rtm_quant = fm.RT.get_shared_rtm_quantities(x_RT, geom)
         s = rtm_quant["sphalb"][winidx]  # spherical albedo
         rho_ls = fm.RT.fresnel_rf(geom.observer_zenith)

--- a/isofit/radiative_transfer/engines/sRTMnet.py
+++ b/isofit/radiative_transfer/engines/sRTMnet.py
@@ -221,6 +221,7 @@ class SimulatedModtranRT(RadiativeTransferEngine):
         return {
             key: resample_spectrum(values.data, self.emu_wl, self.wl, self.fwhm)
             for key, values in data.items()
+            if values.data.dtype != "int64"
         }
 
     def get_L_atm(self, x_RT, geom):

--- a/isofit/radiative_transfer/engines/sRTMnet.py
+++ b/isofit/radiative_transfer/engines/sRTMnet.py
@@ -217,7 +217,7 @@ class SimulatedModtranRT(RadiativeTransferEngine):
         Resamples the predicts produced by preSim to be saved in self.lut_path
         """
         # REVIEW: Likely should chunk along the point dim to improve this
-        data = luts.load(self.predict_path).sel(point=tuple(point)).load()
+        data = luts.load(self.predict_path, mode="r").sel(point=tuple(point)).load()
         return {
             key: resample_spectrum(values.data, self.emu_wl, self.wl, self.fwhm)
             for key, values in data.items()

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -13,6 +13,7 @@ import numpy as np
 import xarray as xr
 from netCDF4 import Dataset
 
+__file__ = "..."
 Logger = logging.getLogger(__file__)
 
 

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -40,7 +40,7 @@ class Keys:
         "transm_up_dif": 0,
         "thermal_upwelling": np.nan,
         "thermal_downwelling": np.nan,
-        # add keys for the flux coupling terms
+        # add keys for radiances along all optical paths
         "bi-direct": 0,
         "hemi-direct": 0,
         "direct-hemi": 0,

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -658,8 +658,7 @@ def load(
     >>> load(file, subset).unstack().dims
     Frozen({'AOT550': 3, 'H2OSTR': 10, 'wl': 285})
     """
-    valid = ("before", "before-save", "after", "after-save")
-    if decoupling not in valid:
+    if decoupling not in ("before", "before-save", "after", "after-save"):
         raise AttributeError("Decoupling must be set to either 'before' or 'after'")
 
     if dask:

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -13,7 +13,6 @@ import numpy as np
 import xarray as xr
 from netCDF4 import Dataset
 
-__file__ = "..."
 Logger = logging.getLogger(__file__)
 
 

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -434,10 +434,10 @@ def couple(ds, inplace=True):
         Dataset with coupled terms
     """
     terms = {
-        "bi-direct": ("transm_down_dir", "transm_up_dir"),
-        "hemi-direct": ("transm_down_dif", "transm_up_dir"),
-        "direct-hemi": ("transm_down_dir", "transm_up_dif"),
-        "bi-hemi": ("transm_down_dif", "transm_up_dif"),
+        "bi-direct": ("transm_down_dir", "null", "transm_up_dir"),
+        "hemi-direct": ("transm_down_dir", "transm_down_dif", "transm_up_dir"),
+        "direct-hemi": ("transm_down_dir", "null", "transm_up_dif"),
+        "bi-hemi": ("transm_down_dir", "transm_down_dif", "transm_up_dif"),
     }
 
     # Detect if coupling needs to occur first
@@ -455,11 +455,14 @@ def couple(ds, inplace=True):
         if not inplace:
             ds = ds.copy()
 
-        for term, (key1, key2) in terms.items():
+        for term, (key1, key2, key3) in terms.items():
             try:
-                ds[term] = ds[key1] * ds[key2]
+                ds[term] = (ds[key1] + ds[key2]) * ds[key3]
             except KeyError:
-                ds[term] = 0
+                try:
+                    ds[term] = ds[key1] * ds[key3]
+                except KeyError:
+                    ds[term] = 0
 
     return ds
 

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -39,6 +39,11 @@ class Keys:
         "transm_up_dif": 0,
         "thermal_upwelling": np.nan,
         "thermal_downwelling": np.nan,
+        # add keys for the flux coupling terms
+        "bi-direct": 0,
+        "hemi-direct": 0,
+        "direct-hemi": 0,
+        "bi-hemi": 0,
     }
 
 

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -446,10 +446,9 @@ def decouple(ds, inplace=True):
     if data is None:
         # Not all keys exist
         calc = "missing"
-    else:
+    elif not bool(data.any().to_array().all()):
         # If any key is empty
-        if not bool(data.any().to_array().all()):
-            calc = "empty"
+        calc = "empty"
 
     if calc:
         Logger.debug(f"A decoupled term is {calc}, calculating")

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -456,7 +456,10 @@ def couple(ds, inplace=True):
             ds = ds.copy()
 
         for term, (key1, key2) in terms.items():
-            ds[term] = ds[key1] * ds[key2]
+            try:
+                ds[term] = ds[key1] * ds[key2]
+            except KeyError:
+                ds[term] = 0
 
     return ds
 

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -675,7 +675,7 @@ def load(
     if "before" in coupling:
         couple(ds)
 
-        # Save back to the original file, only the the coupled terms
+        # Save back to the original file, only the coupled terms
         if all(
             [
                 "save" in coupling,
@@ -684,7 +684,7 @@ def load(
             ]
         ):
             Logger.debug(f"Saving coupled terms back to the original input file")
-            terms = ["bi-direct", "hemi-direct", "direct-hemi", "bi-hemi"]
+            terms = ["dir-dir", "dif-dir", "dir-dif", "dif-dif"]
             ds[terms].to_netcdf(file, mode="a")
 
     # Special case that doesn't require defining the entire grid subsetting strategy

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -41,10 +41,10 @@ class Keys:
         "thermal_upwelling": np.nan,
         "thermal_downwelling": np.nan,
         # add keys for radiances along all optical paths
-        "bi-direct": 0,
-        "hemi-direct": 0,
-        "direct-hemi": 0,
-        "bi-hemi": 0,
+        "dir-dir": 0,
+        "dif-dir": 0,
+        "dir-dif": 0,
+        "dif-dif": 0,
     }
 
 
@@ -434,10 +434,10 @@ def couple(ds, inplace=True):
         Dataset with coupled terms
     """
     terms = {
-        "bi-direct": ("transm_down_dir", "null", "transm_up_dir"),
-        "hemi-direct": ("transm_down_dir", "transm_down_dif", "transm_up_dir"),
-        "direct-hemi": ("transm_down_dir", "null", "transm_up_dif"),
-        "bi-hemi": ("transm_down_dir", "transm_down_dif", "transm_up_dif"),
+        "dir-dir": ("transm_down_dir", "transm_up_dir"),
+        "dif-dir": ("transm_down_dif", "transm_up_dir"),
+        "dir-dif": ("transm_down_dir", "transm_up_dif"),
+        "dif-dif": ("transm_down_dif", "transm_up_dif"),
     }
 
     # Detect if coupling needs to occur first
@@ -455,14 +455,11 @@ def couple(ds, inplace=True):
         if not inplace:
             ds = ds.copy()
 
-        for term, (key1, key2, key3) in terms.items():
+        for term, (key1, key2) in terms.items():
             try:
-                ds[term] = (ds[key1] + ds[key2]) * ds[key3]
+                ds[term] = ds[key1] * ds[key2]
             except KeyError:
-                try:
-                    ds[term] = ds[key1] * ds[key3]
-                except KeyError:
-                    ds[term] = 0
+                ds[term] = 0
 
     return ds
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -330,14 +330,19 @@ class RadiativeTransfer:
         Returns:
             interpolated radiances along all optical paths:
             bi-directional            (downward direct * upward direct)
-            hemispherical-directional (downward diffuse * upward direct)
+            hemispherical-directional ((downward direct + diffuse) * upward direct)
             directional-hemispherical (downward direct * upward diffuse)
-            bi-hemispherical          (downward diffuse * upward diffuse)
+            bi-hemispherical          ((downward direct + diffuse) * upward diffuse)
         """
         if any(
             [type(r[key]) != np.ndarray for key in self.rt_engines[0].coupling_terms]
         ):
-            self.L_coupled = [r["transm_down_dir"], r["transm_down_dif"], 0, 0]
+            self.L_coupled = [
+                r["transm_down_dir"],
+                r["transm_down_dir"] + r["transm_down_dif"],
+                0,
+                0,
+            ]
         else:
             for key in self.rt_engines[0].coupling_terms:
                 self.L_coupled.append(

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -175,7 +175,6 @@ class RadiativeTransfer:
         Physics-based forward model to calculate at-sensor radiance.
         Includes topography, background reflectance, and glint.
         """
-        # ToDo: get TOA solar zenith angle from geometry object or from self?
         coszen = (
             np.cos(np.deg2rad(geom.solar_zenith))
             if np.isnan(self.coszen)

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -199,10 +199,10 @@ class RadiativeTransfer:
         # including glint for water surfaces
         if self.glint_model:
             E_down_tot = E_down_dir + E_down_dif
-            L_sky = x_surface[-2] * E_down_dir + x_surface[-1] * E_down_dif
+            E_sky = x_surface[-2] * E_down_dir + x_surface[-1] * E_down_dif
 
             rho_ls = 0.02  # fresnel reflectance factor (approx. 0.02 for nadir view)
-            glint = rho_ls * (L_sky / E_down_tot)
+            glint = rho_ls * (E_sky / E_down_tot)
         else:
             glint = np.zeros(rfl.shape)
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -335,7 +335,10 @@ class RadiativeTransfer:
             bi-hemispherical          ((downward direct + diffuse) * upward diffuse)
         """
         if any(
-            [type(r[key]) != np.ndarray for key in self.rt_engines[0].coupling_terms]
+            [
+                type(r[key]) != np.ndarray or len(r[key]) == 1
+                for key in self.rt_engines[0].coupling_terms
+            ]
         ):
             self.L_coupled = [
                 r["transm_down_dir"],

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -314,7 +314,7 @@ class RadiativeTransfer:
                 L_atms.append(L_atm)
         return np.hstack(L_atms)
 
-    def get_L_down(self, x_RT: np.array, geom: Geometry) -> np.array:
+    def get_L_down_transmitted(self, x_RT: np.array, geom: Geometry) -> np.array:
         """Get the interpolated direct and diffuse downward radiance on the sun-to-surface path.
         Thermal_downwelling already includes the transmission factor.
         Also assume there is no multiple scattering for TIR.

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -384,7 +384,7 @@ class RadiativeTransfer:
         s_alb = r["sphalb"]
 
         # direct and diffuse downward radiance on the sun-to-surface path
-        # note: currently, E_down_dir comes scaled by the TOA solar zenith angle,
+        # note: currently, L_down_dir comes scaled by the TOA solar zenith angle,
         # thus, unscaling and rescaling by local solar zenith angle required
         # to account for surface slope and aspect
         L_down_dir, L_down_dif = self.get_L_down(x_RT, geom)

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -209,7 +209,7 @@ class RadiativeTransfer:
         L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
 
         # Special case: 1-component model
-        if L_tot == 0:
+        if type(L_tot) != np.ndarray or len(L_tot) == 1:
             L_tot = self.get_L_down_transmitted(x_RT, geom)[0]
             # we assume rho_dir_dir = rho_dif_dir = rho_dir_dif = rho_dif_dif
             rho_dif_dif = rho_dir_dir

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -139,7 +139,7 @@ class RadiativeTransfer:
 
         self.solar_irr = np.concatenate([RT.solar_irr for RT in self.rt_engines])
 
-        # flux coupling terms
+        # radiances along all optical paths
         self.L_coupled = []
 
     def xa(self):
@@ -194,7 +194,7 @@ class RadiativeTransfer:
         # atmospheric spherical albedo
         s_alb = r["sphalb"]
 
-        # flux coupling terms
+        # radiances along all optical paths
         L_bi_direct, L_hemi_direct, L_direct_hemi, L_bi_hemi = self.get_L_coupled(
             r, coszen, cos_i
         )
@@ -212,10 +212,10 @@ class RadiativeTransfer:
         ret = (
             L_atm
             + (
-                L_bi_direct * rfl_dir  # bi-directional flux
-                + L_hemi_direct * rfl_dif  # hemispherical-directional flux
-                + L_direct_hemi * bg_dir  # directional-hemispherical flux
-                + L_bi_hemi * bg_dif  # bi-hemispherical flux
+                L_bi_direct * rfl_dir  # bi-directional radiance
+                + L_hemi_direct * rfl_dif  # hemispherical-directional radiance
+                + L_direct_hemi * bg_dir  # directional-hemispherical radiance
+                + L_bi_hemi * bg_dif  # bi-hemispherical radiance
             )
             / (1.0 - s_alb * bg_dif)
             + L_up
@@ -278,7 +278,7 @@ class RadiativeTransfer:
         return np.hstack(L_atms)
 
     def get_L_down(self, x_RT: np.array, geom: Geometry) -> np.array:
-        """Get the interpolated direct and diffuse downward fluxes on the sun-to-surface path.
+        """Get the interpolated direct and diffuse downward radiance on the sun-to-surface path.
         Thermal_downwelling already includes the transmission factor.
         Also assume there is no multiple scattering for TIR.
 
@@ -300,7 +300,7 @@ class RadiativeTransfer:
                 L_down_dir = r["transm_down_dir"]
                 L_down_dif = r["transm_down_dif"]
                 if RT.rt_mode == "transm":
-                    # transform downward transmittance to downward flux
+                    # transform downward transmittance to downward radiance
                     L_down_dir = (
                         (self.solar_irr * self.coszen) / np.pi * r["transm_down_dir"]
                     )
@@ -311,7 +311,7 @@ class RadiativeTransfer:
         return np.hstack(L_downs)
 
     def get_L_coupled(self, r, coszen, cos_i):
-        """Get the interpolated coupled fluxes on the sun-to-surface-to-sensor path.
+        """Get the interpolated radiances on the sun-to-surface-to-sensor path.
         These follow the nomenclature as presented by Schaepman-Strub et al. (2006),
         which essentially are the terms from Nicodemus et al. (1977),
         but adapted to the remote sensing case by Martonchik et al. (2000).
@@ -322,7 +322,7 @@ class RadiativeTransfer:
             cos_i:  local solar zenith angle at the surface
 
         Returns:
-            interpolated coupled fluxes:
+            interpolated radiances along all optical paths:
             bi-directional            (downward direct * upward direct)
             hemispherical-directional (downward diffuse * upward direct)
             directional-hemispherical (downward direct * upward diffuse)
@@ -340,7 +340,7 @@ class RadiativeTransfer:
                     else r[key]
                 )
 
-        # unscaling and rescaling downward direct flux terms by local solar zenith angle (see above)
+        # unscaling and rescaling downward direct radiance by local solar zenith angle (see above)
         for ind in [0, 2]:
             self.L_coupled[ind] = self.L_coupled[ind] / coszen * cos_i
 
@@ -383,7 +383,7 @@ class RadiativeTransfer:
         # atmospheric spherical albedo
         s_alb = r["sphalb"]
 
-        # direct and diffuse downward fluxes on the sun-to-surface path
+        # direct and diffuse downward radiance on the sun-to-surface path
         # note: currently, E_down_dir comes scaled by the TOA solar zenith angle,
         # thus, unscaling and rescaling by local solar zenith angle required
         # to account for surface slope and aspect

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -390,13 +390,10 @@ class RadiativeTransfer:
                     else r[key]
                 )
 
-        # unscaling and rescaling downward direct radiance by local solar zenith angle (see above)
-        for ind in [0, 2]:
-            self.L_coupled[ind] = self.L_coupled[ind] / coszen * cos_i
-
-        L_dir_dir = self.L_coupled[0]
+        # assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle
+        L_dir_dir = self.L_coupled[0] / coszen * cos_i
         L_dif_dir = self.L_coupled[1]
-        L_dir_dif = self.L_coupled[2]
+        L_dir_dif = self.L_coupled[2] / coszen * cos_i
         L_dif_dif = self.L_coupled[3]
 
         return L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -139,9 +139,6 @@ class RadiativeTransfer:
 
         self.solar_irr = np.concatenate([RT.solar_irr for RT in self.rt_engines])
 
-        # flux coupling terms
-        self.E_coupled = []
-
     def xa(self):
         """Pull the priors from each of the individual RTs."""
         return self.prior_mean
@@ -289,17 +286,17 @@ class RadiativeTransfer:
                 L_atms.append(L_atm)
         return np.hstack(L_atms)
 
-    def get_E_down(self, x_RT: np.array, geom: Geometry) -> np.array:
-        """Get the interpolated direct and diffuse downward fluxes on the sun-to-surface path.
-        Thermal_downwelling already includes the transmission factor.
-        Also assume there is no multiple scattering for TIR.
+    def get_L_down_transmitted(self, x_RT: np.array, geom: Geometry) -> np.array:
+        """Get the interpolated total downward atmospheric transmittance.
+        Thermal_downwelling already includes the transmission factor. Also
+        assume there is no multiple scattering for TIR.
 
         Args:
             x_RT: radiative-transfer portion of the statevector
             geom: local geometry conditions for lookup
 
         Returns:
-            interpolated direct and diffuse downward fluxes on the sun-to-surface path
+            interpolated total downward atmospheric transmittance
         """
         L_downs = []
         for RT in self.rt_engines:

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -138,9 +138,6 @@ class RadiativeTransfer:
 
         self.solar_irr = np.concatenate([RT.solar_irr for RT in self.rt_engines])
 
-        # radiances along all optical paths
-        self.L_coupled = []
-
     def xa(self):
         """Pull the priors from each of the individual RTs."""
         return self.prior_mean
@@ -369,6 +366,9 @@ class RadiativeTransfer:
             L_dir_dif => downward direct * upward diffuse
             L_dif_dif => downward diffuse * upward diffuse
         """
+        # radiances along all optical paths
+        L_coupled = []
+
         if any(
             [
                 type(r[key]) != np.ndarray or len(r[key]) == 1
@@ -376,7 +376,7 @@ class RadiativeTransfer:
             ]
         ):
             # In case of the 1-component model, we cannot populate the coupling terms
-            self.L_coupled = [
+            L_coupled = [
                 0,
                 0,
                 0,
@@ -384,17 +384,17 @@ class RadiativeTransfer:
             ]
         else:
             for key in self.rt_engines[0].coupling_terms:
-                self.L_coupled.append(
+                L_coupled.append(
                     self.solar_irr * coszen / np.pi * r[key]
                     if self.rt_engines[0].rt_mode == "transm"
                     else r[key]
                 )
 
         # assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle
-        L_dir_dir = self.L_coupled[0] / coszen * cos_i
-        L_dif_dir = self.L_coupled[1]
-        L_dir_dif = self.L_coupled[2] / coszen * cos_i
-        L_dif_dif = self.L_coupled[3]
+        L_dir_dir = L_coupled[0] / coszen * cos_i
+        L_dif_dir = L_coupled[1]
+        L_dir_dif = L_coupled[2] / coszen * cos_i
+        L_dif_dif = L_coupled[3]
 
         return L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -195,7 +195,9 @@ class RadiativeTransfer:
         s_alb = r["sphalb"]
 
         # flux coupling terms
-        if any([r[key] == 0 for key in self.rt_engines[0].coupling_terms]):
+        if any(
+            [type(r[key]) != np.ndarray for key in self.rt_engines[0].coupling_terms]
+        ):
             self.E_coupled = [r["transm_down_dir"], r["transm_down_dif"], 0, 0]
         else:
             for key in self.rt_engines[0].coupling_terms:

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -105,7 +105,6 @@ class RadiativeTransfer:
                 raise AttributeError(error)
 
         # If any engine is true, self is true
-        self.topography_model = any([rte.topography_model for rte in self.rt_engines])
         self.glint_model = any([rte.glint_model for rte in self.rt_engines])
 
         # The rest of the code relies on sorted order of the individual RT engines which cannot

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -105,6 +105,7 @@ class RadiativeTransfer:
                 raise AttributeError(error)
 
         # If any engine is true, self is true
+        self.topography_model = any([rte.topography_model for rte in self.rt_engines])
         self.glint_model = any([rte.glint_model for rte in self.rt_engines])
 
         # The rest of the code relies on sorted order of the individual RT engines which cannot

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -185,9 +185,9 @@ class RadiativeTransfer:
         s_alb = r["sphalb"]
 
         # flux coupling terms
-        E_coupled = []
+        self.E_coupled = []
         for key in self.rt_engines[0].coupling_terms:
-            E_coupled.append(
+            self.E_coupled.append(
                 self.solar_irr * self.coszen / np.pi * r[key]
                 if self.rt_engines[0].rt_mode == "transm"
                 else r[key]
@@ -195,7 +195,7 @@ class RadiativeTransfer:
 
         # unscaling and rescaling downward direct flux terms by local solar zenith angle (see above)
         for ind in [0, 2]:
-            E_coupled[ind] = E_coupled[ind] / self.coszen * cos_i
+            self.E_coupled[ind] = self.E_coupled[ind] / self.coszen * cos_i
 
         # thermal transmittance
         L_up = Ls * (r["transm_up_dir"] + r["transm_up_dif"])
@@ -210,10 +210,10 @@ class RadiativeTransfer:
         ret = (
             L_atm
             + (
-                E_coupled[0] * rfl_dir  # bidirectional flux
-                + E_coupled[1] * rfl_dif  # hemispherical-directional flux
-                + E_coupled[2] * bg_dir  # directional-hemispherical flux
-                + E_coupled[3] * bg_dif  # bi-hemispherical flux
+                self.E_coupled[0] * rfl_dir  # bidirectional flux
+                + self.E_coupled[1] * rfl_dif  # hemispherical-directional flux
+                + self.E_coupled[2] * bg_dir  # directional-hemispherical flux
+                + self.E_coupled[3] * bg_dif  # bi-hemispherical flux
             )
             / (1.0 - s_alb * bg_dif)
             + L_up

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -110,6 +110,7 @@ class RadiativeTransferEngine:
         )
         self.coupling_terms = ["dir-dir", "dif-dir", "dir-dif", "dif-dif"]
         self.multipart_transmittance = engine_config.multipart_transmittance
+        self.topography_model = engine_config.topography_model
         self.glint_model = engine_config.glint_model
 
         # Specify wavelengths and fwhm to be used for either resampling an existing LUT or building a new instance

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -110,7 +110,6 @@ class RadiativeTransferEngine:
         )
         self.coupling_terms = ["dir-dir", "dif-dir", "dir-dif", "dif-dif"]
         self.multipart_transmittance = engine_config.multipart_transmittance
-        self.topography_model = engine_config.topography_model
         self.glint_model = engine_config.glint_model
 
         # Specify wavelengths and fwhm to be used for either resampling an existing LUT or building a new instance

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -105,7 +105,10 @@ class RadiativeTransferEngine:
         self.sim_path = engine_config.sim_path
 
         # Enable special modes
-        self.rt_mode = engine_config.rt_mode
+        self.rt_mode = (
+            engine_config.rt_mode if engine_config.rt_mode is not None else "transm"
+        )
+        self.coupling_terms = ["dir-dir", "dif-dir", "dir-dif", "dif-dif"]
         self.multipart_transmittance = engine_config.multipart_transmittance
         self.topography_model = engine_config.topography_model
         self.glint_model = engine_config.glint_model

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -213,6 +213,7 @@ class RadiativeTransferEngine:
 
             # Verify no duplicates exist else downstream functions will fail
             duplicates = False
+
             for dim, vals in lut_grid.items():
                 if np.unique(vals).size < len(vals):
                     duplicates = True

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -88,7 +88,7 @@ class Surface:
 
         return self.rfl
 
-    def calc_rfl(self, x_surface, geom):
+    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
         """Calculate the directed reflectance (specifically the HRDF) for this
         state vector."""
 

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -88,7 +88,7 @@ class Surface:
 
         return self.rfl
 
-    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
+    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
         """Calculate the directed reflectance (specifically the HRDF) for this
         state vector."""
 

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -88,7 +88,7 @@ class Surface:
 
         return self.rfl
 
-    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
+    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
         """Calculate the directed reflectance (specifically the HRDF) for this
         state vector."""
 

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -92,7 +92,9 @@ class Surface:
         """Calculate the directed reflectance (specifically the HRDF) for this
         state vector."""
 
-        return self.rfl
+        # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.
+        #  As long as this is not implemented, return the same reflectance vector for both.
+        return self.rfl, self.rfl
 
     def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,

--- a/isofit/surface/surface_additive_glint.py
+++ b/isofit/surface/surface_additive_glint.py
@@ -76,7 +76,7 @@ class AdditiveGlintSurface(ThermalSurface):
         x[self.glint_ind] = glint
         return x
 
-    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
+    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
         """Reflectance (includes specular glint)."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.

--- a/isofit/surface/surface_additive_glint.py
+++ b/isofit/surface/surface_additive_glint.py
@@ -79,7 +79,10 @@ class AdditiveGlintSurface(ThermalSurface):
     def calc_rfl(self, x_surface, geom):
         """Reflectance (includes specular glint)."""
 
-        return self.calc_lamb(x_surface, geom) + x_surface[self.glint_ind]
+        # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.
+        #  As long as this is not implemented, return the same reflectance vector for both.
+        rfl = self.calc_lamb(x_surface, geom) + x_surface[self.glint_ind]
+        return rfl, rfl
 
     def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,

--- a/isofit/surface/surface_additive_glint.py
+++ b/isofit/surface/surface_additive_glint.py
@@ -76,7 +76,7 @@ class AdditiveGlintSurface(ThermalSurface):
         x[self.glint_ind] = glint
         return x
 
-    def calc_rfl(self, x_surface, geom):
+    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
         """Reflectance (includes specular glint)."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.

--- a/isofit/surface/surface_additive_glint.py
+++ b/isofit/surface/surface_additive_glint.py
@@ -76,7 +76,7 @@ class AdditiveGlintSurface(ThermalSurface):
         x[self.glint_ind] = glint
         return x
 
-    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
+    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
         """Reflectance (includes specular glint)."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -98,7 +98,7 @@ class GlintModelSurface(MultiComponentSurface):
         x[self.glint_ind + 1] = g_dsf_est  # SKY_GLINT g_dsf
         return x
 
-    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
+    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
         """Direct and diffuse Reflectance (includes sun and sky glint)."""
 
         rho_ls = 0.02  # fresnel reflectance factor (approx. 0.02 for nadir view)

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -98,12 +98,12 @@ class GlintModelSurface(MultiComponentSurface):
         x[self.glint_ind + 1] = g_dsf_est  # SKY_GLINT g_dsf
         return x
 
-    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
+    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
         """Direct and diffuse Reflectance (includes sun and sky glint)."""
 
         rho_ls = 0.02  # fresnel reflectance factor (approx. 0.02 for nadir view)
-        sun_glint = rho_ls * (x_surface[-2] * E_down_dir / (E_down_dir + E_down_dif))
-        sky_glint = rho_ls * (x_surface[-1] * E_down_dif / (E_down_dir + E_down_dif))
+        sun_glint = rho_ls * (x_surface[-2] * L_down_dir / (L_down_dir + L_down_dif))
+        sky_glint = rho_ls * (x_surface[-1] * L_down_dif / (L_down_dir + L_down_dif))
 
         rfl_dir = self.calc_lamb(x_surface, geom) + sun_glint
         rfl_dif = self.calc_lamb(x_surface, geom) + sky_glint

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -105,10 +105,10 @@ class GlintModelSurface(MultiComponentSurface):
         sun_glint = rho_ls * (x_surface[-2] * L_down_dir / (L_down_dir + L_down_dif))
         sky_glint = rho_ls * (x_surface[-1] * L_down_dif / (L_down_dir + L_down_dif))
 
-        rfl_dir = self.calc_lamb(x_surface, geom) + sun_glint
-        rfl_dif = self.calc_lamb(x_surface, geom) + sky_glint
+        rho_dir_dir = self.calc_lamb(x_surface, geom) + sun_glint
+        rho_dif_dir = self.calc_lamb(x_surface, geom) + sky_glint
 
-        return rfl_dir, rfl_dif
+        return rho_dir_dir, rho_dif_dir
 
     def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -98,12 +98,17 @@ class GlintModelSurface(MultiComponentSurface):
         x[self.glint_ind + 1] = g_dsf_est  # SKY_GLINT g_dsf
         return x
 
-    def calc_rfl(self, x_surface, geom):
-        """Reflectance (includes specular glint)."""
+    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
+        """Direct and diffuse Reflectance (includes sun and sky glint)."""
 
-        return self.calc_lamb(
-            x_surface, geom
-        )  # Return surface reflectance only; glint added in later
+        rho_ls = 0.02  # fresnel reflectance factor (approx. 0.02 for nadir view)
+        sun_glint = rho_ls * (x_surface[-2] * E_down_dir / (E_down_dir + E_down_dif))
+        sky_glint = rho_ls * (x_surface[-1] * E_down_dif / (E_down_dir + E_down_dif))
+
+        rfl_dir = self.calc_lamb(x_surface, geom) + sun_glint
+        rfl_dif = self.calc_lamb(x_surface, geom) + sky_glint
+
+        return rfl_dir, rfl_dif
 
     def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -107,7 +107,10 @@ class LUTSurface(Surface):
     def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
         """Non-Lambertian reflectance."""
 
-        return self.calc_lamb(x_surface, geom)
+        # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.
+        #  As long as this is not implemented, return the same reflectance vector for both.
+        rfl = self.calc_lamb(x_surface, geom)
+        return rfl, rfl
 
     def calc_lamb(self, x_surface, geom):
         """Lambertian reflectance.  Be sure to incorporate BRDF-related

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -104,7 +104,7 @@ class LUTSurface(Surface):
 
         return x_surface
 
-    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
+    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
         """Non-Lambertian reflectance."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -104,7 +104,7 @@ class LUTSurface(Surface):
 
         return x_surface
 
-    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
+    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
         """Non-Lambertian reflectance."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -104,7 +104,7 @@ class LUTSurface(Surface):
 
         return x_surface
 
-    def calc_rfl(self, x_surface, geom):
+    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
         """Non-Lambertian reflectance."""
 
         return self.calc_lamb(x_surface, geom)

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -183,7 +183,7 @@ class MultiComponentSurface(Surface):
             )
         return x_surface
 
-    def calc_rfl(self, x_surface, geom):
+    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
         """Non-Lambertian reflectance."""
 
         return self.calc_lamb(x_surface, geom)

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -183,7 +183,7 @@ class MultiComponentSurface(Surface):
             )
         return x_surface
 
-    def calc_rfl(self, geom, x_surface, E_down_dir=None, E_down_dif=None):
+    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
         """Non-Lambertian reflectance."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -186,7 +186,10 @@ class MultiComponentSurface(Surface):
     def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
         """Non-Lambertian reflectance."""
 
-        return self.calc_lamb(x_surface, geom)
+        # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.
+        #  As long as this is not implemented, return the same reflectance vector for both.
+        rfl = self.calc_lamb(x_surface, geom)
+        return rfl, rfl
 
     def calc_lamb(self, x_surface, geom):
         """Lambertian reflectance."""

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -183,7 +183,7 @@ class MultiComponentSurface(Surface):
             )
         return x_surface
 
-    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
+    def calc_rfl(self, geom, x_surface, E_down_dir=None, E_down_dif=None):
         """Non-Lambertian reflectance."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -183,7 +183,7 @@ class MultiComponentSurface(Surface):
             )
         return x_surface
 
-    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
+    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
         """Non-Lambertian reflectance."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -75,7 +75,7 @@ class ThermalSurface(MultiComponentSurface):
 
         return x_surface
 
-    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
+    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
         """Reflectance. This could be overriden to add (for example)
         specular components"""
 

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -75,7 +75,7 @@ class ThermalSurface(MultiComponentSurface):
 
         return x_surface
 
-    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
+    def calc_rfl(self, x_surface, geom, E_down_dir=None, E_down_dif=None):
         """Reflectance. This could be overriden to add (for example)
         specular components"""
 

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -79,7 +79,10 @@ class ThermalSurface(MultiComponentSurface):
         """Reflectance. This could be overriden to add (for example)
         specular components"""
 
-        return self.calc_lamb(x_surface, geom)
+        # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.
+        #  As long as this is not implemented, return the same reflectance vector for both.
+        rfl = self.calc_lamb(x_surface, geom)
+        return rfl, rfl
 
     def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -75,7 +75,7 @@ class ThermalSurface(MultiComponentSurface):
 
         return x_surface
 
-    def calc_rfl(self, x_surface, geom):
+    def calc_rfl(self, x_surface, E_down_dir, E_down_dif, geom):
         """Reflectance. This could be overriden to add (for example)
         specular components"""
 

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -108,8 +108,9 @@ class ThermalSurface(MultiComponentSurface):
 
         T = x_surface[self.surf_temp_ind]
         rfl = self.calc_rfl(x_surface, geom)
-        rfl[rfl > 1.0] = 1.0
-        emissivity = 1 - rfl
+        # ToDo: direct and diffuse reflectance vectors not supported yet
+        rfl[0][rfl[0] > 1.0] = 1.0
+        emissivity = 1 - rfl[0]
         Ls, dLs_dT = emissive_radiance(emissivity, T, self.wl)
         return Ls
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -73,6 +73,7 @@ def apply_oe(
     num_neighbors=[],
     atm_sigma=[2],
     pressure_elevation=False,
+    multipart_transmittance=False,
     prebuilt_lut=None,
     no_min_lut_spacing=False,
     inversion_windows=None,
@@ -180,6 +181,8 @@ def apply_oe(
         Only used with the analytical line.
     pressure_elevation : bool, default=False
         Flag to retrieve elevation
+    multipart_transmittance: bool, default=False
+        Flag to indicate whether a 4-component transmittance model (coupling terms) is to be used
     prebuilt_lut : str, default=None
         Use this pre-constructed look up table for all retrievals. Must be an
         ISOFIT-compatible RTE NetCDF
@@ -562,6 +565,7 @@ def apply_oe(
                 uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
                 prebuilt_lut_path=prebuilt_lut,
                 inversion_windows=INVERSION_WINDOWS,
+                multipart_transmittance=multipart_transmittance,
             )
 
             # Run modtran retrieval
@@ -665,6 +669,7 @@ def apply_oe(
             pressure_elevation=pressure_elevation,
             prebuilt_lut_path=prebuilt_lut,
             inversion_windows=INVERSION_WINDOWS,
+            multipart_transmittance=multipart_transmittance,
         )
 
         # Run retrieval
@@ -758,6 +763,7 @@ def apply_oe(
 @click.option("--num_neighbors", "-nn", type=int, multiple=True)
 @click.option("--atm_sigma", "-as", type=float, multiple=True, default=[2])
 @click.option("--pressure_elevation", is_flag=True, default=False)
+@click.option("--multipart_transmittance", is_flag=True, default=False)
 @click.option("--prebuilt_lut", type=str)
 @click.option("--no_min_lut_spacing", is_flag=True, default=False)
 @click.option("--inversion_windows", type=float, nargs=2, multiple=True, default=None)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -494,6 +494,7 @@ def build_presolve_config(
     debug: bool = False,
     inversion_windows=[[350.0, 1360.0], [1410, 1800.0], [1970.0, 2500.0]],
     prebuilt_lut_path: str = None,
+    multipart_transmittance: bool = False,
 ) -> None:
     """Write an isofit config file for a presolve, with limited info.
 
@@ -507,7 +508,8 @@ def build_presolve_config(
         uncorrelated_radiometric_uncertainty: uncorrelated radiometric uncertainty parameter for isofit
         segmentation_size: image segmentation size if empirical line is used
         debug: flag to enable debug_mode in the config.implementation
-        lut_path: lut path to use; if none, presolve config will create a new file
+        prebuilt_lut_path: lut path to use; if none, presolve config will create a new file
+        multipart_transmittance: flag to indicate whether a 4-component transmittance model is to be used
     """
 
     # Determine number of spectra included in each retrieval.  If we are
@@ -526,10 +528,8 @@ def build_presolve_config(
 
     if surface_category == "glint_model_surface":
         glint_model = True
-        multipart_transmittance = True
     else:
         glint_model = False
-        multipart_transmittance = False
 
     if prebuilt_lut_path is None:
         lut_path = join(paths.lut_h2o_directory, "lut.nc")
@@ -690,6 +690,7 @@ def build_main_config(
     debug: bool = False,
     inversion_windows=[[350.0, 1360.0], [1410, 1800.0], [1970.0, 2500.0]],
     prebuilt_lut_path: str = None,
+    multipart_transmittance: bool = False,
 ) -> None:
     """Write an isofit config file for the main solve, using the specified pathnames and all given info
 
@@ -716,6 +717,7 @@ def build_main_config(
         segmentation_size:                    image segmentation size if empirical line is used
         pressure_elevation:                   if true, retrieve pressure elevation
         debug:                                if true, run ISOFIT in debug mode
+        multipart_transmittance:              flag to indicate whether a 4-component transmittance model is to be used
     """
 
     # Determine number of spectra included in each retrieval.  If we are
@@ -739,10 +741,8 @@ def build_main_config(
 
     if surface_category == "glint_model_surface":
         glint_model = True
-        multipart_transmittance = True
     else:
         glint_model = False
-        multipart_transmittance = False
 
     radiative_transfer_config = {
         "radiative_transfer_engines": {


### PR DESCRIPTION
@pgbrodrick @davidraythompson This is a first draft for a simplification of `radiative_transfer.py`. The two main goals are:

1. Clean up transmittance terms, so that, e.g., `transm_down_dif` only holds the diffuse downward transmittance and not the total transmittance (down * up, direct + diffuse), such as in the current sRTMnet and standard MODTRAN case.
2. Integrate different model variations, namely the topography model, the glint model, and adjacency effects into one single radiance model, in particular, remove preclusive if-clauses.

There are two main problems/questions as of now:

1. The proposed new implementation only works if at least one of the variables `transm_up_dir` and `transm_up_dif` is not zero. Otherwise, the term `((E_down_dir + E_down_dif) * (T_up_dir + T_up_dif)) / (1.0 - s_alb * bg)` would be zero as well causing incorrectly modeled radiance. With sRTMnet and standard MODTRAN we currently don't have separated upward transmittance available. Proposed solution: deprecate single-transmittance mode in ISOFIT.
2. Both the KF emulator and the universal LUT we've recently been testing provide separated direct and diffuse, but combined downward and upward fluxes. So again, both `transm_up_dir` and `transm_up_dif` would be zero. Proposed solution: train emulator and build LUT to output separated downward and upward fluxes.

Please find some more topics for discussion at in-line comments.

Let me know what you think!
