### PR TITLE
Data docs updates

### DIFF
--- a/docs/source/custom/CONTRIBUTING.rst
+++ b/docs/source/custom/CONTRIBUTING.rst
@@ -66,7 +66,7 @@ dependencies using an appropriate package manager for their system.
 environment to pick up new dependencies, updates to the ``isofit`` build
 process, etc.
 
-Additionally, be sure to download the extra ISOFIT data files and examples via the `isofit download all` command. See :doc:`data` for more.
+Additionally, be sure to download the extra ISOFIT data files and examples via the `isofit download all` command. See :ref:`data` for more.
 
 
 Testing

--- a/docs/source/custom/data.rst
+++ b/docs/source/custom/data.rst
@@ -1,26 +1,26 @@
-=====================
-Recommended Procedure
-=====================
+===============
+Extra Downloads
+===============
 
 To get started with ISOFIT examples, simply execute the two following commands:
 
-.. code-block:: bash
+.. code-block::
 
     $ isofit download all
     $ isofit build
 
 The first will download all additional ISOFIT dependencies and configure them for the current system.
 The second will build the ISOFIT examples using the configured dependencies.
-From there, examples will be available under `~/.isofit/examples/`.
+From there, examples will be available under :code:`~/.isofit/examples/`.
 Each subdirectory will have one or more scripts that are prepared for execution.
 
