### PR TITLE
rte_configure_and_exit

### DIFF
--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -33,7 +33,7 @@ class ImplementationConfig(BaseConfigSection):
         self._mode_type = str
         self.mode = "inversion"
         """
-        str: Defines the operating mode for isofit. Current options are: inversion, inversion_mcmc, 
+        str: Defines the operating mode for isofit. Current options are: inversion, inversion_mcmc,
         and 'simulation'.
         """
 
@@ -61,15 +61,6 @@ class ImplementationConfig(BaseConfigSection):
         self.ray_include_dashboard = False
         """str: Ray - parameter.  Boolean to include dashboard."""
 
-        self._rte_configure_and_exit_type = bool
-        self.rte_configure_and_exit = False
-        """bool: Indicates that code should terminate as soon as all radiative transfer engine configuration files are
-        written (without running them)"""
-
-        self._rte_auto_rebuild_type = bool
-        self.rte_auto_rebuild = True
-        """bool: Flag indicating whether radiative transfer engines should automatically rebuild."""
-
         self._ray_temp_dir_type = str
         self.ray_temp_dir = "/tmp/ray"
         """str: Overrides the standard ray temporary directory.  Useful for multiuser systems."""
@@ -81,7 +72,7 @@ class ImplementationConfig(BaseConfigSection):
         self._io_buffer_size_type = int
         self.io_buffer_size = 100
         """bool: Integer indicating how large (how many spectra) of chunks to read/process/write.  A
-        buffer size of 1 means pixels are processed independently.  Large buffers can help prevent IO choke points, 
+        buffer size of 1 means pixels are processed independently.  Large buffers can help prevent IO choke points,
         especially if the """
 
         self._max_hash_table_size_type = int

--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -89,13 +89,13 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         self._glint_model_type = bool
         self.glint_model = False
         """
-        Flag to indicate whether to use the sun and sky glint model from Gege (2012, 2014) in the forward model. 
+        Flag to indicate whether to use the sun and sky glint model from Gege (2012, 2014) in the forward model.
         Only currently functional with multipart MODTRAN.
         """
 
         self._rt_mode_type = str
         self.rt_mode = None
-        """str: Radiative transfer mode of LUT simulations. 
+        """str: Radiative transfer mode of LUT simulations.
         'transm' for transmittances, 'rdn' for reflected radiance."""
 
         self._lut_names_type = dict()
@@ -182,6 +182,12 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         self._irradiance_file_type = str
         self.irradiance_file = None
         """str: 6s-only irradiance file."""
+
+        # MODTRAN and 6S
+        self._rte_configure_and_exit_type = bool
+        self.rte_configure_and_exit = False
+        """bool: Indicates that code should terminate as soon as all radiative transfer engine configuration files are
+        written (without running them)"""
 
         self.set_config_options(sub_configdic)
 

--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -322,25 +322,13 @@ class ModtranRT(RadiativeTransferEngine):
         infilename = "LUT_" + filename_base + ".json"
         infilepath = os.path.join(self.sim_path, "LUT_" + filename_base + ".json")
 
-        if not self.required_results_exist(filename_base):
-            rebuild = True
-        else:
-            # We compare the two configuration files, ignoring names and
-            # wavelength paths which tend to be non-portable
-            with open(infilepath, "r") as fin:
-                current_config = json.load(fin)["MODTRAN"]
-                current_config[0]["MODTRANINPUT"]["NAME"] = ""
-                modtran_config[0]["MODTRANINPUT"]["NAME"] = ""
-                current_config[0]["MODTRANINPUT"]["SPECTRAL"]["FILTNM"] = ""
-                modtran_config[0]["MODTRANINPUT"]["SPECTRAL"]["FILTNM"] = ""
-                current_str = json.dumps(current_config)
-                modtran_str = json.dumps(modtran_config)
-                rebuild = modtran_str.strip() != current_str.strip()
-
-        if not rebuild:
+        if self.required_results_exist(filename_base):
             Logger.warning(
                 f"File already exists and not set to rebuild, skipping execution: {filename_base}"
             )
+            return
+
+        if self.engine_config.rte_configure_and_exit:
             return
 
         # write_config_file

--- a/isofit/radiative_transfer/engines/sRTMnet.py
+++ b/isofit/radiative_transfer/engines/sRTMnet.py
@@ -135,6 +135,10 @@ class SimulatedModtranRT(RadiativeTransferEngine):
             modtran_emulation=True,
             build_interpolators=False,
         )
+
+        if self.engine_config.rte_configure_and_exit:
+            return
+
         # Extract useful information from the sim
         self.esd = sim.esd
         self.sim_lut_path = config.lut_path

--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -87,7 +87,7 @@ class SixSRT(RadiativeTransferEngine):
                 f"6S path not valid, downstream simulations will be broken: {sixS}"
             )
 
-    def makeSim(self, point: np.array, template_only: bool = False):
+    def makeSim(self, point: np.array):
         """
         Perform 6S simulations
 
