### PR TITLE
Update modtran.py

### DIFF
--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -306,10 +306,6 @@ class ModtranRT(RadiativeTransferEngine):
         vals["NAME"] = filename_base
         vals["FILTNM"] = os.path.normpath(self.filtpath)
 
-        # Translate to the MODTRAN OBSZEN convention, assumes we are downlooking
-        if vals["OBSZEN"] < 90:
-            vals["OBSZEN"] = 180 - abs(vals["OBSZEN"])
-
         modtran_config_str, modtran_config = self.modtran_driver(dict(vals))
 
         # Check rebuild conditions: LUT is missing or from a different config


### PR DESCRIPTION
A block of code was giving an error about OBSZEN, which is not in the dictionary.  I believe that this is because the geometry data are in a separate geometry object?  Does something else need to be updated for modtran to run under isofit?

This is more of a question about a problem I am having with running ISOFIT.

```
 File "/mnt/persistent_data/isofit/isofit/radiative_transfer/engines/modtran.py", line 311, in makeSim
    if vals["OBSZEN"] < 90:
       ~~~~^^^^^^^^^^
KeyError: 'OBSZEN'

(Pdb) print(vals)
{'H2OSTR': 0.01, 'DISALB': True, 'NAME': 'H2OSTR-0.0100', 'FILTNM': '/mnt/data/20230401_ASO/VNIR/L2A_reflectance/lut_h2o/wavelengths_modtran_406.01799_996.667975.flt'}
(Pdb)
```