### PR TITLE
ESD moved to IO

### DIFF
--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -758,6 +758,7 @@ class IO:
     def load_esd(file):
         try:
             esd = np.loadtxt(file)
+            logging.debug(f"Loaded ESD from file: {file}")
         except FileNotFoundError:
             logging.warning(
                 "Earth-sun-distance file not found on system. "

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -29,6 +29,7 @@ import scipy.io
 import xarray as xr
 from spectral.io import envi
 
+import isofit
 from isofit.configs import Config
 from isofit.core.common import envi_header
 from isofit.core.forward import ForwardModel
@@ -348,6 +349,11 @@ class InputData:
 class IO:
     """..."""
 
+    # Default ESD path
+    earth_sun_distance_path = os.path.join(
+        isofit.root, "data", "earth_sun_distance.txt"
+    )
+
     def __init__(self, config: Config, forward: ForwardModel):
         """Initialization specifies retrieval subwindows for calculating
         measurement cost distributions."""
@@ -437,6 +443,9 @@ class IO:
             filename = self.config.input.radiometry_correction_file
             self.radiance_correction, wl = load_spectrum(filename)
 
+        # Load the earth sun distance data
+        self.esd = self.load_esd(self.earth_sun_distance_path)
+
     def get_components_at_index(self, row: int, col: int) -> InputData:
         """
         Load data from input files at the specified (row, col) index.
@@ -495,6 +504,7 @@ class IO:
         geom = Geometry(
             obs=data["obs_file"],
             loc=data["loc_file"],
+            esd=self.esd,
             bg_rfl=data["background_reflectance_file"],
         )
 
@@ -743,6 +753,20 @@ class IO:
         self.write_datasets(
             row, col, to_write, states, flush_immediately=flush_immediately
         )
+
+    @staticmethod
+    def load_esd(file):
+        try:
+            esd = np.loadtxt(file)
+        except FileNotFoundError:
+            logging.warning(
+                "Earth-sun-distance file not found on system. "
+                "Proceeding without might cause some inaccuracies down the line."
+            )
+            esd = np.ones((366, 2))
+            esd[:, 0] = np.arange(1, 367, 1)
+
+        return esd
 
 
 def write_bil_chunk(

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -54,6 +54,13 @@ class Geometry:
         self.surface_elevation_km = None
         self.earth_sun_distance = None
         self.esd_factor = None
+
+        if esd is None:
+            logging.warning(
+                "Earth sun distance not provided. Proceeding without might cause some inaccuracies down the line"
+            )
+            esd = np.ones((366, 2))
+            esd[:, 0] = np.arange(1, 367, 1)
         self.earth_sun_distance_reference = esd
 
         self.bg_rfl = bg_rfl

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -38,6 +38,7 @@ class Geometry:
         obs: np.array = None,
         loc: np.array = None,
         dt: datetime = None,
+        esd: np.array = None,
         bg_rfl=None,
     ):
         # Set some benign defaults...
@@ -53,20 +54,7 @@ class Geometry:
         self.surface_elevation_km = None
         self.earth_sun_distance = None
         self.esd_factor = None
-
-        self.earth_sun_file = None
-        self.earth_sun_distance_path = os.path.join(
-            isofit.root, "data", "earth_sun_distance.txt"
-        )
-        try:
-            self.earth_sun_distance_reference = np.loadtxt(self.earth_sun_distance_path)
-        except FileNotFoundError:
-            logging.warning(
-                "Earth-sun-distance file not found on system. "
-                "Proceeding without might cause some inaccuracies down the line."
-            )
-            self.earth_sun_distance_reference = np.ones((366, 2))
-            self.earth_sun_distance_reference[:, 0] = np.arange(1, 367, 1)
+        self.earth_sun_distance_reference = esd
 
         self.bg_rfl = bg_rfl
         self.cos_i = None

--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -311,7 +311,16 @@ class ModtranRT(RadiativeTransferEngine):
         vals["DISALB"] = True
         vals["NAME"] = filename_base
         vals["FILTNM"] = os.path.normpath(self.filtpath)
+
+        # Translate to the MODTRAN OBSZEN convention, assumes we are downlooking
+        if vals["OBSZEN"] < 90:
+            vals["OBSZEN"] = 180 - abs(vals["OBSZEN"])
+
         modtran_config_str, modtran_config = self.modtran_driver(dict(vals))
+
+        # Translate to the MODTRAN OBSZEN convention
+        if vals["OBSZEN"] < 90:
+            vals["OBSZEN"] = 180 - abs(vals["OBSZEN"])
 
         # Check rebuild conditions: LUT is missing or from a different config
         infilename = "LUT_" + filename_base + ".json"

--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -318,10 +318,6 @@ class ModtranRT(RadiativeTransferEngine):
 
         modtran_config_str, modtran_config = self.modtran_driver(dict(vals))
 
-        # Translate to the MODTRAN OBSZEN convention
-        if vals["OBSZEN"] < 90:
-            vals["OBSZEN"] = 180 - abs(vals["OBSZEN"])
-
         # Check rebuild conditions: LUT is missing or from a different config
         infilename = "LUT_" + filename_base + ".json"
         infilepath = os.path.join(self.sim_path, "LUT_" + filename_base + ".json")

--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -29,6 +29,7 @@ from isofit.configs.sections.radiative_transfer_config import (
     RadiativeTransferEngineConfig,
 )
 from isofit.core.common import resample_spectrum
+from isofit.core.fileio import IO
 from isofit.radiative_transfer.radiative_transfer_engine import RadiativeTransferEngine
 
 Logger = logging.getLogger(__file__)
@@ -270,15 +271,7 @@ class SixSRT(RadiativeTransferEngine):
         """
         Loads the earth-sun distance file
         """
-        try:
-            self.esd = np.loadtxt(self.earth_sun_distance_path)
-        except FileNotFoundError:
-            Logger.info(
-                "Earth-sun-distance file not found on system. "
-                "Proceeding without might cause some inaccuracies down the line."
-            )
-            self.esd = np.ones((366, 2))
-            self.esd[:, 0] = np.arange(1, 367, 1)
+        self.esd = IO.load_esd(IO.earth_sun_distance_path)
 
         dt = datetime(2000, self.engine_config.month, self.engine_config.day)
         self.day_of_year = dt.timetuple().tm_yday

--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -29,7 +29,6 @@ from isofit.configs.sections.radiative_transfer_config import (
     RadiativeTransferEngineConfig,
 )
 from isofit.core.common import resample_spectrum
-from isofit.core.fileio import IO
 from isofit.radiative_transfer.radiative_transfer_engine import RadiativeTransferEngine
 
 Logger = logging.getLogger(__file__)
@@ -271,7 +270,15 @@ class SixSRT(RadiativeTransferEngine):
         """
         Loads the earth-sun distance file
         """
-        self.esd = IO.load_esd(IO.earth_sun_distance_path)
+        try:
+            self.esd = np.loadtxt(self.earth_sun_distance_path)
+        except FileNotFoundError:
+            Logger.info(
+                "Earth-sun-distance file not found on system. "
+                "Proceeding without might cause some inaccuracies down the line."
+            )
+            self.esd = np.ones((366, 2))
+            self.esd[:, 0] = np.arange(1, 367, 1)
 
         dt = datetime(2000, self.engine_config.month, self.engine_config.day)
         self.day_of_year = dt.timetuple().tm_yday

--- a/isofit/test/test_geometry.py
+++ b/isofit/test/test_geometry.py
@@ -3,7 +3,6 @@ from isofit.core.geometry import Geometry
 
 def test_Geometry():
     geom = Geometry()
-    assert geom.earth_sun_file == None
     assert geom.observer_zenith == 0
     assert geom.observer_azimuth == 0
     assert geom.observer_altitude_km == None

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -31,7 +31,7 @@ from spectral.io import envi
 from isofit import ray
 from isofit.configs import configs
 from isofit.core.common import envi_header, load_spectrum
-from isofit.core.fileio import write_bil_chunk
+from isofit.core.fileio import IO, write_bil_chunk
 from isofit.core.forward import ForwardModel
 from isofit.core.geometry import Geometry
 from isofit.inversion.inverse import Inversion
@@ -294,6 +294,8 @@ class Worker(object):
             - 9999
         )
 
+        esd = IO.load_esd(IO.earth_sun_distance_path)
+
         for r in range(start_line, stop_line):
             for c in range(output_state.shape[1]):
                 meas = rdn[r, c, :]
@@ -302,7 +304,7 @@ class Worker(object):
                 if np.all(meas < 0):
                     continue
                 x_RT = rt_state[r, c, self.fm.idx_RT - len(self.fm.idx_surface)]
-                geom = Geometry(obs=obs[r, c, :], loc=loc[r, c, :])
+                geom = Geometry(obs=obs[r, c, :], loc=loc[r, c, :], esd=esd)
 
                 states, unc = invert_analytical(
                     self.iv.fm,


### PR DESCRIPTION
Moves the loading of the ESD file to the `core/fileio.py:IO` class to maintain consistency with other data loading. Additionally made it an optional parameter to the `Geometry` class. 

This is an alternative implementation to resolve the bug described in #530.

Integrated #527 to fix Black formatting. 