### PR TITLE
Statevector consistency check

### DIFF
--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -94,6 +94,12 @@ class RadiativeTransfer:
             rte = Engines[confRT.engine_name](**params)
             self.rt_engines.append(rte)
 
+            # Make sure
+            if (expected := len(config.statevector)) != (got := rte.indices.x_RT):
+                error = f"Mismatch between the number of elements for the config statevector and the lut_grid: {expected=}, {got=}"
+                Logger.error(error)
+                raise AttributeError(error)
+
         # If any engine is true, self is true
         self.topography_model = any([rte.topography_model for rte in self.rt_engines])
         self.glint_model = any([rte.glint_model for rte in self.rt_engines])

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -96,7 +96,7 @@ class RadiativeTransfer:
 
             # Make sure
             if (expected := len(config.statevector)) != (got := rte.indices.x_RT):
-                error = f"Mismatch between the number of elements for the config statevector and the lut_grid: {expected=}, {got=}"
+                error = f"Mismatch between the number of elements for the config statevector and the LUT.indices.x_RT: {expected=}, {got=}"
                 Logger.error(error)
                 raise AttributeError(error)
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -254,12 +254,12 @@ class RadiativeTransferEngine:
         self.cached = SimpleNamespace(point=np.array([]))
         Logger.debug(f"LUTs fully loaded")
 
+        # For each point index, determine if that point derives from Geometry or x_RT
+        self.indices = SimpleNamespace(geom={}, x_RT=[])
+
         # Attach interpolators
         if build_interpolators:
             self.build_interpolators()
-
-            # For each point index, determine if that point derives from Geometry or x_RT
-            self.indices = SimpleNamespace()
 
             # Hidden assumption: geometry keys come first, then come RTE keys
             self.geometry_input_names = set(self.geometry_input_names) - set(


### PR DESCRIPTION
RT now checks every child RTEs' assumption of source for elements, be it either from geom or x_RT, and verifies consistency with the `config.forward_model.radiative_transfer.statevector`

Closes #543 