### PR TITLE
Helpful Validation

### DIFF
--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -762,7 +762,7 @@ class IO:
             Loaded ESD. If the file fails to load, creates a default
         """
         if file is None:
-            file = os.path.join(env.data, "earth_sun_distance.txt")
+            file = env.path("data", "earth_sun_distance.txt")
 
         try:
             esd = np.loadtxt(file)

--- a/isofit/data/cli/__init__.py
+++ b/isofit/data/cli/__init__.py
@@ -43,12 +43,19 @@ def validate_all():
 def env_validate(keys, **kwargs):
     """
     Utility function for the `env` object to quickly validate specific dependencies
+
+    Parameters
+    ----------
+    keys : list
+        List of validator functions to call
     """
+    error = kwargs.get("error", print)
+
     all_valid = True
     for key in keys:
         module = Modules.get(key)
         if module is None:
-            print(f"Product not found: {key}")
+            error(f"Product not found: {key}")
             all_valid = False
         else:
             all_valid &= module.validate(**kwargs)

--- a/isofit/data/cli/data.py
+++ b/isofit/data/cli/data.py
@@ -87,7 +87,7 @@ def validate(path=None, debug=print, error=print, **_):
 
     if not (path := Path(path)).exists():
         error(
-            "Error: Path does not exist, please download it via `isofit download data`"
+            "Error: Data path does not exist, please download it via `isofit download data`"
         )
         return False
 

--- a/isofit/data/cli/data.py
+++ b/isofit/data/cli/data.py
@@ -59,7 +59,7 @@ def download_cli(**kwargs):
     download(**kwargs)
 
 
-def validate(path=None, **_):
+def validate(path=None, debug=print, error=print, **_):
     """
     Validates an ISOFIT data installation
 
@@ -67,6 +67,10 @@ def validate(path=None, **_):
     ----------
     path : str, default=None
         Path to verify. If None, defaults to the ini path
+    debug : function, default=print
+        Print function to use for debug messages, eg. logging.debug
+    error : function, default=print
+        Print function to use for error messages, eg. logging.error
     **_ : dict
         Ignores unused params that may be used by other validate functions. This is to
         maintain compatibility with env.validate
@@ -79,10 +83,10 @@ def validate(path=None, **_):
     if path is None:
         path = env.data
 
-    print(f"Verifying path for ISOFIT data: {path}")
+    debug(f"Verifying path for ISOFIT data: {path}")
 
     if not (path := Path(path)).exists():
-        print(
+        error(
             "Error: Path does not exist, please download it via `isofit download data`"
         )
         return False
@@ -95,12 +99,12 @@ def validate(path=None, **_):
     ]
     files = list(path.glob("*"))
     if not all([path / file in files for file in check]):
