### PR TITLE
MKL/OMP env vars fixed

### DIFF
--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -142,6 +142,19 @@ Windows
 
     setx VARIABLE_NAME "DIRECTORY" (use your actual path)
 
+ISOFIT variables
+----------------
+
+The following environment variables are actively used within ISOFIT:
+
+- `MKL_NUM_THREADS` and `OMP_NUM_THREADS` - These control the threading of various packages within ISOFIT. It is
+important to set these to "1" to ensure ISOFIT performs to its fullest capabilities. By default, ISOFIT will insert
+these into the environment if they are not set and/or not set correctly.
+- `ISOFIT_NO_SET_THREADS` - This will disable automatically setting the MKL and OMP environment variables. This is recommended
+only for advanced users that know what they are doing and can mitigate the consequences.
+- `ISOFIT_DEBUG` - This will disable the `ray` package across ISOFIT to force single-core execution. Primarily used as
+a debugging tool by developers and is not recommended for use.
+
 Quick Start with sRTMnet (Recommended for new users)
 ====================================================
 

--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -39,3 +39,28 @@ if os.environ.get("ISOFIT_DEBUG"):
     from .wrappers import ray
 else:
     import ray
+
+from threadpoolctl import threadpool_info
+
+
+def checkNumThreads():
+    """
+    Checks the num_threads setting in the environment and raises a strong warning if it
+    is not set to 1 .
+    """
+    error = False
+    if info := threadpool_info():
+        if info[0]["num_threads"] > 1:
+            error = "greater than"
+    else:
+        error = "not set to"
+
+    if error:
+        Logger.warning(
+            f"""
+******************************************************************************************
+! Number of threads is {error} 1, this may greatly impact performance
+! Please set this the environment variables 'MKL_NUM_THREADS' and 'OMP_NUM_THREADS' to '1'
+******************************************************************************************\
+"""
+        )

--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -1,5 +1,14 @@
 """ISOFIT command line interface."""
 
+import os
+
+# Explicitly set the number of threads to be 1, so we more effectively run in parallel
+# Must be executed before importing numpy, otherwise doesn't work
+# Setting in the CLI ensures this works for any script
+if not os.environ.get("ISOFIT_NO_SET_THREADS"):
+    os.environ["MKL_NUM_THREADS"] = "1"
+    os.environ["OMP_NUM_THREADS"] = "1"
+
 import click
 
 import isofit

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -24,10 +24,16 @@ import multiprocessing
 import os
 import time
 
+# Explicitly set the number of threads to be 1, so we more effectively run in parallel
+# Must be executed before importing numpy, otherwise doesn't work
+if not os.environ.get("ISOFIT_NO_SET_THREADS"):
+    os.environ["MKL_NUM_THREADS"] = "1"
+    os.environ["OMP_NUM_THREADS"] = "1"
+
 import click
 import numpy as np
 
-from isofit import ray
+from isofit import checkNumThreads, ray
 from isofit.configs import configs
 from isofit.core.fileio import IO
 from isofit.core.forward import ForwardModel
@@ -45,10 +51,9 @@ class Isofit:
     """
 
     def __init__(self, config_file, level="INFO", logfile=None):
-        # Explicitly set the number of threads to be 1, so we more effectively
-        # run in parallel
-        os.environ["MKL_NUM_THREADS"] = "1"
-        os.environ["OMP_NUM_THREADS"] = "1"
+        # Check the MKL/OMP env vars and raise a warning if not set properly
+        checkNumThreads()
+
         # Set logging level
         self.loglevel = level
         self.logfile = logfile


### PR DESCRIPTION
Fixed a longstanding bug where `MKL_NUM_THREADS` and `OMP_NUM_THREADS` was not being set properly by ISOFIT. These need to be set before any import/instantiation of numpy.

Additionally adds a new ISOFIT env var `ISOFIT_NO_SET_THREADS` to disable automatically setting these for advanced users.

Closes #444