### PR TITLE
Cancel-in-progress Workflows

### DIFF
--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -27,6 +27,10 @@ on:
   pull_request:
     branches: ["dev", "main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   test:
@@ -43,6 +47,9 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
+
+      - name: Print concurrency group
+        run: echo '${{ github.workflow }}-${{ github.ref }}'
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: ["dev", "main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   test:


### PR DESCRIPTION
Workflows should auto-cancel in-progress ones when a new set is triggered (such as a new commit).

Since we have long-running workflows, this should help resolve issues in cases of rapid development causing clogging in the workflows.