### PR TITLE
Bad data close to bad flag

### DIFF
--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -495,7 +495,7 @@ class IO:
 
         ## Check for any bad data flags
         for source in self.input_datasets:
-            if np.all(abs(data[source] - self.input_datasets[source].flag) < eps):
+            if np.allclose(data[source], self.input_datasets[source].flag):
                 return None
 
         # We build the geometry object for this spectrum.  For files not


### PR DESCRIPTION
Swaps out a `np.all` with `np.allclose` to handle cases where an input data source has values very close to the bad data flag but not exact

Closes #159