### PR TITLE
LUT Speedup

### DIFF
--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -354,6 +354,7 @@ def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):
         if encompass:
             where = ds[dim].where(ds[dim] > lte).dropna(dim)
             lte = where[l] if where.size else ds[dim].max()
+            Logger.debug(f"Encompass changed lte value to {lte}")
 
         ds = ds.sel({dim: ds[dim] <= lte})
 
@@ -364,6 +365,7 @@ def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):
         if encompass:
             where = ds[dim].where(ds[dim] < gte).dropna(dim)
             gte = where[g] if where.size else ds[dim].min()
+            Logger.debug(f"Encompass changed gte value to {gte}")
 
         ds = ds.sel({dim: gte <= ds[dim]})
 
@@ -409,7 +411,13 @@ def sub(ds: xr.Dataset, dim: str, strat) -> xr.Dataset:
 
 
 def load(
-    file: str, subset: dict = None, dask=True, mode="r", lock=False, load=True, **kwargs
+    file: str,
+    subset: dict = None,
+    dask=False,
+    mode="r",
+    lock=False,
+    load=True,
+    **kwargs,
 ) -> xr.Dataset:
     """
     Loads a LUT NetCDF


### PR DESCRIPTION
# Description

Collection of improvements to the `luts.py` module to increase the loading speed. Present goals are to reduce the loading speed on any LUT to be less than two minutes for any strategy. 

Leaving as a draft while performing ongoing experiments. 

# Changes

- 🐛 Fixed a bug with subsetting dimensions that are in reversed order. Subsetting wasn't actually working as intended, often leaving the entire dimension in play. As a result, downstream processing could have significant additional overhead, such as interpolation.