-If there are any issues, please report them to the [ISOFIT repository](https://github.com/isofit/isofit/issues).
+If there are any issues, please report them to the `ISOFIT repository<https://github.com/isofit/isofit/issues>`_.
 
 The contents below go into further details about additional commands.
 
-==================
-ISOFIT Data Module
-==================
+=======================
+Extra Downloads Options
+=======================
 
 .. contents:: Table of Contents
     :depth: 2
@@ -30,11 +30,11 @@ These include things like larger data files and the ISOFIT examples.
 
 .. note::
 
-    The below commands assume a user is in their `/Users/[user]/` directory, aka `~`
+    The below commands assume a user is in their :code:`/Users/[user]/` directory, aka :code:`~`
 
-When the `isofit` command is first executed, it will create a directory under the user's home directory named `.isofit` as well as initialize a default `isofit.ini` file:
+When the :code:`isofit` command is first executed, it will create a directory under the user's home directory named :code:`.isofit` as well as initialize a default :code:`isofit.ini` file:
 
-.. code-block:: bash
+.. code-block::
 
     $ isofit
     Wrote to file: /Users/[user]/.isofit/isofit.ini
@@ -48,9 +48,9 @@ When the `isofit` command is first executed, it will create a directory under th
     sixs = /Users/[user]/.isofit/sixs
     modtran = /Users/[user]/.isofit/modtran
 
-Notice the default location for all paths is `~/.isofit/`. These can be modified by either directly editing the INI file or by using the ISOFIT CLI:
+Notice the default location for all paths is :code:`~/.isofit/`. These can be modified by either directly editing the INI file or by using the ISOFIT CLI:
 
-.. code-block:: bash
+.. code-block::
 
     $ isofit --help
     Usage: isofit [OPTIONS] COMMAND [ARGS]...
@@ -70,9 +70,9 @@ Notice the default location for all paths is `~/.isofit/`. These can be modified
       --save / -S, --no-save  Save the ini file
       --help                  Show this message and exit.
 
-Using a data override flag (`-d`, `-e`, `-c`, `-em`, `-6s`) will update the the INI with the provided path:
+Using a data override flag (:code:`-d`, :code:`-e`, :code:`-c`, :code:`-em`, :code:`-6s`) will update the the INI with the provided path:
 
-.. code-block:: bash
+.. code-block::
 
     $ isofit -e tutorials
     Wrote to file: /Users/[user]/.isofit/isofit.ini
@@ -88,7 +88,7 @@ Using a data override flag (`-d`, `-e`, `-c`, `-em`, `-6s`) will update the the 
 
 For advanced users, the INI file itself as well as the base directory and the section of the INI may be modified:
 
-.. code-block:: bash
+.. code-block::
 
     $ isofit -i test.ini -b test -s test -d test
     Wrote to file: test.ini
@@ -110,12 +110,12 @@ For advanced users, the INI file itself as well as the base directory and the se
     sixs = /Users/[user]/dev/test/sixs
     modtran = /Users/[user]/dev/test/modtran
 
-The `DEFAULT` section is still instantiated, but now there's a `test` section with a different `data` path than the default.
-Also note the default `examples` is different -- this is because the above examples changed it in the default INI, which is still read if available.
+The :code:`DEFAULT` section is still instantiated, but now there's a `:code:test` section with a different :code:`data` path than the default.
+Also note the default :code:`examples` is different -- this is because the above examples changed it in the default INI, which is still read if available.
 
-Additionally, these paths may be used in command-line arguments via the `isofit path` command. For example:
+Additionally, these paths may be used in command-line arguments via the :code:`isofit path` command. For example:
 
-.. code-block:: bash
+.. code-block::
 
     $ cd $(isofit path examples)
     $ ls $(isofit path data)/reflectance
@@ -124,26 +124,36 @@ Additionally, these paths may be used in command-line arguments via the `isofit 
 Downloads
 =========
 
-ISOFIT comes with a `download` command that provides users the ability to download and install extra files such as larger data files and examples.
-To get started, execute the `isofit download --help` in a terminal. At this time, there are 7 subcommands:
+ISOFIT comes with a :code:`download` command that provides users the ability to download and install extra files such as larger data files and examples.
+To get started, execute the :code:`isofit download --help` in a terminal. At this time, there are 7 subcommands:
 
-=======     ===========
-Command     Description
-=======     ===========
-`paths`     Displays the currently configured path for a download
-`all`       Executes all of the download commands below
-`data`      Downloads ISOFIT data files from https://github.com/isofit/isofit-data
-`examples`  Downloads the ISOFIT examples from https://github.com/isofit/isofit-tutorials
-`imagecube` Downloads required data for the image_cube example
-`sRTMnet`   Downloads the sRTMnet model
-`sixs`      Downloads and builds 6sv-2.1
-=======     ===========
+.. list-table::
+    :widths: 25 75
+    :header-rows: 1
+
+    * - Command
+      - Description
+    * - :code:`paths`
+      - Displays the currently configured path for a download
+    * - :code:`all`
+      - Executes all of the download commands below
+    * - :code:`data`
+      - Downloads ISOFIT data files from https://github.com/isofit/isofit-data
+    * - :code:`examples`
+      - Downloads the ISOFIT examples from https://github.com/isofit/isofit-tutorials
+    * - :code:`imagecube`
+      - Downloads required data for the image_cube example
+    * - :code:`sRTMnet`
+      - Downloads the sRTMnet model
+    * - :code:`sixs`
+      - Downloads and builds 6sv-2.1
+
 
 The paths for each download are defined in the currently active INI.
-Download paths can be modified by either directly modifying the `~/.isofit/isofit.ini` or by using `isofit --help` flags (shown above).
-Additionally, download paths may be temporarily overridden and not saved to the active INI by providing a `--output [path]`. For example:
+Download paths can be modified by either directly modifying the :code:`~/.isofit/isofit.ini` or by using :code:`isofit --help` flags (shown above).
+Additionally, download paths may be temporarily overridden and not saved to the active INI by providing a :code:`--output [path]`. For example:
 
-.. code-block:: bash
+.. code-block::
 
     $ isofit download data --help
     Usage: isofit download data [OPTIONS]
@@ -162,13 +172,13 @@ Additionally, download paths may be temporarily overridden and not saved to the 
     -t, --tag TEXT     Release tag to pull  [default: latest]
     --help             Show this message and exit.
 
-Some subcommands have additional flags to further tweak the download, such as `data` and `examples` having a `--tag` to download specific tag releases, or `sRTMnet` having `--version` for different model versions, but it is recommended to use the default to pull the most up-to-date download for each.
+Some subcommands have additional flags to further tweak the download, such as :code:`data` and :code:`examples` having a :code:`--tag` to download specific tag releases, or :code:`sRTMnet` having :code:`--version` for different model versions, but it is recommended to use the default to pull the most up-to-date download for each.
 
 
 Building
 ========
 
-ISOFIT examples rely on the `isofit build` command to generate configuration files and scripts dependent on a user's active INI file.
+ISOFIT examples rely on the :code:`isofit build` command to generate configuration files and scripts dependent on a user's active INI file.
 Each example contains a set of template files generate the required files for the example.
 By default, a user will not need to modify these templates.
 If an advanced user desires to change the configuration of an example, it is strongly recommended to run the build command first and edit the generated outputs.
@@ -178,11 +188,7 @@ However, every example should work out-of-the-box with the default downloads and
 Developers
 ==========
 
-This section is specifically for developers seeking to expand either the downloads or examples.
-
-Creating a Download
-===================
-
+This section is specifically for developers seeking to expand either the examples.
 
 
 Creating Examples
@@ -195,23 +201,119 @@ Creating a new example must define one or more templates for the given example t
 Templates
 ---------
 
+Templates are used to generate configuration and script files relative to a user's installation environment.
+Changes to the ISOFIT INI may rebuild the examples quickly for a new environent.
+Instead of hardcoding relative paths, the :code:`isofit build` command will replace values within the templates with the values defined by a given INI.
+For example, a template may define :code:`{examples}`, this will be replaced with the INI's :code:`examples` string.
+
 There are two types of examples supported at this time:
 
-1. Direct `Isofit` calls. These examples build configuration files to pass directly into the `Isofit` class to call `.run()`
+1. Direct :code:`Isofit` calls. These examples build configuration files to pass directly into the :code:`Isofit` class to call :code:`.run()`
 
-For existing examples of this type include [SantaMonica](https://github.com/isofit/isofit-tutorials/tree/main/20151026_SantaMonica), [Pasadena](https://github.com/isofit/isofit-tutorials/tree/main/20171108_Pasadena), and [ThermalIR](https://github.com/isofit/isofit-tutorials/tree/main/20190806_ThermalIR).
-Depending on the example, extra directories may be included such as prebuilt simulation files in the `lut` directory.
+For existing examples of this type include `SantaMonica<https://github.com/isofit/isofit-tutorials/tree/main/20151026_SantaMonica>`_, `Pasadena<https://github.com/isofit/isofit-tutorials/tree/main/20171108_Pasadena>`_, and `ThermalIR<https://github.com/isofit/isofit-tutorials/tree/main/20190806_ThermalIR>`_.
+Depending on the example, extra directories may be included such as prebuilt simulation files in the :code:`lut` directory.
+
+A bash and python script will be generated for each directory under the templates directory. For example, given a template directory:
+
+.. code-block::
+
+    [example]/
+    └─ templates/
+      ├─ reduced/
+      | ├─ config1.json
+      | └─ config2.json
+      ├─ advanced/
+      | └─ config3.yml
+      └─ surface.json
+
+will generate the following configs and scripts:
+
+.. code-block::
+
+    [example]/
+    └─ configs/
+    | ├─ reduced/
+    | | ├─ config1.json
+    | | └─ config2.json
+    | ├─ advanced/
+    | | └─ config3.json
+    | └─ surface.json
+    ├─ reduced.sh
+    ├─ reduced.py
+    ├─ advanced.sh
+    └─ advanced.py
+
+Each script will have the configs for it. For example, :code:`reduced.sh` would contain:
+
+.. code-block::
+
+    # Build a surface model first
+    echo 'Building surface model: surface.json'
+    isofit surface_model ~/.isofit/examples/[example]/configs/surface.json
+
+    # Now run retrievals
+    echo 'Running 1/2: config1.json'
+    isofit run --level DEBUG ~/.isofit/examples/[example]/configs/reduced/config1.json
+
+    echo 'Running 2/2: config2.json'
+    isofit run --level DEBUG ~/.isofit/examples/[example]/configs/reduced/config2.json
 
 
-2. `apply_oe` scripts. These examples use templates to define the arguments for a call to the `isofit apply_oe` utility
+2. :code:`apply_oe` scripts. These examples use templates to define the arguments for a call to the :code:`isofit apply_oe` utility.
+
+Existing examples of this type include the `small<https://github.com/isofit/isofit-tutorials/tree/main/image_cube/small/templates>`_ and `medium image cube<https://github.com/isofit/isofit-tutorials/tree/main/image_cube/medium/templates>`_ examples.
+These templates are a list of arguments in a :code:`[name].args.json` file. For each :code:`[name]` file, separate scripts will be generated.
+For example, given the following templates:
+
+.. code-block::
+
+    [example]/
+    └─ templates/
+      ├─ simple.args.json
+      └─ advanced.args.json
+
+will generate the following scripts:
+
+.. code-block::
+
+    [example]/
+    ├─ simple.sh
+    └─ advanced.sh
+
+The small image cube example's :code:`default.args.json` is currently defined as:
+
+.. code-block:: json
+
+    [
+    "{imagecube}/medium/ang20170323t202244_rdn_7k-8k",
+    "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
+    "{imagecube}/medium/ang20170323t202244_loc_7k-8k",
+    "{examples}/image_cube/medium",
+    "ang",
+    "--surface_path {examples}/image_cube/medium/configs/surface.json",
+    "--emulator_base {srtmnet}/sRTMnet_v120.h5",
+    "--n_cores {cores}",
+    "--presolve",
+    "--segmentation_size 400",
+    "--pressure_elevation"
+    ]
+
+This will generate :code:`default.sh`:
+
+.. code-block::
+
+    isofit apply_oe \
+      ~/.isofit/examples/imagecube/small/ang20170323t202244_rdn_7000-7010 \
+      ~/.isofit/examples/imagecube/small/ang20170323t202244_obs_7000-7010 \
+      ~/.isofit/examples/imagecube/small/ang20170323t202244_loc_7000-7010 \
+      ~/.isofit/examples/examples/image_cube/small \
+      ang \
+      --surface_path ~/.isofit/examples/examples/image_cube/small/configs/surface.json \
+      --n_cores 10 \
+      --presolve \
+      --segmentation_size 400 \
+      --pressure_elevation
 
 
-
-
-Once the the example with its templates are finalized, it must be integrated into the [ISOFIT Tutorials](https://github.com/isofit/isofit-tutorials) repository.
+Once the the example with its templates are finalized, it must be integrated into the `ISOFIT Tutorials<https://github.com/isofit/isofit-tutorials>`_ repository.
 Create a new pull request with a description of the example being created and maintainers will review it then merge and release a new version.
-
-Building
---------
-
-defined within `isofit/data/build_examples.py` in the `Examples` dictionary.

--- a/docs/source/custom/data.rst
+++ b/docs/source/custom/data.rst
@@ -16,13 +16,24 @@ The second will build the ISOFIT examples using the configured dependencies.
 From there, examples will be available under ``~/.isofit/examples/``.
 Each subdirectory will have one or more scripts that are prepared for execution.
 
+.. note::
+
+  A commonly useful option ``-b [path]``, ``--base [path]`` will set the download location for all products:
+
+  .. code-block::
+
+      $ isofit -b extra-downloads/ download all
+
+  This will change the download directory from the default ``~`` to ``./extra-downloads/``
+
+
 If there are any issues, please report them to the `ISOFIT repository <https://github.com/isofit/isofit/issues>`_.
 
 The contents below go into further details about additional commands.
 
-=======================
-Extra Downloads Options
-=======================
+
+Configuration Options
+=====================
 
 .. contents:: Table of Contents
     :depth: 2
@@ -32,23 +43,24 @@ These include things like larger data files and the ISOFIT examples.
 
 .. note::
 
-    The below commands assume a user is in their ``/Users/[user]/`` directory, aka ``~``
+    The below commands assume a user is in their home directory, aka ``~``. For Mac, this is commonly ``~``.
+    The examples on this page will use ``~``, but in practice this path and other relative paths will be automatically replaced with the absolute path.
 
 When the ``isofit`` command is first executed, it will create a directory under the user's home directory named ``.isofit`` as well as initialize a default ``isofit.ini`` file:
 
 .. code-block::
 
     $ isofit
-    Wrote to file: /Users/[user]/.isofit/isofit.ini
+    Wrote to file: ~/.isofit/isofit.ini
 
-    $ cat /Users/[user]/.isofit/isofit.ini
+    $ cat ~/.isofit/isofit.ini
     [DEFAULT]
-    data = /Users/[user]/.isofit/data
-    examples = /Users/[user]/.isofit/examples
-    imagecube = /Users/[user]/.isofit/imagecube
-    srtmnet = /Users/[user]/.isofit/srtmnet
-    sixs = /Users/[user]/.isofit/sixs
-    modtran = /Users/[user]/.isofit/modtran
+    data = ~/.isofit/data
+    examples = ~/.isofit/examples
+    imagecube = ~/.isofit/imagecube
+    srtmnet = ~/.isofit/srtmnet
+    sixs = ~/.isofit/sixs
+    modtran = ~/.isofit/modtran
 
 Notice the default location for all paths is ``~/.isofit/``. These can be modified by either directly editing the INI file or by using the ISOFIT CLI:
 
@@ -77,16 +89,16 @@ Using a data override flag (``-d``, ``-e``, ``-c``, ``-em``, ``-6s``) will updat
 .. code-block::
 
     $ isofit -e tutorials
-    Wrote to file: /Users/[user]/.isofit/isofit.ini
+    Wrote to file: ~/.isofit/isofit.ini
 
     $ isofit download paths
     Download paths will default to:
-    - data = /Users/[user]/.isofit/data
-    - examples = /Users/[user]/tutorials
-    - imagecube = /Users/[user]/.isofit/imagecube
-    - srtmnet = /Users/[user]/.isofit/srtmnet
-    - sixs = /Users/[user]/.isofit/sixs
-    - modtran = /Users/[user]/.isofit/modtran
+    - data = ~/.isofit/data
+    - examples = ~/tutorials
+    - imagecube = ~/.isofit/imagecube
+    - srtmnet = ~/.isofit/srtmnet
+    - sixs = ~/.isofit/sixs
+    - modtran = ~/.isofit/modtran
 
 For advanced users, the INI file itself as well as the base directory and the section of the INI may be modified:
 
@@ -97,20 +109,20 @@ For advanced users, the INI file itself as well as the base directory and the se
 
     $ cat test.ini
     [DEFAULT]
-    data = /Users/[user]/.isofit/data
-    examples = /Users/[user]/tutorials
-    imagecube = /Users/[user]/.isofit/imagecube
-    srtmnet = /Users/[user]/.isofit/srtmnet
-    sixs = /Users/[user]/.isofit/sixs
-    modtran = /Users/[user]/.isofit/modtran
+    data = ~/.isofit/data
+    examples = ~/tutorials
+    imagecube = ~/.isofit/imagecube
+    srtmnet = ~/.isofit/srtmnet
+    sixs = ~/.isofit/sixs
+    modtran = ~/.isofit/modtran
 
     [test]
-    data = /Users/[user]/dev/test
-    examples = /Users/[user]/dev/test/examples
-    imagecube = /Users/[user]/dev/test/imagecube
-    srtmnet = /Users/[user]/dev/test/srtmnet
-    sixs = /Users/[user]/dev/test/sixs
-    modtran = /Users/[user]/dev/test/modtran
+    data = ~/dev/test
+    examples = ~/dev/test/examples
+    imagecube = ~/dev/test/imagecube
+    srtmnet = ~/dev/test/srtmnet
+    sixs = ~/dev/test/sixs
+    modtran = ~/dev/test/modtran
 
 The ``DEFAULT`` section is still instantiated, but now there's a ``test`` section with a different ``data`` path than the default.
 Also note the default ``examples`` is different -- this is because the above examples changed it in the default INI, which is still read if available.
@@ -177,8 +189,8 @@ Additionally, download paths may be temporarily overridden and not saved to the 
 Some subcommands have additional flags to further tweak the download, such as ``data`` and ``examples`` having a ``--tag`` to download specific tag releases, or ``sRTMnet`` having ``--version`` for different model versions, but it is recommended to use the default to pull the most up-to-date download for each.
 
 
-Building
-========
+Building Examples
+=================
 
 ISOFIT examples rely on the ``isofit build`` command to generate configuration files and scripts dependent on a user's active INI file.
 Each example contains a set of template files generate the required files for the example.
@@ -186,7 +198,6 @@ By default, a user will not need to modify these templates.
 If an advanced user desires to change the configuration of an example, it is strongly recommended to run the build command first and edit the generated outputs.
 However, every example should work out-of-the-box with the default downloads and build.
 
-==========
 Developers
 ==========
 
@@ -194,14 +205,14 @@ This section is specifically for developers seeking to expand either the example
 
 
 Creating Examples
-=================
+-----------------
 
 ISOFIT leverages specially-designed templates to build the example configurations depending on the installation environment defined by an INI.
 Creating a new example must define one or more templates for the given example type.
 
 
 Templates
----------
+~~~~~~~~~
 
 Templates are used to generate configuration and script files relative to a user's installation environment.
 Changes to the ISOFIT INI may rebuild the examples quickly for a new environent.

--- a/docs/source/custom/data.rst
+++ b/docs/source/custom/data.rst
@@ -1,3 +1,5 @@
+.. _data:
+
 ===============
 Extra Downloads
 ===============
@@ -231,7 +233,7 @@ will generate the following configs and scripts:
 .. code-block::
 
     [example]/
-    └─ configs/
+    ├─ configs/
     | ├─ reduced/
     | | ├─ config1.json
     | | └─ config2.json

--- a/docs/source/custom/data.rst
+++ b/docs/source/custom/data.rst
@@ -11,7 +11,7 @@ To get started with ISOFIT examples, simply execute the two following commands:
 
 The first will download all additional ISOFIT dependencies and configure them for the current system.
 The second will build the ISOFIT examples using the configured dependencies.
-From there, examples will be available under :code:`~/.isofit/examples/`.
+From there, examples will be available under ``~/.isofit/examples/``.
 Each subdirectory will have one or more scripts that are prepared for execution.
 
 If there are any issues, please report them to the `ISOFIT repository<https://github.com/isofit/isofit/issues>`_.
@@ -30,9 +30,9 @@ These include things like larger data files and the ISOFIT examples.
 
 .. note::
 
-    The below commands assume a user is in their :code:`/Users/[user]/` directory, aka :code:`~`
+    The below commands assume a user is in their ``/Users/[user]/`` directory, aka ``~``
 
-When the :code:`isofit` command is first executed, it will create a directory under the user's home directory named :code:`.isofit` as well as initialize a default :code:`isofit.ini` file:
+When the ``isofit`` command is first executed, it will create a directory under the user's home directory named ``.isofit`` as well as initialize a default ``isofit.ini`` file:
 
 .. code-block::
 
@@ -48,7 +48,7 @@ When the :code:`isofit` command is first executed, it will create a directory un
     sixs = /Users/[user]/.isofit/sixs
     modtran = /Users/[user]/.isofit/modtran
 
-Notice the default location for all paths is :code:`~/.isofit/`. These can be modified by either directly editing the INI file or by using the ISOFIT CLI:
+Notice the default location for all paths is ``~/.isofit/``. These can be modified by either directly editing the INI file or by using the ISOFIT CLI:
 
 .. code-block::
 
@@ -70,7 +70,7 @@ Notice the default location for all paths is :code:`~/.isofit/`. These can be mo
       --save / -S, --no-save  Save the ini file
       --help                  Show this message and exit.
 
-Using a data override flag (:code:`-d`, :code:`-e`, :code:`-c`, :code:`-em`, :code:`-6s`) will update the the INI with the provided path:
+Using a data override flag (``-d``, ``-e``, ``-c``, ``-em``, ``-6s``) will update the the INI with the provided path:
 
 .. code-block::
 
@@ -110,10 +110,10 @@ For advanced users, the INI file itself as well as the base directory and the se
     sixs = /Users/[user]/dev/test/sixs
     modtran = /Users/[user]/dev/test/modtran
 
-The :code:`DEFAULT` section is still instantiated, but now there's a `:code:test` section with a different :code:`data` path than the default.
-Also note the default :code:`examples` is different -- this is because the above examples changed it in the default INI, which is still read if available.
+The ``DEFAULT`` section is still instantiated, but now there's a ``test`` section with a different ``data`` path than the default.
+Also note the default ``examples`` is different -- this is because the above examples changed it in the default INI, which is still read if available.
 
-Additionally, these paths may be used in command-line arguments via the :code:`isofit path` command. For example:
+Additionally, these paths may be used in command-line arguments via the ``isofit path`` command. For example:
 
 .. code-block::
 
@@ -124,8 +124,8 @@ Additionally, these paths may be used in command-line arguments via the :code:`i
 Downloads
 =========
 
-ISOFIT comes with a :code:`download` command that provides users the ability to download and install extra files such as larger data files and examples.
-To get started, execute the :code:`isofit download --help` in a terminal. At this time, there are 7 subcommands:
+ISOFIT comes with a ``download`` command that provides users the ability to download and install extra files such as larger data files and examples.
+To get started, execute the ``isofit download --help`` in a terminal. At this time, there are 7 subcommands:
 
 .. list-table::
     :widths: 25 75
@@ -133,25 +133,25 @@ To get started, execute the :code:`isofit download --help` in a terminal. At thi
 
     * - Command
       - Description
-    * - :code:`paths`
+    * - ``paths``
       - Displays the currently configured path for a download
-    * - :code:`all`
+    * - ``all``
       - Executes all of the download commands below
-    * - :code:`data`
+    * - ``data``
       - Downloads ISOFIT data files from https://github.com/isofit/isofit-data
-    * - :code:`examples`
+    * - ``examples``
       - Downloads the ISOFIT examples from https://github.com/isofit/isofit-tutorials
-    * - :code:`imagecube`
+    * - ``imagecube``
       - Downloads required data for the image_cube example
-    * - :code:`sRTMnet`
+    * - ``sRTMnet``
       - Downloads the sRTMnet model
-    * - :code:`sixs`
+    * - ``sixs``
       - Downloads and builds 6sv-2.1
 
 
 The paths for each download are defined in the currently active INI.
-Download paths can be modified by either directly modifying the :code:`~/.isofit/isofit.ini` or by using :code:`isofit --help` flags (shown above).
-Additionally, download paths may be temporarily overridden and not saved to the active INI by providing a :code:`--output [path]`. For example:
+Download paths can be modified by either directly modifying the ``~/.isofit/isofit.ini`` or by using ``isofit --help`` flags (shown above).
+Additionally, download paths may be temporarily overridden and not saved to the active INI by providing a ``--output [path]``. For example:
 
 .. code-block::
 
@@ -161,10 +161,10 @@ Additionally, download paths may be temporarily overridden and not saved to the 
     Downloads the extra ISOFIT data files from the repository
     https://github.com/isofit/isofit-data.
 
-    Run `isofit download paths` to see default path locations.
+    Run ``isofit download paths`` to see default path locations.
     There are two ways to specify output directory:
-      - `isofit --data /path/data download data`: Override the ini file. This will save the provided path for future reference.
-      - `isofit download data --output /path/data`: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
+      - ``isofit --data /path/data download data``: Override the ini file. This will save the provided path for future reference.
+      - ``isofit download data --output /path/data``: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
     It is recommended to use the first style so the download path is remembered in the future.
 
     Options:
@@ -172,13 +172,13 @@ Additionally, download paths may be temporarily overridden and not saved to the 
     -t, --tag TEXT     Release tag to pull  [default: latest]
     --help             Show this message and exit.
 
-Some subcommands have additional flags to further tweak the download, such as :code:`data` and :code:`examples` having a :code:`--tag` to download specific tag releases, or :code:`sRTMnet` having :code:`--version` for different model versions, but it is recommended to use the default to pull the most up-to-date download for each.
+Some subcommands have additional flags to further tweak the download, such as ``data`` and ``examples`` having a ``--tag`` to download specific tag releases, or ``sRTMnet`` having ``--version`` for different model versions, but it is recommended to use the default to pull the most up-to-date download for each.
 
 
 Building
 ========
 
-ISOFIT examples rely on the :code:`isofit build` command to generate configuration files and scripts dependent on a user's active INI file.
+ISOFIT examples rely on the ``isofit build`` command to generate configuration files and scripts dependent on a user's active INI file.
 Each example contains a set of template files generate the required files for the example.
 By default, a user will not need to modify these templates.
 If an advanced user desires to change the configuration of an example, it is strongly recommended to run the build command first and edit the generated outputs.
@@ -203,15 +203,15 @@ Templates
 
 Templates are used to generate configuration and script files relative to a user's installation environment.
 Changes to the ISOFIT INI may rebuild the examples quickly for a new environent.
-Instead of hardcoding relative paths, the :code:`isofit build` command will replace values within the templates with the values defined by a given INI.
-For example, a template may define :code:`{examples}`, this will be replaced with the INI's :code:`examples` string.
+Instead of hardcoding relative paths, the ``isofit build`` command will replace values within the templates with the values defined by a given INI.
+For example, a template may define ``{examples}``, this will be replaced with the INI's ``examples`` string.
 
 There are two types of examples supported at this time:
 
-1. Direct :code:`Isofit` calls. These examples build configuration files to pass directly into the :code:`Isofit` class to call :code:`.run()`
+1. Direct ``Isofit`` calls. These examples build configuration files to pass directly into the ``Isofit`` class to call ``.run()``
 
 For existing examples of this type include `SantaMonica<https://github.com/isofit/isofit-tutorials/tree/main/20151026_SantaMonica>`_, `Pasadena<https://github.com/isofit/isofit-tutorials/tree/main/20171108_Pasadena>`_, and `ThermalIR<https://github.com/isofit/isofit-tutorials/tree/main/20190806_ThermalIR>`_.
-Depending on the example, extra directories may be included such as prebuilt simulation files in the :code:`lut` directory.
+Depending on the example, extra directories may be included such as prebuilt simulation files in the ``lut`` directory.
 
 A bash and python script will be generated for each directory under the templates directory. For example, given a template directory:
 
@@ -243,7 +243,7 @@ will generate the following configs and scripts:
     ├─ advanced.sh
     └─ advanced.py
 
-Each script will have the configs for it. For example, :code:`reduced.sh` would contain:
+Each script will have the configs for it. For example, ``reduced.sh`` would contain:
 
 .. code-block::
 
@@ -259,10 +259,10 @@ Each script will have the configs for it. For example, :code:`reduced.sh` would 
     isofit run --level DEBUG ~/.isofit/examples/[example]/configs/reduced/config2.json
 
 
-2. :code:`apply_oe` scripts. These examples use templates to define the arguments for a call to the :code:`isofit apply_oe` utility.
+2. ``apply_oe`` scripts. These examples use templates to define the arguments for a call to the ``isofit apply_oe`` utility.
 
-Existing examples of this type include the `small<https://github.com/isofit/isofit-tutorials/tree/main/image_cube/small/templates>`_ and `medium image cube<https://github.com/isofit/isofit-tutorials/tree/main/image_cube/medium/templates>`_ examples.
-These templates are a list of arguments in a :code:`[name].args.json` file. For each :code:`[name]` file, separate scripts will be generated.
+Existing examples of this type include the `small<https://github.com/isofit/isofit-tutorials/tree/main/image_cube/small/templates>`_ and ``medium image cube<https://github.com/isofit/isofit-tutorials/tree/main/image_cube/medium/templates>`_ examples.
+These templates are a list of arguments in a ``[name].args.json`` file. For each ``[name]`` file, separate scripts will be generated.
 For example, given the following templates:
 
 .. code-block::
@@ -280,7 +280,7 @@ will generate the following scripts:
     ├─ simple.sh
     └─ advanced.sh
 
-The small image cube example's :code:`default.args.json` is currently defined as:
+The small image cube example's ``default.args.json`` is currently defined as:
 
 .. code-block:: json
 
@@ -298,7 +298,7 @@ The small image cube example's :code:`default.args.json` is currently defined as
     "--pressure_elevation"
     ]
 
-This will generate :code:`default.sh`:
+This will generate ``default.sh``:
 
 .. code-block::
 

--- a/docs/source/custom/data.rst
+++ b/docs/source/custom/data.rst
@@ -14,7 +14,7 @@ The second will build the ISOFIT examples using the configured dependencies.
 From there, examples will be available under ``~/.isofit/examples/``.
 Each subdirectory will have one or more scripts that are prepared for execution.
 
-If there are any issues, please report them to the `ISOFIT repository<https://github.com/isofit/isofit/issues>`_.
+If there are any issues, please report them to the `ISOFIT repository <https://github.com/isofit/isofit/issues>`_.
 
 The contents below go into further details about additional commands.
 
@@ -210,7 +210,7 @@ There are two types of examples supported at this time:
 
 1. Direct ``Isofit`` calls. These examples build configuration files to pass directly into the ``Isofit`` class to call ``.run()``
 
-For existing examples of this type include `SantaMonica<https://github.com/isofit/isofit-tutorials/tree/main/20151026_SantaMonica>`_, `Pasadena<https://github.com/isofit/isofit-tutorials/tree/main/20171108_Pasadena>`_, and `ThermalIR<https://github.com/isofit/isofit-tutorials/tree/main/20190806_ThermalIR>`_.
+For existing examples of this type include `SantaMonica <https://github.com/isofit/isofit-tutorials/tree/main/20151026_SantaMonica>`_, `Pasadena <https://github.com/isofit/isofit-tutorials/tree/main/20171108_Pasadena>`_, and `ThermalIR <https://github.com/isofit/isofit-tutorials/tree/main/20190806_ThermalIR>`_.
 Depending on the example, extra directories may be included such as prebuilt simulation files in the ``lut`` directory.
 
 A bash and python script will be generated for each directory under the templates directory. For example, given a template directory:
@@ -261,7 +261,7 @@ Each script will have the configs for it. For example, ``reduced.sh`` would cont
 
 2. ``apply_oe`` scripts. These examples use templates to define the arguments for a call to the ``isofit apply_oe`` utility.
 
-Existing examples of this type include the `small<https://github.com/isofit/isofit-tutorials/tree/main/image_cube/small/templates>`_ and ``medium image cube<https://github.com/isofit/isofit-tutorials/tree/main/image_cube/medium/templates>`_ examples.
+Existing examples of this type include the `small <https://github.com/isofit/isofit-tutorials/tree/main/image_cube/small/templates>`_ and ``medium image cube <https://github.com/isofit/isofit-tutorials/tree/main/image_cube/medium/templates>`_ examples.
 These templates are a list of arguments in a ``[name].args.json`` file. For each ``[name]`` file, separate scripts will be generated.
 For example, given the following templates:
 
@@ -315,5 +315,5 @@ This will generate ``default.sh``:
       --pressure_elevation
 
 
-Once the the example with its templates are finalized, it must be integrated into the `ISOFIT Tutorials<https://github.com/isofit/isofit-tutorials>`_ repository.
+Once the the example with its templates are finalized, it must be integrated into the `ISOFIT Tutorials <https://github.com/isofit/isofit-tutorials>`_ repository.
 Create a new pull request with a description of the example being created and maintainers will review it then merge and release a new version.

--- a/docs/source/custom/docker.rst
+++ b/docs/source/custom/docker.rst
@@ -1,14 +1,14 @@
 ISOFIT Docker
 =============
-The official container images are located on Dockerhub under [jammont/isofit](https://hub.docker.com/r/jammont/isofit).
+The official container images are located on Dockerhub under `jammont/isofit<https://hub.docker.com/r/jammont/isofit>`_.
 They come pre-configured with everything a user may need to get started using ISOFIT and executing its examples.
 
 Tags
 ----
-- `latest` - Most recent released ISOFIT version
-- `3.x.x` - Specific release builds
+- ``latest`` - Most recent released ISOFIT version
+- ``3.x.x`` - Specific release builds
 
-Images are currently built for `amd64` and `arm64` architectures.
+Images are currently built for ``amd64`` and ``arm64`` architectures.
 
 
 Getting Started
@@ -16,49 +16,70 @@ Getting Started
 
 Start by pulling the image:
 
-.. code-block:: bash
-  $ docker pull jammont/isofit:latest
+.. code-block::
 
-This image is default tagged as `jammont/isofit`. As such, to use it run:
+    $ docker pull jammont/isofit:latest
 
-.. code-block:: bash
-  $ docker run -it --rm --shm-size=16gb jammont/isofit bash
+This image is default tagged as ``jammont/isofit``. As such, to use it run:
 
-- `-it` - Run in `[i]nteractive` and `[t]erminal` modes, which will build a container and place the user inside of it.
-- `--rm` - Removes the container once finished. If you intend to modify the container between sessions, remove this flag.
-- `--shm-size=16gb` - Expands the shared memory space for the container. This is used by Ray and, if not set, may have significant performance impacts. The larger the better, this may need to be tweaked to your system.
-- `jammont/isofit` - The `tag` name of the image. If you built your own ISOFIT image using a different tag, be sure to replace this string.
-- `bash` - The command to run for `-it`. Using `bash` here will invoke a bash instance for the user. If you wanted to launch a specific script without entering the container, you could replace this command.
+.. code-block::
 
-After running the above command, you will placed inside the container as the root user. From here you may proceed to use ISOFIT as you need.
+    $ docker run -it --rm --shm-size=16gb jammont/isofit bash
+
+A breakdown of the above command:
+
+.. list-table::
+    :widths: 10 90
+    :header-rows: 1
+
+    * - Flag
+      - Purpose
+    * - ``it``
+      - Run in ``[i]nteractive`` and ``[t]erminal`` modes. Any commands after ``jammont/isofit`` will be executed from the container
+    * - ``--rm``
+      - Removes the container once finished. If you intend to modify the container between sessions, remove this flag. View existing containers via ``docker ps``
+    * - ``--shm-size=16gb``
+      - Expands the shared memory space for the container. This is used by Ray and, if not set, may have significant performance impacts. The larger the better, this may need to be tweaked to your system.
+    * - ``jammont/isofit``
+      - The ``tag`` name of the image. If you built your own ISOFIT image using a different tag, be sure to replace this string. Defaults to ``jammont/isofit:latest``, or pull a specific version like ``jammont/isofit:3.2.1``
+    * - ``bash``
+      - The command to run for ``-it``. Using ``bash`` here will invoke a bash instance for the user. If you wanted to launch a specific script without entering the container, you could replace this command, such as ``isofit -v`` to get the installed ISOFIT version.
+
+Given that the above command invokes a bash shell, the user will be placed inside the container.
+From here you may use ISOFIT via the commandline or make further edits.
+If ``--rm`` is enabled, exiting the container will delete it along with any changes made.
 
 You may need to attach volumes to the container at runtime in order to access files external to the container. For instance:
 
-.. code-block:: bash
-  $ docker run --rm -it -v /host/path:/container/path jammont/isofit bash
+.. code-block::
 
-This will provide `/host/path` available inside of the container as `/container/path`. As such, any changes made inside the container to this path or its contents will be reflected on the host.
+    $ docker run -v /host/path:/container/path jammont/isofit
+
+This will provide ``/host/path`` available inside of the container as ``/container/path``.
+As such, any changes made inside the container to this path or its contents will be reflected on the host.
 
 Additional examples for executing ISOFIT interactively:
 
-.. code-block:: bash
-  # Print version
-  $ docker run --rm -it jammont/isofit isofit --version
+.. code-block::
 
-  # Execute an example
-  $ docker run --rm -it --shm-size=16gb jammont/isofit bash examples/20151026_SantaMonica/run.sh
-  $ docker run --rm -it --shm-size=16gb jammont/isofit bash examples/image_cube/small/analytical.sh
+    # Print version
+    $ docker run --rm -it jammont/isofit isofit --version
+
+    # Execute an example
+    $ docker run --rm -it --shm-size=16gb jammont/isofit bash examples/20151026_SantaMonica/run.sh
+    $ docker run --rm -it --shm-size=16gb jammont/isofit bash examples/image_cube/small/analytical.sh
 
 
 Jupyter
 -------
 The default run command for the container is to start up a Jupyterlab server on internal port 8888.
-To connect to this port and make it accessible via the browser, pass the `-p [host]:8888` parameter:
+To connect to this port and make it accessible via the browser, pass the ``-p [host]:8888`` parameter:
 
-.. code-block:: bash
-  $ docker run --rm --shm-size=16gb -p 8888:8888 jammont/isofit
+.. code-block::
 
-This will start up the Jupyterlab server on port `8888`. Navigate to `127.0.0.1:8888` in a web browser to start using the server.
+    $ docker run --rm --shm-size=16gb -p 8888:8888 jammont/isofit
+
+This will start up the Jupyterlab server on port ``8888``. Navigate to ``127.0.0.1:8888`` in a web browser to start using the server.
 
 To shutdown, hit CTRL-C in the running terminal.
 
@@ -66,16 +87,17 @@ To shutdown, hit CTRL-C in the running terminal.
 Building the Image
 ------------------
 
-The ISOFIT container can be manually built by pulling the repository and running `docker build --tag [name] .` in the repository's root.
+The ISOFIT container can be manually built by pulling the repository and running ``docker build --tag [name] .`` in the repository's root (where the ``Dockerfile`` is located).
 For example, to build a specific branch of ISOFIT, the following may be performed:
 
-.. code-block:: bash
-  git clone https://github.com/isofit/isofit.git
-  cd isofit
-  git checkout [branch]
-  docker build --tag [branch] .
+.. code-block::
 
-This will build a container and tag it as `[branch]`. This tag can anything as it is local to your device.
+    git clone https://github.com/isofit/isofit.git
+    cd isofit
+    git checkout [branch]
+    docker build --tag [branch] .
 
-Once the container is built, refer to the `Getting Started` section for next steps.
-Replace the default `jammont/isofit` tag with the tag you chose for your newly built image.
+This will build a container and tag it as ``[branch]``. This tag can anything as it is local to your device.
+
+Once the container is built, refer to the ``Getting Started`` section for next steps.
+Replace the default ``jammont/isofit`` tag with the tag you chose for your newly built image.

--- a/docs/source/custom/docker.rst
+++ b/docs/source/custom/docker.rst
@@ -1,6 +1,6 @@
 ISOFIT Docker
 =============
-The official container images are located on Dockerhub under `jammont/isofit<https://hub.docker.com/r/jammont/isofit>`_.
+The official container images are located on Dockerhub under `jammont/isofit <https://hub.docker.com/r/jammont/isofit>`_.
 They come pre-configured with everything a user may need to get started using ISOFIT and executing its examples.
 
 Tags
@@ -29,12 +29,12 @@ This image is default tagged as ``jammont/isofit``. As such, to use it run:
 A breakdown of the above command:
 
 .. list-table::
-    :widths: 10 90
+    :widths: 20 80
     :header-rows: 1
 
     * - Flag
       - Purpose
-    * - ``it``
+    * - ``-it``
       - Run in ``[i]nteractive`` and ``[t]erminal`` modes. Any commands after ``jammont/isofit`` will be executed from the container
     * - ``--rm``
       - Removes the container once finished. If you intend to modify the container between sessions, remove this flag. View existing containers via ``docker ps``

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -152,12 +152,12 @@ The following environment variables are actively used within ISOFIT:
 
     * - Variable
       - Purpose
-    * - ``MKL_NUM_THREADS`` and ``OMP_NUM_THREADS``
-      - These control the threading of various packages within ISOFIT. It is important to set these to "1" to ensure ISOFIT performs to its fullest capabilities. By default, ISOFIT will insert these into the environment if they are not set and/or not set correctly.
+    * - ``MKL_NUM_THREADS``, ``OMP_NUM_THREADS``
+      - These control the threading of various packages within ISOFIT. It is important to set these to ``1`` to ensure ISOFIT performs to its fullest capabilities. By default, ISOFIT will insert these into the environment if they are not set and/or not set correctly.
     * - ``ISOFIT_NO_SET_THREADS``
       - This will disable automatically setting the MKL and OMP environment variables. Only recommended for advanced users that know what they are doing and can mitigate the consequences.
     * - ``ISOFIT_DEBUG``
-      - Disables the `ray` package across ISOFIT to force single-core execution. Primarily used as a debugging tool by developers and is not recommended for normal use.
+      - Disables the ``ray`` package across ISOFIT to force single-core execution. Primarily used as a debugging tool by developers and is not recommended for normal use.
 
 Quick Start with sRTMnet (Recommended for new users)
 ====================================================
@@ -231,16 +231,16 @@ LibRadTran RT code as well as to neural network emulators.
 
 1. Create an environment variable MODTRAN_DIR pointing to the base MODTRAN 6.0 directory.
 
-2. Run the following code
+2. Run the following code:
 
 .. code::
 
-    cd $(isofit path examples)/20171108_Pasadena
-    ./modtran.sh
+    $ cd $(isofit path examples)/20171108_Pasadena
+    $ ./modtran.sh
 
-3. This will build a surface model and run the retrieval. The default example uses a lookup table approximation, and the code should recognize that the tables do not currently exist.  It will call MODTRAN to rebuild them, which will take a few minutes.
+3. This will build a surface model and run the retrieval. The default example uses a lookup table approximation, and the code should recognize that the tables do not currently exist. It will call MODTRAN to rebuild them, which will take a few minutes.
 
-4. Look for output data in $(isofit path examples)/20171108_Pasadena/output/.
+4. Look for output data in ``$(isofit path examples)/20171108_Pasadena/output/``.
 
 
 Additional Installation Info for Mac OSX
@@ -258,7 +258,7 @@ Additional Installation Info for Mac OSX
 Known Incompatibilities
 =======================
 
-Ray may have compatability issues with older machines with glibc < 2.14.
+Ray may have compatibility issues with older machines with glibc < 2.14.
 
 
 .. _Conda: https://conda.io/docs/

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -1,11 +1,13 @@
+============
 Installation
 ============
 
 .. contents:: Table of Contents
     :depth: 2
 
-Install from conda-forge
-************************
+Conda-Forge (Recommended)
+-------------------------
+
 Recommended approach!
 
 New environment:
@@ -35,8 +37,8 @@ or
     conda install -c conda-forge isofit
 
 
-Install with ``pip``
-********************
+PyPI (``pip``)
+--------------
 
 .. note::
 
@@ -48,8 +50,7 @@ Install with ``pip``
     that also have ``$ python3`` and ``$ pip3`` executables, or executables for
     specific versions of Python like ``$ python3.11`` and ``$ pip3.11``.
 
-ISOFIT can be installed from the `Python Package Index <https://pypi.org/project/isofit/>`_
-with:
+ISOFIT can be installed from the `Python Package Index <https://pypi.org/project/isofit/>`_ with:
 
 .. code-block:: bash
 
@@ -67,18 +68,21 @@ against the ``main`` branch:
     $ pip install "git+https://github.com/isofit/isofit.git@main"
 
 
-Install from github
-*******************
+Manual (GitHub)
+---------------
+
+We recommend using `Mamba <https://mamba.readthedocs.io/en/latest/>`_ to create a virtual environment:
 
 .. code-block:: bash
 
-    git clone https://github.com/isofit/isofit
-    mamba env create -f isofit/recipe/environment_isofit_basic.yml
-    mamba activate isofit_env
-    pip install -e ./isofit
+    $ git clone https://github.com/isofit/isofit
+    $ mamba env create -f isofit/recipe/environment_isofit_basic.yml
+    $ mamba activate isofit_env
+    $ pip install -e ./isofit
+
 
 Downloading Extra Files
------------------------
+=======================
 
 Once ISOFIT is installed, the CLI provides an easy way to download additional files that may be useful.
 These can be acquired via the ``isofit download`` command, and the current list of downloads we support is available via ``isofit download --help``.
@@ -86,14 +90,15 @@ See :ref:`data` for more information.
 
 > **_NOTE:_**  The default location for downloading extra files is ``~/.isofit/``. First time invoking the ISOFIT CLI will instantiate this directory and an ``isofit.ini`` file for storing the paths to downloaded products.
 
-Setting environment variables
+
+Setting Environment Variables
 =============================
 
 Depending on the selected RTM, specific environment variables pointing to the RTM's base directory have to be set prior to running ISOFIT.
 In the following, general instructions on how to set these variables on MacOS, Linux and Windows are provided.
 
 MacOS
-*****
+-----
 
 - Most MacOS systems load environment variables from the user's .bash_profile configuration file. Open this file with your preferred text editor, such as vim:
 
@@ -114,7 +119,7 @@ MacOS
     source ~/.bash_profile
 
 Linux
-*****
+-----
 
 - Most Linux profiles use either bash or csh/tcsh shells.  These shells load environment variables from the user's .bashrc or .cshrc configuration files.
 
@@ -131,7 +136,7 @@ Linux
     setenv VARIABLE_NAME=DIRECTORY (use your actual path)
 
 Windows
-*******
+-------
 
 - Using a command prompt, type one of the following:
 
@@ -159,6 +164,8 @@ The following environment variables are actively used within ISOFIT:
     * - ``ISOFIT_DEBUG``
       - Disables the ``ray`` package across ISOFIT to force single-core execution. Primarily used as a debugging tool by developers and is not recommended for normal use.
 
+
+====================================================
 Quick Start with sRTMnet (Recommended for new users)
 ====================================================
 
@@ -167,6 +174,7 @@ sRTMnet is an emulator for MODTRAN 6, that works by coupling a neural network wi
 
 Automatic (Recommended)
 -----------------------
+
 ISOFIT can automatically install 6S and sRTMnet with the latest versions:
 
 .. code::
@@ -176,32 +184,39 @@ ISOFIT can automatically install 6S and sRTMnet with the latest versions:
 
 The above commands will ensure these models are built and available for ISOFIT.
 
+.. note::
+
+  A commonly useful option ``-b [path]``, ``--base [path]`` will set the download location for all products:
+
+  .. code-block::
+
+      $ isofit -b extra-downloads/ download all
+
+  This will change the download directory from the default ``~`` to ``./extra-downloads/``
+
+  See :ref:`data` for more information.
+
 Manual (Advanced)
 -----------------
+
 The following procedure walks through the steps required to install sRTMnet manually:
 
-1. Download `6S v2.1 <https://salsa.umd.edu/files/6S/6sV2.1.tar>`_, and compile.  If you use a modern system,
-it is likely you will need to specify a legacy compiling configuration by changing line 3 of the Makefile to:
+#. Download `6S v2.1 <https://salsa.umd.edu/files/6S/6sV2.1.tar>`_, and compile.
+   If you use a modern system, it is likely you will need to specify a legacy compiling configuration by changing line 3 of the Makefile to::
 
-.. code::
+      EXTRA = -O -ffixed-line-length-132 -std=legacy
 
-    EXTRA   = -O -ffixed-line-length-132 -std=legacy
+#. Configure your environment by pointing the SIXS_DIR variable to point to your installation directory.
 
-2. Configure your environment by pointing the SIXS_DIR variable to point to your installation directory.
+#. Download the `pre-trained sRTMnet neural network <https://avng.jpl.nasa.gov/pub/PBrodrick/isofit/sRTMnet_v120.h5>`_, as well as some `auxiliary data <https://avng.jpl.nasa.gov/pub/PBrodrick/isofit/sRTMnet_v120_aux.npz>`_.
+   This will give you an hdf5 and an aux file. It is important that you store both in the same directory.
 
-3. Download the `pre-trained sRTMnet neural network <https://avng.jpl.nasa.gov/pub/PBrodrick/isofit/sRTMnet_v120.h5>`_,
-as well as some `auxiliary data <https://avng.jpl.nasa.gov/pub/PBrodrick/isofit/sRTMnet_v120_aux.npz>`_.
-This will give you an hdf5 and an aux file. It is important that you store both in the same directory.
-Finally, point the environment variable EMULATOR_PATH to the hdf5 file.
+   You will likely need to set the path to 6S and sRTMnet for the ISOFIT ini file as well as rebuild the examples.
+   To do this, execute::
 
-You will likely need to set the path to 6S and sRTMnet for the ISOFIT ini file as well as rebuild the examples.
-To do this, execute:
+      $ isofit --sixs /path/to/sixs/ --srtmnet /path/to/sRTMnet/ build
 
-.. code::
-
-    $ isofit --sixs /path/to/sixs --srtmnet /path/to/sRTMnet.h5 build
-
-5. Run one of the following examples:
+#. Run one of the following examples:
 
 .. code::
 
@@ -229,30 +244,16 @@ This quick start presumes that you have an installation of the MODTRAN 6.0 radia
 preferred radiative transfer option if available, though we have also included interfaces to the open source
 LibRadTran RT code as well as to neural network emulators.
 
-1. Create an environment variable MODTRAN_DIR pointing to the base MODTRAN 6.0 directory.
+#. Create an environment variable MODTRAN_DIR pointing to the base MODTRAN 6.0 directory.
 
-2. Run the following code:
-
-.. code::
+#. Run the following code::
 
     $ cd $(isofit path examples)/20171108_Pasadena
     $ ./modtran.sh
 
-3. This will build a surface model and run the retrieval. The default example uses a lookup table approximation, and the code should recognize that the tables do not currently exist. It will call MODTRAN to rebuild them, which will take a few minutes.
+#. This will build a surface model and run the retrieval. The default example uses a lookup table approximation, and the code should recognize that the tables do not currently exist. It will call MODTRAN to rebuild them, which will take a few minutes.
 
-4. Look for output data in ``$(isofit path examples)/20171108_Pasadena/output/``.
-
-
-Additional Installation Info for Mac OSX
-========================================
-
-1. Install the command-line compiler
-
-.. code::
-
-  xcode-select --install
-
-2. Download the python3 installer from https://www.python.org/downloads/mac-osx/
+#. Look for output data in ``$(isofit path examples)/20171108_Pasadena/output/``.
 
 
 Known Incompatibilities
@@ -260,18 +261,7 @@ Known Incompatibilities
 
 Ray may have compatibility issues with older machines with glibc < 2.14.
 
-
-.. _Conda: https://conda.io/docs/
-.. _Miniforge: https://github.com/conda-forge/miniforge
-.. _Mamba: https://github.com/mamba-org/mamba
-.. _Anaconda: https://www.anaconda.com/products/distribution
-.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
-.. _pip: https://pip.pypa.io
-.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
-.. _Ray: https://docs.ray.io/en/latest/index.html
-
-
 Additional Installation Info for Developers
-========================================
+===========================================
 
 Be sure to read the :ref:`contributing` page as additional installation steps must be performed.

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -40,7 +40,7 @@ Install with ``pip``
 
 .. note::
 
-    The commands below use ``$ pip``, however ``$ python -m pip`` or is often a
+    The commands below use ``$ pip``, however ``$ python -m pip`` is often a
     safer choice. It is possible for the ``$ pip`` executable to point to a
     different version of Python than the ``$ python`` executable. Using
     ``$ python -m pip`` at least ensures that the package is installed against
@@ -82,6 +82,7 @@ Downloading Extra Files
 
 Once ISOFIT is installed, the CLI provides an easy way to download additional files that may be useful.
 These can be acquired via the ``isofit download`` command, and the current list of downloads we support is available via ``isofit download --help``.
+See :ref:`data` for more information.
 
 > **_NOTE:_**  The default location for downloading extra files is ``~/.isofit/``. First time invoking the ISOFIT CLI will instantiate this directory and an ``isofit.ini`` file for storing the paths to downloaded products.
 
@@ -145,19 +146,39 @@ ISOFIT variables
 
 The following environment variables are actively used within ISOFIT:
 
-- `MKL_NUM_THREADS` and `OMP_NUM_THREADS` - These control the threading of various packages within ISOFIT. It is
-important to set these to "1" to ensure ISOFIT performs to its fullest capabilities. By default, ISOFIT will insert
-these into the environment if they are not set and/or not set correctly.
-- `ISOFIT_NO_SET_THREADS` - This will disable automatically setting the MKL and OMP environment variables. This is recommended
-only for advanced users that know what they are doing and can mitigate the consequences.
-- `ISOFIT_DEBUG` - This will disable the `ray` package across ISOFIT to force single-core execution. Primarily used as
-a debugging tool by developers and is not recommended for use.
+.. list-table::
+    :widths: 20 80
+    :header-rows: 1
+
+    * - Variable
+      - Purpose
+    * - ``MKL_NUM_THREADS`` and ``OMP_NUM_THREADS``
+      - These control the threading of various packages within ISOFIT. It is important to set these to "1" to ensure ISOFIT performs to its fullest capabilities. By default, ISOFIT will insert these into the environment if they are not set and/or not set correctly.
+    * - ``ISOFIT_NO_SET_THREADS``
+      - This will disable automatically setting the MKL and OMP environment variables. Only recommended for advanced users that know what they are doing and can mitigate the consequences.
+    * - ``ISOFIT_DEBUG``
+      - Disables the `ray` package across ISOFIT to force single-core execution. Primarily used as a debugging tool by developers and is not recommended for normal use.
 
 Quick Start with sRTMnet (Recommended for new users)
 ====================================================
 
 sRTMnet is an emulator for MODTRAN 6, that works by coupling a neural network with a surrogate RTM (6S v2.1).
-Installation requires two steps:
+
+
+Automatic (Recommended)
+-----------------------
+ISOFIT can automatically install 6S and sRTMnet with the latest versions:
+
+.. code::
+
+    $ isofit download sixs
+    $ isofit download srtmnet
+
+The above commands will ensure these models are built and available for ISOFIT.
+
+Manual (Advanced)
+-----------------
+The following procedure walks through the steps required to install sRTMnet manually:
 
 1. Download `6S v2.1 <https://salsa.umd.edu/files/6S/6sV2.1.tar>`_, and compile.  If you use a modern system,
 it is likely you will need to specify a legacy compiling configuration by changing line 3 of the Makefile to:
@@ -173,27 +194,32 @@ as well as some `auxiliary data <https://avng.jpl.nasa.gov/pub/PBrodrick/isofit/
 This will give you an hdf5 and an aux file. It is important that you store both in the same directory.
 Finally, point the environment variable EMULATOR_PATH to the hdf5 file.
 
-4. Run one of the following examples:
+You will likely need to set the path to 6S and sRTMnet for the ISOFIT ini file as well as rebuild the examples.
+To do this, execute:
+
+.. code::
+
+    $ isofit --sixs /path/to/sixs --srtmnet /path/to/sRTMnet.h5 build
+
+5. Run one of the following examples:
 
 .. code::
 
     # Small example pixel-by-pixel
-    cd $(isofit path examples)/image_cube/small/
-    ./small-chunk.sh
+    $ cd $(isofit path examples)/image_cube/small/
+    $ ./default.sh
 
 .. code::
 
     # Medium example with empirical line solution
-    cd $(isofit path examples)/image_cube/medium/
-    ./empirical.sh
+    $ cd $(isofit path examples)/image_cube/medium/
+    $ ./empirical.sh
 
 .. code::
 
     # Medium example with analytical line solution
-    cd $(isofit path examples)/image_cube/medium/
-    ./analytical.sh
-
-
+    $ cd $(isofit path examples)/image_cube/medium/
+    $ ./analytical.sh
 
 
 Quick Start using MODTRAN 6.0
@@ -215,55 +241,6 @@ LibRadTran RT code as well as to neural network emulators.
 3. This will build a surface model and run the retrieval. The default example uses a lookup table approximation, and the code should recognize that the tables do not currently exist.  It will call MODTRAN to rebuild them, which will take a few minutes.
 
 4. Look for output data in $(isofit path examples)/20171108_Pasadena/output/.
-
-
-Quick Start with LibRadTran 2.0.x
-=================================
-
-This quick start requires an installation of the open source LibRadTran radiative transfer model (`LibRadTran <http://www.libradtran.org/doku.php>`_).
-A few important steps have to be considered when installing the software, which are outlined below. We have tested with the latest 2.0.4 release.
-
-1. Download and unpack the latest version of LibRadTran:
-
-.. code::
-
-    wget -nv http://www.libradtran.org/download/libRadtran-2.0.4.tar.gz
-    tar -xf libRadtran-2.0.4.tar.gz
-
-2. Download and unpack the "REPTRAN" absorption parameterization:
-
-.. code::
-
-    wget -nv http://www.meteo.physik.uni-muenchen.de/~libradtran/lib/exe/fetch.php?media=download:reptran_2017_all.tar.gz -O reptran-2017-all.tar.gz
-    tar -xf reptran-2017-all.tar.gz
-
-3. Unpacking REPTRAN will create a folder called 'data' with a subfolder 'correlated_k'. Copy this subfolder to the LibRadTran data directory:
-
-.. code::
-
-    cp -r data/correlated_k libRadtran-2.0.4/data
-
-4. Go to the LibRadTran base directory, configure and compile the software. It's important to set python2 as interpreter and 'ignore-errors' when running the 'make' command:
-
-.. code::
-
-    cd libRadtran-2.0.4
-    PYTHON=$(which python2) ./configure --prefix=$(pwd)
-    make --ignore-errors
-
-5. Create an environment variable LIBRADTRAN_DIR pointing to the base libRadTran directory.
-
-6. Run the following code
-
-.. code::
-
-    cd $(isofit path examples)/20171108_Pasadena
-    ./run_example_libradtran.sh
-
-7. This will build a surface model and run the retrieval. The default example uses a lookup table approximation, and the code should recognize that the tables do not currently exist.  It will call LibRadTran to rebuild them, which will take a few minutes.
-
-8. Look for output data in $(isofit path examples)/20171108_Pasadena/output/.
-
 
 
 Additional Installation Info for Mac OSX

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -81,9 +81,9 @@ Downloading Extra Files
 -----------------------
 
 Once ISOFIT is installed, the CLI provides an easy way to download additional files that may be useful.
-These can be acquired via the `isofit download` command, and the current list of downloads we support is available via `isofit download --help`.
+These can be acquired via the ``isofit download`` command, and the current list of downloads we support is available via ``isofit download --help``.
 
-> **_NOTE:_**  The default location for downloading extra files is `~/.isofit/`. First time invoking the ISOFIT CLI will instantiate this directory and an `isofit.ini` file for storing the paths to downloaded products.
+> **_NOTE:_**  The default location for downloading extra files is ``~/.isofit/``. First time invoking the ISOFIT CLI will instantiate this directory and an ``isofit.ini`` file for storing the paths to downloaded products.
 
 Setting environment variables
 =============================


### PR DESCRIPTION
Some docs related to the `data` module weren't displaying correctly. Notable fixes:
- Refactored a table to use proper RST syntax. Was previously not displaying 
- Words wrapped in `` were being indented instead of highlighted, which made sentences awkward to read
- Unfinished dev section describing the templates has now been fleshed out. They weren't supposed to be pushed yet but accidentally got included early, so this cleans them up
- Other sections of the docs now refer to the downloads/data module more consistently
- Removed labradtran from installation docs
- Recommend using `isofit download` for 6s and sRTMnet instead of manually downloading and installing