### PR TITLE
Removed nds-k from VectorInterpolator

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -57,7 +57,7 @@ class VectorInterpolator:
         self,
         grid_input: List[List[float]],
         data_input: np.array,
-        version="nds-1",
+        version="mlg",
     ):
         # Determine if this a singular unique value, if so just return that directly
         val = data_input[(0,) * data_input.ndim]
@@ -104,7 +104,7 @@ class VectorInterpolator:
 
     def _interpolate(self, points):
         """
-        Supports styles 'rg' and 'nds-k'
+        Supports style 'rg'
         """
         # If we only have one point, we can't do any interpolation, so just
         # return the original data.


### PR DESCRIPTION
We removed nds-k support in commit 79459acf98c8984391e691477607ad7e6bdcc73f but missed removing it as the default style for VectorInterpolator. This fixes that.

Closes #541