@@ -95,8 +95,6 @@ class SixSRT(RadiativeTransferEngine):
         ----------
         point: np.array
             Point to process
-        template_only: bool, default=False
-            Only write the simulation template then exit. If False, subprocess call 6S
         """
         # Retrieve the files to process
         name = self.point_to_filename(point)
@@ -119,13 +117,15 @@ class SixSRT(RadiativeTransferEngine):
             # in multipart transmittance mode, we need to run 6s for ech wavelength separately
             for wl in self.wl:
                 cmd = self.rebuild_cmd(point=point, wlinf=wl, wlsup=wl)
-                if template_only is False:
+
+                if not self.engine_config.rte_configure_and_exit:
                     call = subprocess.run(cmd, shell=True, capture_output=True)
                     if call.stdout:
                         Logger.error(call.stdout.decode())
         else:
             cmd = self.rebuild_cmd(point, wlinf=self.wl[0], wlsup=self.wl[-1])
-            if template_only is False:
+
+            if not self.engine_config.rte_configure_and_exit:
                 call = subprocess.run(cmd, shell=True, capture_output=True)
                 if call.stdout:
                     Logger.error(call.stdout.decode())

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -424,6 +424,7 @@ class RadiativeTransferEngine:
             readSim = ray.put(self.readSim)
             lut_path = ray.put(self.lut_path)
             buffer_time = ray.put(self.max_buffer_time)
+            rte_configure_and_exit = ray.put(self.engine_config.rte_configure_and_exit)
 
             jobs = [
                 streamSimulation.remote(
@@ -433,6 +434,7 @@ class RadiativeTransferEngine:
                     readSim,
                     lut_path,
                     max_buffer_time=buffer_time,
+                    rte_configure_and_exit=self.engine_config.rte_configure_and_exit,
                 )
                 for point in self.points
             ]
@@ -637,6 +639,7 @@ def streamSimulation(
     reader: Callable,
     output: str,
     max_buffer_time: float = 0.5,
+    rte_configure_and_exit: bool = False,
 ):
     """Run a simulation for a single point and stream the results to a saved lut file.
 
@@ -647,6 +650,7 @@ def streamSimulation(
         reader (function): function to read the results of the simulation
         output (str): LUT store to save results to
         max_buffer_time (float, optional): _description_. Defaults to 0.5.
+        rte_configure_and_exit (bool, optional): exit early if not executing simulations
     """
     Logger.debug(f"Simulating(point={point})")
 
@@ -655,6 +659,10 @@ def streamSimulation(
 
     # Execute the simulation
     simmer(point)
+
+    # No data will be produced, just configuration files
+    if rte_configure_and_exit:
+        return
 
     # Read the simulation results
     data = reader(point)


### PR DESCRIPTION
Re-implements support for `rte_configure_and_exit` which causes engines to write configuration/template files and not execute.

Additionally deprecated support for `rte_auto_rebuild`. ISOFIT will just check if files exist and assume they are correct; it is the user's responsibility to correct them otherwise.

Closes #140