### PR TITLE
Analytical Line Speed Improvements

### DIFF
--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -25,8 +25,12 @@ from datetime import datetime
 import numpy as np
 
 import isofit
+from isofit import ray
 
 from .sunposition import sunpos
+
+# Cache for loading the ESD file
+ESD = None
 
 
 class Geometry:
@@ -54,19 +58,27 @@ class Geometry:
         self.earth_sun_distance = None
         self.esd_factor = None
 
-        self.earth_sun_file = None
+        self.earth_sun_file = None  # Unused?
         self.earth_sun_distance_path = os.path.join(
             isofit.root, "data", "earth_sun_distance.txt"
         )
-        try:
-            self.earth_sun_distance_reference = np.loadtxt(self.earth_sun_distance_path)
-        except FileNotFoundError:
-            logging.warning(
-                "Earth-sun-distance file not found on system. "
-                "Proceeding without might cause some inaccuracies down the line."
-            )
-            self.earth_sun_distance_reference = np.ones((366, 2))
-            self.earth_sun_distance_reference[:, 0] = np.arange(1, 367, 1)
+
+        global ESD
+        if ESD is None:
+            try:
+                ESD = np.loadtxt(self.earth_sun_distance_path)
+                logging.debug(
+                    f"Succesfully loaded ESD from {self.earth_sun_distance_path}"
+                )
+            except FileNotFoundError:
+                logging.warning(
+                    "Earth-sun-distance file not found on system. "
+                    "Proceeding without might cause some inaccuracies down the line."
+                )
+                ESD = np.ones((366, 2))
+                ESD[:, 0] = np.arange(1, 367, 1)
+
+        self.earth_sun_distance_reference = ESD
 
         self.bg_rfl = bg_rfl
         self.cos_i = None

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -25,7 +25,6 @@ from datetime import datetime
 import numpy as np
 
 import isofit
-from isofit import ray
 
 from .sunposition import sunpos
 


### PR DESCRIPTION
# Description

The analytical line algorithm had reduced performance from version 2 to 3:
```txt
v2 - Analytical line inversions complete.  1141.06s total, 1393.2274 spectra/s, 34.8307 spectra/s/core
v3 - Analytical line inversions complete.  1889.64s total, 841.3036 spectra/s, 21.0326 spectra/s/core
```

Current working theory is that the Geometry object is the fault due to reloading the same ESD file in a for loop:

Version 2
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/020a73e3-880d-4ec0-ba69-7f4a1c38114a">

Version 3
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/5173c0e4-ca3a-4acb-910a-5be454b1e8f6">

Notice the large block on the bottom right of the v3 profiling. That is entirely a `np.loadtxt` operation:
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/018c8679-2564-4900-aebe-1c73ed6c1660">

Version 2 does not load an existing ESD file so does not have this overhead. It appears the analytical line algorithm repeatedly initializes the Geometry object which reloads this file:

```python
for r in range(start_line, stop_line):
    for c in range(output_state.shape[1]):
        ...
        geom = Geometry(obs=obs[r, c, :], loc=loc[r, c, :])
```

This may explain why core utilization is less than 100% like version 2 experiences.

# Changes
- Cache the loaded ESD via a global variable within the Geometry module. This improved the performance to:
```
Analytical line inversions complete.  1196.91s total, 1328.219 spectra/s, 33.2055 spectra/s/core
```