### PR TITLE
Added key check on the lut grid for OBSZEN before checking MODTRAN convention

### DIFF
--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -307,7 +307,7 @@ class ModtranRT(RadiativeTransferEngine):
         vals["FILTNM"] = os.path.normpath(self.filtpath)
 
         # Translate to the MODTRAN OBSZEN convention, assumes we are downlooking
-        if vals["OBSZEN"] < 90:
+        if vals.get("OBSZEN") and vals.get("OBSZEN") < 90:
             vals["OBSZEN"] = 180 - abs(vals["OBSZEN"])
 
         modtran_config_str, modtran_config = self.modtran_driver(dict(vals))


### PR DESCRIPTION
Runs previously failed for images where the OBSZEN range is smaller than the lut_grid spacing. Modtran.py assumed that there was a lut_grid element for OBSZEN. This adds flexibility to only check for the correct zenith angle convention if the lut key is there.

Alternative to #571 and will close #569.

I'm currently testing that the fix works for a small image on the cluster.