-        print(
+        error(
             "Error: ISOFIT data do not appear to be installed correctly, please ensure it is"
         )
         return False
 
-    print("Path is valid")
+    debug("Path is valid")
     return True
 
 

--- a/isofit/data/cli/examples.py
+++ b/isofit/data/cli/examples.py
@@ -61,7 +61,7 @@ def download_cli(**kwargs):
     download(**kwargs)
 
 
-def validate(path=None, **_):
+def validate(path=None, debug=print, error=print, **_):
     """
     Validates an ISOFIT examples installation
 
@@ -69,6 +69,10 @@ def validate(path=None, **_):
     ----------
     path : str, default=None
         Path to verify. If None, defaults to the ini path
+    debug : function, default=print
+        Print function to use for debug messages, eg. logging.debug
+    error : function, default=print
+        Print function to use for error messages, eg. logging.error
     **_ : dict
         Ignores unused params that may be used by other validate functions. This is to
         maintain compatibility with env.validate
@@ -81,10 +85,10 @@ def validate(path=None, **_):
     if path is None:
         path = env.examples
 
-    print(f"Verifying path for ISOFIT examples: {path}")
+    debug(f"Verifying path for ISOFIT examples: {path}")
 
     if not (path := Path(path)).exists():
-        print(
+        error(
             "Error: Path does not exist, please download it via `isofit download examples`"
         )
         return False
@@ -100,12 +104,12 @@ def validate(path=None, **_):
         "py-hypertrace",
     ]
     if not list(path.glob("*")) != expected:
-        print(
+        error(
             "Error: ISOFIT examples do not appear to be installed correctly, please ensure it is"
         )
         return False
 
-    print("Path is valid")
+    debug("Path is valid")
     return True
 
 

--- a/isofit/data/cli/examples.py
+++ b/isofit/data/cli/examples.py
@@ -89,7 +89,7 @@ def validate(path=None, debug=print, error=print, **_):
 
     if not (path := Path(path)).exists():
         error(
-            "Error: Path does not exist, please download it via `isofit download examples`"
+            "Error: Examples path does not exist, please download it via `isofit download examples`"
         )
         return False
 

--- a/isofit/data/cli/image_cube.py
+++ b/isofit/data/cli/image_cube.py
@@ -77,7 +77,7 @@ def download_cli(**kwargs):
     download(**kwargs)
 
 
-def validate(path=None, size="both", **_):
+def validate(path=None, size="both", debug=print, error=print, **_):
     """
     Validates an ISOFIT image cube data installation
 
@@ -87,6 +87,10 @@ def validate(path=None, size="both", **_):
         Path to verify. If None, defaults to the ini path
     size : "both" | "small" | "medium"
         Which chunk size to validate
+    debug : function, default=print
+        Print function to use for debug messages, eg. logging.debug
+    error : function, default=print
+        Print function to use for error messages, eg. logging.error
     **_ : dict
         Ignores unused params that may be used by other validate functions. This is to
         maintain compatibility with env.validate
@@ -102,19 +106,19 @@ def validate(path=None, size="both", **_):
     if path is None:
         path = Path(env.imagecube)
 
-    print(f"Verifying path for ISOFIT {size} image cube: {path}")
+    debug(f"Verifying path for ISOFIT {size} image cube: {path}")
 
     sizes = {"small": "7000-7010", "medium": "7k-8k"}
     for kind in ("loc", "obs", "rdn"):
         file = path / size / f"ang20170323t202244_{kind}_{sizes[size]}"
         if not file.exists():
-            print(
+            error(
                 f"Error: ISOFIT {size} image cube data do not appear to be installed correctly, please ensure it is"
             )
-            print(f"Missing file: {file}")
+            error(f"Missing file: {file}")
             return False
 
-    print("Path is valid")
+    debug("Path is valid")
     return True
 
 

--- a/isofit/data/cli/sixs.py
+++ b/isofit/data/cli/sixs.py
@@ -107,7 +107,9 @@ def validate(path=None, debug=print, error=print, **_):
     debug(f"Verifying path for 6S: {path}")
 
     if not (path := Path(path)).exists():
-        error("Error: Path does not exist, please download it via `isofit download 6S`")
+        error(
+            "Error: 6S path does not exist, please download it via `isofit download 6S`"
+        )
         return False
 
     if not (path / f"sixsV2.1").exists():

--- a/isofit/data/cli/sixs.py
+++ b/isofit/data/cli/sixs.py
@@ -80,7 +80,7 @@ def download_cli(**kwargs):
     download(**kwargs)
 
 
-def validate(path=None, **_):
+def validate(path=None, debug=print, error=print, **_):
     """
     Validates a 6S installation
 
@@ -88,6 +88,10 @@ def validate(path=None, **_):
     ----------
     path : str, default=None
         Path to verify. If None, defaults to the ini path
+    debug : function, default=print
+        Print function to use for debug messages, eg. logging.debug
+    error : function, default=print
+        Print function to use for error messages, eg. logging.error
     **_ : dict
         Ignores unused params that may be used by other validate functions. This is to
         maintain compatibility with env.validate
@@ -100,19 +104,19 @@ def validate(path=None, **_):
     if path is None:
         path = env.sixs
 
-    print(f"Verifying path for 6S: {path}")
+    debug(f"Verifying path for 6S: {path}")
 
     if not (path := Path(path)).exists():
-        print("Error: Path does not exist, please download it via `isofit download 6S`")
+        error("Error: Path does not exist, please download it via `isofit download 6S`")
         return False
 
     if not (path / f"sixsV2.1").exists():
-        print(
+        error(
             "Error: 6S does not appear to be installed correctly, please ensure it is"
         )
         return False
 
-    print("Path is valid")
+    debug("Path is valid")
     return True
 
 

--- a/isofit/data/cli/srtmnet.py
+++ b/isofit/data/cli/srtmnet.py
@@ -88,7 +88,7 @@ def download_cli(**kwargs):
     download(**kwargs)
 
 
-def validate(path=None, **_):
+def validate(path=None, debug=print, error=print, **_):
     """
     Validates an sRTMnet installation
 
@@ -96,6 +96,10 @@ def validate(path=None, **_):
     ----------
     path : str, default=None
         Path to verify. If None, defaults to the ini path
+    debug : function, default=print
+        Print function to use for debug messages, eg. logging.debug
+    error : function, default=print
+        Print function to use for error messages, eg. logging.error
     **_ : dict
         Ignores unused params that may be used by other validate functions. This is to
         maintain compatibility with env.validate
@@ -108,23 +112,23 @@ def validate(path=None, **_):
     if path is None:
         path = env.srtmnet
 
-    print(f"Verifying path for sRTMnet: {path}")
+    debug(f"Verifying path for sRTMnet: {path}")
 
     if not (path := Path(path)).exists():
-        print(
+        error(
             "Error: sRTMnet path does not exist, please download it via `isofit download sRTMnet`"
         )
         return False
 
     if not list(path.glob("*.h5")):
-        print("Error: sRTMnet model not found, please download it")
+        error("Error: sRTMnet model not found, please download it")
         return False
 
     if not list(path.glob("*_aux.npz")):
-        print("Error: sRTMnet aux file not found, please download it")
+        error("Error: sRTMnet aux file not found, please download it")
         return False
 
-    print("Path is valid")
+    debug("Path is valid")
     return True
 
 

--- a/isofit/data/ini.py
+++ b/isofit/data/ini.py
@@ -195,7 +195,7 @@ class Ini:
         """
         self.validate([dir], debug=Logger.debug, error=Logger.error)
 
-        path = Path([self[dir], *path]).resolve()
+        path = Path(*[self[dir], *path]).resolve()
 
         if not path.exists():
             Logger.error(

--- a/isofit/data/ini.py
+++ b/isofit/data/ini.py
@@ -177,11 +177,45 @@ class Ini:
             except:
                 Logger.exception(f"Failed to dump ini to file: {self.ini}")
 
+    def path(self, dir: str, path: str) -> Path:
+        """
+        Retrieves a path under one of the env directories and validates the path exists.
+
+        Parameters
+        ----------
+        dir : str
+            One of the env directories, eg. "data", "examples"
+        path : str
+            Path to a file under the `dir`
+
+        Returns
+        -------
+        pathlib.Path
+            Validated full path
+        """
+        self.validate([dir], debug=Logger.debug, error=Logger.error)
+
+        path = (Path(self[dir]) / path).resolve()
+
+        if not path.exists():
+            Logger.error(
+                f"The following path does not exist, please verify your installation environment: {path}"
+            )
+
+        return path
+
     @staticmethod
     def validate(keys: List) -> bool:
         """
-        Validates known products. This function is defined by isofit.data.cli.__init__.py
+        Validates known products.
+
+        Parameters
+        ----------
+        keys : list
+            List of products to validate
         """
-        raise NotImplemented(
+        # Should never be raised as this function is defined and set in isofit.data.cli.__init__
+        # If this is hit, there's a critical environment issue
+        raise NotImplementedError(
             "ISOFIT failed to attach the validation function to this object"
         )

--- a/isofit/data/ini.py
+++ b/isofit/data/ini.py
@@ -177,7 +177,7 @@ class Ini:
             except:
                 Logger.exception(f"Failed to dump ini to file: {self.ini}")
 
-    def path(self, dir: str, path: str) -> Path:
+    def path(self, dir: str, *path: list) -> Path:
         """
         Retrieves a path under one of the env directories and validates the path exists.
 
@@ -185,7 +185,7 @@ class Ini:
         ----------
         dir : str
             One of the env directories, eg. "data", "examples"
-        path : str
+        *path : List[str]
             Path to a file under the `dir`
 
         Returns
@@ -195,7 +195,7 @@ class Ini:
         """
         self.validate([dir], debug=Logger.debug, error=Logger.error)
 
-        path = (Path(self[dir]) / path).resolve()
+        path = Path([self[dir], *path]).resolve()
 
         if not path.exists():
             Logger.error(

--- a/isofit/test/test_cli.py
+++ b/isofit/test/test_cli.py
@@ -40,12 +40,13 @@ def surface(cwd):
     # Generate the surface.mat using the image_cube example config
     # fmt: off
     surface_model(
-        config_path=f"{env.examples}/20171108_Pasadena/configs/ang20171108t184227_surface.json",
-        wavelength_path=f"{env.examples}/20171108_Pasadena/remote/20170320_ang20170228_wavelength_fit.txt",
+        config_path=env.path("examples", "20171108_Pasadena", "remote", "ang20171108t184227_surface.json"),
+        wavelength_path=env.path("examples", "20171108_Pasadena", "remote", "20170320_ang20170228_wavelength_fit.txt"),
         output_path=outp
     )
     # fmt: on
     # Return the path to the mat file
+
     return outp
 
 
@@ -89,7 +90,7 @@ def test_apply_oe(files, args, surface):
     ray.shutdown()
     sleep(120)
 
-    args[3] = os.path.join(env.srtmnet, "sRTMnet_v120.h5")
+    args[3] = env.path("srtmnet", "sRTMnet_v120.h5")
     arguments = ["apply_oe", *files, *args, "--surface_path", surface]
 
     # Passing non-string arguments to click is not allowed.

--- a/isofit/test/test_cli.py
+++ b/isofit/test/test_cli.py
@@ -40,7 +40,7 @@ def surface(cwd):
     # Generate the surface.mat using the image_cube example config
     # fmt: off
     surface_model(
-        config_path=env.path("examples", "20171108_Pasadena", "remote", "ang20171108t184227_surface.json"),
+        config_path=env.path("examples", "20171108_Pasadena", "configs", "ang20171108t184227_surface.json"),
         wavelength_path=env.path("examples", "20171108_Pasadena", "remote", "20170320_ang20170228_wavelength_fit.txt"),
         output_path=outp
     )

--- a/isofit/test/test_examples.py
+++ b/isofit/test/test_examples.py
@@ -23,7 +23,7 @@ from isofit.utils import surface_model
 def test_santa_monica(args, monkeypatch):
     """Run the Santa Monica test dataset."""
 
-    monkeypatch.chdir(f"{env.examples}/20151026_SantaMonica/")
+    monkeypatch.chdir(env.path("examples", "20151026_SantaMonica/"))
     surface_model("configs/prm20151026t173213_surface_coastal.json")
 
     runner = CliRunner()
@@ -47,7 +47,7 @@ def test_santa_monica(args, monkeypatch):
 def test_pasadena_modtran(args, monkeypatch):
     """Run Pasadena example dataset."""
 
-    monkeypatch.chdir(f"{env.examples}/20171108_Pasadena/")
+    monkeypatch.chdir(env.path("examples", "20171108_Pasadena/"))
     surface_model("configs/ang20171108t184227_surface.json")
 
     runner = CliRunner()
@@ -63,7 +63,7 @@ def test_pasadena_modtran(args, monkeypatch):
 def test_pasadena_topoflux(monkeypatch):
     """Run Pasadena topoflux example dataset."""
 
-    monkeypatch.chdir(f"{env.examples}/20171108_Pasadena/")
+    monkeypatch.chdir(env.path("examples", "20171108_Pasadena/"))
     surface_model("configs/ang20171108t184227_surface.json")
 
     model = Isofit(
@@ -77,7 +77,7 @@ def test_pasadena_topoflux(monkeypatch):
 def test_modtran_one(monkeypatch):
     """Run MODTRAN example dataset."""
 
-    monkeypatch.chdir(f"{env.examples}/20190806_ThermalIR/")
+    monkeypatch.chdir(env.path("examples", "20190806_ThermalIR/"))
     surface_model("configs/surface.json")
 
     model = Isofit(
@@ -91,7 +91,7 @@ def test_modtran_one(monkeypatch):
 # def test_profiling_cube_small(monkeypatch):
 #     """Run profiling datasets."""
 #
-#     monkeypatch.chdir(f"{env.examples}/profiling_cube/")
+#     monkeypatch.chdir(env.path("examples", "profiling_cube/"))
 #
 #     environ = os.environ.copy()
 #     environ["ISOFIT_DEBUG"] = "1"

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -182,33 +182,29 @@ class Pathnames:
         self.sixs_path = os.getenv("SIXS_DIR", env.sixs)
 
         if args.sensor == "avcl":
-            self.noise_path = join(env.data, "avirisc_noise.txt")
+            self.noise_path = env.path("data", "avirisc_noise.txt")
         elif args.sensor == "emit":
-            self.noise_path = join(env.data, "emit_noise.txt")
+            self.noise_path = env.path("data", "emit_noise.txt")
             if self.input_channelized_uncertainty_path is None:
-                self.input_channelized_uncertainty_path = join(
-                    env.data, "emit_osf_uncertainty.txt"
+                self.input_channelized_uncertainty_path = env.path(
+                    "data", "emit_osf_uncertainty.txt"
                 )
             if self.input_model_discrepancy_path is None:
-                self.input_model_discrepancy_path = join(
-                    env.data, "emit_model_discrepancy.mat"
+                self.input_model_discrepancy_path = env.path(
+                    "data", "emit_model_discrepancy.mat"
                 )
+
         else:
             self.noise_path = None
             logging.info("no noise path found, proceeding without")
             # quit()
 
-        self.earth_sun_distance_path = abspath(join(env.data, "earth_sun_distance.txt"))
-        self.irradiance_file = abspath(
-            join(
-                env.examples,
-                "20151026_SantaMonica",
-                "data",
-                "prism_optimized_irr.dat",
-            )
+        self.earth_sun_distance_path = env.path("data", "earth_sun_distance.txt")
+        self.irradiance_file = env.path(
+            "examples", "20151026_SantaMonica", "data", "prism_optimized_irr.dat"
         )
 
-        self.aerosol_tpl_path = join(env.data, "aerosol_template.json")
+        self.aerosol_tpl_path = env.path("data", "aerosol_template.json")
         self.rdn_factors_path = None
         if args.rdn_factors_path is not None:
             self.rdn_factors_path = abspath(args.rdn_factors_path)
@@ -1143,7 +1139,7 @@ def load_climatology(
 
     """
 
-    aerosol_model_path = os.path.join(env.data, "aerosol_model.txt")
+    aerosol_model_path = env.path("data", "aerosol_model.txt")
     aerosol_state_vector = {}
     aerosol_lut_grid = {}
     aerosol_lut_ranges = [

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -182,16 +182,16 @@ class Pathnames:
         self.sixs_path = os.getenv("SIXS_DIR", env.sixs)
 
         if args.sensor == "avcl":
-            self.noise_path = env.path("data", "avirisc_noise.txt")
+            self.noise_path = str(env.path("data", "avirisc_noise.txt"))
         elif args.sensor == "emit":
-            self.noise_path = env.path("data", "emit_noise.txt")
+            self.noise_path = str(env.path("data", "emit_noise.txt"))
             if self.input_channelized_uncertainty_path is None:
-                self.input_channelized_uncertainty_path = env.path(
-                    "data", "emit_osf_uncertainty.txt"
+                self.input_channelized_uncertainty_path = str(
+                    env.path("data", "emit_osf_uncertainty.txt")
                 )
             if self.input_model_discrepancy_path is None:
-                self.input_model_discrepancy_path = env.path(
-                    "data", "emit_model_discrepancy.mat"
+                self.input_model_discrepancy_path = str(
+                    env.path("data", "emit_model_discrepancy.mat")
                 )
 
         else:
@@ -199,12 +199,14 @@ class Pathnames:
             logging.info("no noise path found, proceeding without")
             # quit()
 
-        self.earth_sun_distance_path = env.path("data", "earth_sun_distance.txt")
-        self.irradiance_file = env.path(
-            "examples", "20151026_SantaMonica", "data", "prism_optimized_irr.dat"
+        self.earth_sun_distance_path = str(env.path("data", "earth_sun_distance.txt"))
+        self.irradiance_file = str(
+            env.path(
+                "examples", "20151026_SantaMonica", "data", "prism_optimized_irr.dat"
+            )
         )
 
-        self.aerosol_tpl_path = env.path("data", "aerosol_template.json")
+        self.aerosol_tpl_path = str(env.path("data", "aerosol_template.json"))
         self.rdn_factors_path = None
         if args.rdn_factors_path is not None:
             self.rdn_factors_path = abspath(args.rdn_factors_path)
@@ -1139,7 +1141,7 @@ def load_climatology(
 
     """
 
-    aerosol_model_path = env.path("data", "aerosol_model.txt")
+    aerosol_model_path = str(env.path("data", "aerosol_model.txt"))
     aerosol_state_vector = {}
     aerosol_lut_grid = {}
     aerosol_lut_ranges = [


### PR DESCRIPTION
Attempting to provide more helpful debugging/error messages when ISOFIT is missing extra dependencies.

The `validate` functions have added two parameters: `debug` and `error`. These are callables for where to route messages to. By default they route to `print` which is used by the `isofit build` command as there's no logging. However, these change to `logging.debug` and `logging.error` when called from the new `path` function, which is used during an isofit pipeline execution (ie. `apply_oe` or `Isofit().run()`)

This ensures these messages get written to a log file if one exists as well as reduces the verbosity if the logging level is above debug, while maintaining verbosity for the `isofit build` command.

Closes #466 