### PR TITLE
ApplyOE Doc Updates

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -18,7 +18,9 @@ from spectral.io import envi
 import isofit.utils.template_construction as tmpl
 from isofit.core import isofit
 from isofit.core.common import envi_header
-from isofit.utils import analytical_line, empirical_line, extractions, segment
+from isofit.utils import analytical_line as ALAlg
+from isofit.utils import empirical_line as ELAlg
+from isofit.utils import extractions, segment
 
 EPS = 1e-6
 CHUNKSIZE = 256
@@ -668,7 +670,7 @@ def apply_oe(
         if empirical_line:
             # Empirical line
             logging.info("Empirical line inference")
-            empirical_line(
+            ELAlg(
                 reference_radiance_file=paths.rdn_subs_path,
                 reference_reflectance_file=paths.rfl_subs_path,
                 reference_uncertainty_file=paths.uncert_subs_path,
@@ -684,7 +686,7 @@ def apply_oe(
             )
         elif analytical_line:
             logging.info("Analytical line inference")
-            analytical_line(
+            ALAlg(
                 paths.radiance_working_path,
                 paths.loc_working_path,
                 paths.obs_working_path,

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -316,11 +316,11 @@ def apply_oe(
             " data."
         )
 
-    if args.inversion_windows:
+    if inversion_windows:
         assert all(
-            [len(window) == 2 for window in args.inversion_windows]
+            [len(window) == 2 for window in inversion_windows]
         ), "Inversion windows must be in pairs"
-        INVERSION_WINDOWS = args.inversion_windows
+        INVERSION_WINDOWS = inversion_windows
     logging.info(f"Using inversion windows: {INVERSION_WINDOWS}")
 
     dayofyear = dt.timetuple().tm_yday

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -121,16 +121,20 @@ def apply_oe(
     rdn_factors_path : str, default=None
         Specify a radiometric correction factor, if desired
     atmosphere_type : str, default="ATM_MIDLAT_SUMMER"
-        TODO
+        Atmospheric profile to be used for MODTRAN simulations.  Unused for other
+        radiative transfer models.
     channelized_uncertainty_path : str, default=None
         Path to a channelized uncertainty file
     model_discrepancy_path : str, default=None
-        TODO
+        Modifies S_eps in the OE formalism as the Gamma additive term, as:
+        S_eps = Sy + Kb.dot(self.Sb).dot(Kb.T) + Gamma
     lut_config_file : str, default=None
         Path to a look up table configuration file, which will override defaults
         choices
     multiple_restarts : bool, default=False
-        TODO
+        Use multiple initial starting poitns for each OE ptimization run, using
+        the corners of the atmospheric variables as starting points.  This gives
+        a more robust, albeit more expensive, solution.
     logging_level : str, default="INFO"
         Logging level with which to run ISOFIT
     log_file : str, default=None
@@ -152,7 +156,10 @@ def apply_oe(
         if not trying to analyze the atmospheric state at fine scale resolution.
         Mutually exclusive with analytical_line
     analytical_line : bool, default=False
-        TODO
+        Use an analytical solution to the fixed atmospheric state to solve for each
+        pixel.  Starts by running a full OE retrieval on each SLIC superpixel, then
+        interpolates the atmospheric state to each pixel, and closes with the
+        analytical solution.
         Mutually exclusive with empirical_line
     ray_temp_dir : str, default="/tmp/ray"
         Location of temporary directory for ray parallelization engine
@@ -167,16 +174,19 @@ def apply_oe(
         Forced number of neighbors for empirical line extrapolation - overides default
         set from segmentation_size parameter
     atm_sigma : list[int], default=[2]
-        TODO
+        A list of smoothing factors to use during the atmospheric interpolation, one
+        for each atmospheric parameter (or broadcast to all if only one is provided).
+        Only used with the analytical line.
     pressure_elevation : bool, default=False
         Flag to retrieve elevation
     prebuilt_lut : str, default=None
         Use this pre-constructed look up table for all retrievals. Must be an
         ISOFIT-compatible RTE NetCDF
     no_min_lut_spacing : bool, default=False
-        TODO
+        Don't allow the LUTConfig to remove a LUT dimension because of minimal spacing.
     inversion_windows : list[float], default=None
-        TODO
+        Override the default inversion windows.  Will supercede any sensor specific
+        defaults that are in place.
         Must be in 2-item tuples
 
     \b

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -9,7 +9,6 @@ import subprocess
 from datetime import datetime
 from os.path import exists, join
 from shutil import copyfile
-from types import SimpleNamespace
 
 import click
 import numpy as np
@@ -41,184 +40,198 @@ RTM_CLEANUP_LIST = ["*r_k", "*t_k", "*tp7", "*wrn", "*psc", "*plt", "*7sc", "*ac
 INVERSION_WINDOWS = [[350.0, 1360.0], [1410, 1800.0], [1970.0, 2500.0]]
 
 
-# Input arguments
-@click.command(name="apply_oe")
-@click.argument("input_radiance")
-@click.argument("input_loc")
-@click.argument("input_obs")
-@click.argument("working_directory")
-@click.argument("sensor")
-@click.option("--surface_path", "-sp", required=True, type=str)
-@click.option("--copy_input_files", is_flag=True, default=False)
-@click.option("--modtran_path")
-@click.option("--wavelength_path")
-@click.option("--surface_category", default="multicomponent_surface")
-@click.option("--aerosol_climatology_path")
-@click.option("--rdn_factors_path")
-@click.option("--atmosphere_type", default="ATM_MIDLAT_SUMMER")
-@click.option("--channelized_uncertainty_path")
-@click.option("--model_discrepancy_path")
-@click.option("--lut_config_file")
-@click.option("--multiple_restarts", is_flag=True, default=False)
-@click.option("--logging_level", default="INFO")
-@click.option("--log_file")
-@click.option("--n_cores", type=int, default=1)
-@click.option("--num_cpus", type=int, default=1)
-@click.option("--memory_gb", type=int, default=-1)
-@click.option("--presolve", is_flag=True, default=False)
-@click.option("--empirical_line", is_flag=True, default=False)
-@click.option("--analytical_line", is_flag=True, default=False)
-@click.option("--ray_temp_dir", default="/tmp/ray")
-@click.option("--emulator_base")
-@click.option("--segmentation_size", default=40)
-@click.option("--num_neighbors", "-nn", type=int, multiple=True)
-@click.option("--atm_sigma", "-as", type=float, multiple=True, default=[2])
-@click.option("--pressure_elevation", is_flag=True, default=False)
-@click.option("--prebuilt_lut", type=str)
-@click.option("--inversion_windows", type=float, nargs=2, multiple=True, default=None)
-@click.option("--no_min_lut_spacing", is_flag=True, default=False)
-@click.option(
-    "--debug-args",
-    help="Prints the arguments list without executing the command",
-    is_flag=True,
-)
-@click.option("--profile")
-def cli_apply_oe(debug_args, profile, **kwargs):
-    """Apply OE to a block of data"""
+def apply_oe(
+    input_radiance,
+    input_loc,
+    input_obs,
+    working_directory,
+    sensor,
+    surface_path,
+    copy_input_files=False,
+    modtran_path=None,
+    wavelength_path=None,
+    surface_category="multicomponent_surface",
+    aerosol_climatology_path=None,
+    rdn_factors_path=None,
+    atmosphere_type="ATM_MIDLAT_SUMMER",
+    channelized_uncertainty_path=None,
+    model_discrepancy_path=None,
+    lut_config_file=None,
+    multiple_restarts=False,
+    logging_level="INFO",
+    log_file=None,
+    n_cores=1,
+    presolve=False,
+    empirical_line=False,
+    analytical_line=False,
+    ray_temp_dir="/tmp/ray",
+    emulator_base=None,
+    segmentation_size=40,
+    num_neighbors=[],
+    atm_sigma=[2],
+    pressure_elevation=False,
+    prebuilt_lut=None,
+    no_min_lut_spacing=False,
+    inversion_windows=None,
+):
+    """\
+    Applies OE over a flightline using a radiative transfer engine. This executes
+    ISOFIT in a generalized way, accounting for the types of variation that might be
+    considered typical.
 
-    if debug_args:
-        click.echo("Arguments to be passed:")
-        for key, value in kwargs.items():
-            click.echo(f"  {key} = {value!r}")
-    else:
-        if profile:
-            import cProfile
-            import pstats
+    Observation (obs) and location (loc) files are used to determine appropriate
+    geometry lookup tables and provide a heuristic means of determining atmospheric
+    water ranges.
 
-            profiler = cProfile.Profile()
-            profiler.enable()
+    \b
+    Parameters
+    ----------
+    input_radiance : str
+        Radiance data cube. Expected to be ENVI format
+    input_loc : str
+        Location data cube of shape (Lon, Lat, Elevation). Expected to be ENVI format
+    input_obs : str
+        Observation data cube of shape:
+            (path length, to-sensor azimuth, to-sensor zenith,
+            to-sun azimuth, to-sun zenith, phase,
+            slope, aspect, cosine i, UTC time)
+        Expected to be ENVI format
+    working_directory : str
+        Directory to stage multiple outputs, will contain subdirectories
+    sensor : str
+        The sensor used for acquisition, will be used to set noise and datetime
+        settings
+    surface_path : str
+        Path to surface model or json dict of surface model configuration
+    copy_input_files : bool, default=False
+        Flag to choose to copy input_radiance, input_loc, and input_obs locally into
+        the working_directory
+    modtran_path : str, default=None
+        Location of MODTRAN utility. Alternately set with `MODTRAN_DIR` environment
+        variable
+    wavelength_path : str, default=None
+        Location to get wavelength information from, if not specified the radiance
+        header will be used
+    surface_category : str, default="multicomponent_surface"
+        The type of ISOFIT surface priors to use.  Default is multicomponent_surface
+    aerosol_climatology_path : str, default=None
+        Specific aerosol climatology information to use in MODTRAN
+    rdn_factors_path : str, default=None
+        Specify a radiometric correction factor, if desired
+    atmosphere_type : str, default="ATM_MIDLAT_SUMMER"
+        TODO
+    channelized_uncertainty_path : str, default=None
+        Path to a channelized uncertainty file
+    model_discrepancy_path : str, default=None
+        TODO
+    lut_config_file : str, default=None
+        Path to a look up table configuration file, which will override defaults
+        choices
+    multiple_restarts : bool, default=False
+        TODO
+    logging_level : str, default="INFO"
+        Logging level with which to run ISOFIT
+    log_file : str, default=None
+        File path to write ISOFIT logs to
+    n_cores : int, default=1
+        Number of cores to run ISOFIT with. Substantial parallelism is available, and
+        full runs will be very slow in serial. Suggested to max this out on the
+        available system
+    presolve : int, default=False
+        Flag to use a presolve mode to estimate the available atmospheric water range.
+        Runs a preliminary inversion over the image with a 1-D LUT of water vapor, and
+        uses the resulting range (slightly expanded) to bound determine the full LUT.
+        Advisable to only use with small cubes or in concert with the empirical_line
+        setting, or a significant speed penalty will be incurred
+    empirical_line : bool, default=False
+        Use an empirical line interpolation to run full inversions over only a subset
+        of pixels, determined using a SLIC superpixel segmentation, and use a KDTREE of
+        local solutions to interpolate radiance->reflectance. Generally a good option
+        if not trying to analyze the atmospheric state at fine scale resolution.
+        Mutually exclusive with analytical_line
+    analytical_line : bool, default=False
+        TODO
+        Mutually exclusive with empirical_line
+    ray_temp_dir : str, default="/tmp/ray"
+        Location of temporary directory for ray parallelization engine
+    emulator_base : str, default=None
+        Location of emulator base path. Point this at the model folder (or h5 file) of
+        sRTMnet to use the emulator instead of MODTRAN. An additional file with the
+        same basename and the extention _aux.npz must accompany
+        e.g. /path/to/emulator.h5 /path/to/emulator_aux.npz
+    segmentation_size : int, default=40
+        If empirical_line is enabled, sets the size of segments to construct
+    num_neighbors : list[int], default=[]
+        Forced number of neighbors for empirical line extrapolation - overides default
+        set from segmentation_size parameter
+    atm_sigma : list[int], default=[2]
+        TODO
+    pressure_elevation : bool, default=False
+        Flag to retrieve elevation
+    prebuilt_lut : str, default=None
+        Use this pre-constructed look up table for all retrievals. Must be an
+        ISOFIT-compatible RTE NetCDF
+    no_min_lut_spacing : bool, default=False
+        TODO
+    inversion_windows : list[float], default=None
+        TODO
+        Must be in 2-item tuples
 
-        # SimpleNamespace converts a dict into dot-notational
-        apply_oe(SimpleNamespace(**kwargs))
+    \b
+    References
+    ----------
+    D.R. Thompson, A. Braverman,P.G. Brodrick, A. Candela, N. Carbon, R.N. Clark,D. Connelly, R.O. Green, R.F.
+    Kokaly, L. Li, N. Mahowald, R.L. Miller, G.S. Okin, T.H.Painter, G.A. Swayze, M. Turmon, J. Susilouto, and
+    D.S. Wettergreen. Quantifying Uncertainty for Remote Spectroscopy of Surface Composition. Remote Sensing of
+    Environment, 2020. doi: https://doi.org/10.1016/j.rse.2020.111898.
 
-        if profile:
-            profiler.disable()
-            stats = pstats.Stats(profiler)
-            stats.dump_stats(profile)
-
-    click.echo("Done")
-
-
-def apply_oe(args):
-    """This is a helper script to apply OE over a flightline using the MODTRAN radiative transfer engine.
-
-    The goal is to run isofit in a fairly 'standard' way, accounting for the types of variation that might be
-    considered typical.  For instance, we use the observation (obs) and location (loc) files to determine appropriate
-    MODTRAN view-angle geometry look up tables, and provide a heuristic means of determing atmospheric water ranges.
-
-    This code also proivdes the capicity for speedup through the empirical line solution.
-
-    Args:
-        input_radiance (str): radiance data cube [expected ENVI format]
-        input_loc (str): location data cube, (Lon, Lat, Elevation) [expected ENVI format]
-        input_obs (str): observation data cube, (path length, to-sensor azimuth, to-sensor zenith, to-sun azimuth,
-            to-sun zenith, phase, slope, aspect, cosine i, UTC time) [expected ENVI format]
-        working_directory (str): directory to stage multiple outputs, will contain subdirectories
-        sensor (str): the sensor used for acquisition, will be used to set noise and datetime settings.  choices are:
-            [ang, avcl, neon, prism]
-        surface_path (Required, str): Path to surface model or json dict of surface model configuration.
-        copy_input_files (Optional, int): flag to choose to copy input_radiance, input_loc, and input_obs locally into
-            the working_directory.  0 for no, 1 for yes.  Default 0
-        modtran_path (Optional, str): Location of MODTRAN utility, alternately set with MODTRAN_DIR environment variable
-        wavelength_path (Optional, str): Location to get wavelength information from, if not specified the radiance
-            header will be used
-        surface_category (Optional, str): The type of isofit surface priors to use.  Default is multicomponent_surface
-        aerosol_climatology_path (Optional, str): Specific aerosol climatology information to use in MODTRAN,
-            default None
-        rdn_factors_path (Optional, str): Specify a radiometric correction factor, if desired. default None
-        channelized_uncertainty_path (Optional, str): path to a channelized uncertainty file.  default None
-        lut_config_file (Optional, str): Path to a look up table configuration file, which will override defaults
-            chocies. default None
-        logging_level (Optional, str): Logging level with which to run isofit.  Default INFO
-        log_file (Optional, str): File path to write isofit logs to.  Default None
-        n_cores (Optional, int): Number of cores to run isofit with.  Substantial parallelism is available, and full
-            runs will be very slow in serial.  Suggested to max this out on the available system.  Default 1
-        presolve (Optional, int): Flag to use a presolve mode to estimate the available atmospheric water range.  Runs
-            a preliminary inversion over the image with a 1-D LUT of water vapor, and uses the resulting range (slightly
-            expanded) to bound determine the full LUT.  Advisable to only use with small cubes or in concert with the
-            empirical_line setting, or a significant speed penalty will be incurred.  Choices - 0 off, 1 on. Default 0
-        empirical_line (Optional, int): Use an empirical line interpolation to run full inversions over only a subset
-            of pixels, determined using a SLIC superpixel segmentation, and use a KDTREE Of local solutions to
-            interpolate radiance->reflectance.  Generally a good option if not trying to analyze the atmospheric state
-            at fine scale resolution.  Choices - 0 off, 1 on.  Default 0
-        ray_temp_dir (Optional, str): Location of temporary directory for ray parallelization engine.  Default is
-            '/tmp/ray'
-        emulator_base (Optional, str): Location of emulator base path.  Point this at the model folder (or h5 file) of
-            sRTMnet to use the emulator instead of MODTRAN.  An additional file with the same basename and the extention
-            _aux.npz must accompany (e.g. /path/to/emulator.h5 /path/to/emulator_aux.npz)
-        segmentation_size (Optional, int): Size of segments to construct for empirical line (if used).
-        num_neighbors (Optional, int): Forced number of neighbors for empirical line extrapolation - overides default
-            set from segmentation_size parameter.
-        pressure_elevation (Optional, bool): If set, retrieves elevation.
-        prebuilt_lut (Optional, str): Use this pres-constructed look up table for all retrievals.
-
-            Reference:
-            D.R. Thompson, A. Braverman,P.G. Brodrick, A. Candela, N. Carbon, R.N. Clark,D. Connelly, R.O. Green, R.F.
-            Kokaly, L. Li, N. Mahowald, R.L. Miller, G.S. Okin, T.H.Painter, G.A. Swayze, M. Turmon, J. Susilouto, and
-            D.S. Wettergreen. Quantifying Uncertainty for Remote Spectroscopy of Surface Composition. Remote Sensing of
-            Environment, 2020. doi: https://doi.org/10.1016/j.rse.2020.111898.
-
-            Emulator reference:
-            P.G. Brodrick, D.R. Thompson, J.E. Fahlen, M.L. Eastwood, C.M. Sarture, S.R. Lundeen, W. Olson-Duvall,
-            N. Carmon, and R.O. Green. Generalized radiative transfer emulation for imaging spectroscopy reflectance
-            retrievals. Remote Sensing of Environment, 261:112476, 2021.doi: 10.1016/j.rse.2021.112476.
-
-
-    Returns:
-
+    \b
+    sRTMnet emulator:
+    P.G. Brodrick, D.R. Thompson, J.E. Fahlen, M.L. Eastwood, C.M. Sarture, S.R. Lundeen, W. Olson-Duvall,
+    N. Carmon, and R.O. Green. Generalized radiative transfer emulation for imaging spectroscopy reflectance
+    retrievals. Remote Sensing of Environment, 261:112476, 2021.doi: 10.1016/j.rse.2021.112476.
     """
-
-    use_superpixels = args.empirical_line or args.analytical_line
+    use_superpixels = empirical_line or analytical_line
 
     ray.init(
-        num_cpus=args.n_cores,
-        _temp_dir=args.ray_temp_dir,
+        num_cpus=n_cores,
+        _temp_dir=ray_temp_dir,
         include_dashboard=False,
-        local_mode=args.n_cores == 1,
+        local_mode=n_cores == 1,
     )
 
-    if args.sensor not in SUPPORTED_SENSORS:
-        if args.sensor[:3] != "NA-":
+    if sensor not in SUPPORTED_SENSORS:
+        if sensor[:3] != "NA-":
             errstr = (
                 f'Argument error: sensor must be one of {SUPPORTED_SENSORS} or "NA-*"'
             )
             raise ValueError(errstr)
 
-    if args.num_neighbors is not None and len(args.num_neighbors) > 1:
-        if not args.analytical_line:
+    if num_neighbors is not None and len(num_neighbors) > 1:
+        if not analytical_line:
             raise ValueError(
                 "If num_neighbors has multiple elements, --analytical_line must be True"
             )
-        if args.empirical_line:
+        if empirical_line:
             raise ValueError(
                 "If num_neighbors has multiple elements, only --analytical_line is valid"
             )
 
     logging.basicConfig(
         format="%(levelname)s:%(asctime)s || %(filename)s:%(funcName)s() | %(message)s",
-        level=args.logging_level,
-        filename=args.log_file,
+        level=logging_level,
+        filename=log_file,
         datefmt="%Y-%m-%d,%H:%M:%S",
     )
     logging.info(args)
 
     logging.info("Checking input data files...")
-    rdn_dataset = envi.open(envi_header(args.input_radiance))
+    rdn_dataset = envi.open(envi_header(input_radiance))
     rdn_size = (rdn_dataset.shape[0], rdn_dataset.shape[1])
     del rdn_dataset
     for infile_name, infile in zip(
         ["input_radiance", "input_loc", "input_obs"],
-        [args.input_radiance, args.input_loc, args.input_obs],
+        [input_radiance, input_loc, input_obs],
     ):
         if os.path.isfile(infile) is False:
             err_str = (
@@ -237,9 +250,7 @@ def apply_oe(args):
                 raise ValueError(err_str)
     logging.info("...Data file checks complete")
 
-    lut_params = tmpl.LUTConfig(
-        args.lut_config_file, args.emulator_base, args.no_min_lut_spacing
-    )
+    lut_params = tmpl.LUTConfig(lut_config_file, emulator_base, no_min_lut_spacing)
 
     logging.info("Setting up files and directories....")
     paths = tmpl.Pathnames(args)
@@ -250,40 +261,40 @@ def apply_oe(args):
     # Based on the sensor type, get appropriate year/month/day info from initial condition.
     # We'll adjust for line length and UTC day overrun later
     global INVERSION_WINDOWS
-    if args.sensor == "ang":
+    if sensor == "ang":
         # parse flightline ID (AVIRIS-NG assumptions)
         dt = datetime.strptime(paths.fid[3:], "%Y%m%dt%H%M%S")
-    elif args.sensor == "av3":
+    elif sensor == "av3":
         # parse flightline ID (AVIRIS-3 assumptions)
         dt = datetime.strptime(paths.fid[3:], "%Y%m%dt%H%M%S")
         INVERSION_WINDOWS = [[380.0, 1350.0], [1435, 1800.0], [1970.0, 2500.0]]
-    elif args.sensor == "avcl":
+    elif sensor == "avcl":
         # parse flightline ID (AVIRIS-Classic assumptions)
         dt = datetime.strptime("20{}t000000".format(paths.fid[1:7]), "%Y%m%dt%H%M%S")
-    elif args.sensor == "emit":
+    elif sensor == "emit":
         # parse flightline ID (EMIT assumptions)
         dt = datetime.strptime(paths.fid[:19], "emit%Y%m%dt%H%M%S")
         INVERSION_WINDOWS = [[380.0, 1325.0], [1435, 1770.0], [1965.0, 2500.0]]
-    elif args.sensor == "enmap":
+    elif sensor == "enmap":
         # parse flightline ID (EnMAP assumptions)
         dt = datetime.strptime(paths.fid[:15], "%Y%m%dt%H%M%S")
-    elif args.sensor == "hyp":
+    elif sensor == "hyp":
         # parse flightline ID (Hyperion assumptions)
         dt = datetime.strptime(paths.fid[10:17], "%Y%j")
-    elif args.sensor == "neon":
+    elif sensor == "neon":
         # parse flightline ID (NEON assumptions)
         dt = datetime.strptime(paths.fid, "NIS01_%Y%m%d_%H%M%S")
-    elif args.sensor == "prism":
+    elif sensor == "prism":
         # parse flightline ID (PRISM assumptions)
         dt = datetime.strptime(paths.fid[3:], "%Y%m%dt%H%M%S")
-    elif args.sensor == "prisma":
+    elif sensor == "prisma":
         # parse flightline ID (PRISMA assumptions)
         dt = datetime.strptime(paths.fid, "%Y%m%d%H%M%S")
-    elif args.sensor == "gao":
+    elif sensor == "gao":
         # parse flightline ID (GAO/CAO assumptions)
         dt = datetime.strptime(paths.fid[3:-5], "%Y%m%dt%H%M%S")
-    elif args.sensor[:3] == "NA-":
-        dt = datetime.strptime(args.sensor[3:], "%Y%m%d")
+    elif sensor[:3] == "NA-":
+        dt = datetime.strptime(sensor[3:], "%Y%m%d")
     else:
         raise ValueError(
             "Datetime object could not be obtained. Please check file name of input"
@@ -331,9 +342,9 @@ def apply_oe(args):
     # get radiance file, wavelengths, fwhm
     radiance_dataset = envi.open(envi_header(paths.radiance_working_path))
     wl_ds = np.array([float(w) for w in radiance_dataset.metadata["wavelength"]])
-    if args.wavelength_path:
-        if os.path.isfile(args.wavelength_path):
-            chn, wl, fwhm = np.loadtxt(args.wavelength_path).T
+    if wavelength_path:
+        if os.path.isfile(wavelength_path):
+            chn, wl, fwhm = np.loadtxt(wavelength_path).T
             if len(chn) != len(wl_ds) or not np.all(np.isclose(wl, wl_ds, atol=0.01)):
                 raise ValueError(
                     "Number of channels or center wavelengths provided in wavelength file do not match"
@@ -371,11 +382,11 @@ def apply_oe(args):
 
     # check and rebuild surface model if needed
     paths.surface_path = tmpl.check_surface_model(
-        surface_path=args.surface_path, wl=wl, paths=paths
+        surface_path=surface_path, wl=wl, paths=paths
     )
 
     # re-stage surface model if needed
-    if paths.surface_path != args.surface_path:
+    if paths.surface_path != surface_path:
         copyfile(paths.surface_path, paths.surface_working_path)
 
     (
@@ -384,10 +395,10 @@ def apply_oe(args):
         mean_elevation_km,
         elevation_lut_grid,
     ) = tmpl.get_metadata_from_loc(
-        paths.loc_working_path, lut_params, pressure_elevation=args.pressure_elevation
+        paths.loc_working_path, lut_params, pressure_elevation=pressure_elevation
     )
 
-    if args.emulator_base is not None:
+    if emulator_base is not None:
         if elevation_lut_grid is not None and np.any(elevation_lut_grid < 0):
             to_rem = elevation_lut_grid[elevation_lut_grid < 0].copy()
             elevation_lut_grid[elevation_lut_grid < 0] = 0
@@ -422,8 +433,8 @@ def apply_oe(args):
     logging.info(f"Relative to-sun azimuth (deg): {mean_relative_azimuth}")
     logging.info(f"Altitude (km): {mean_altitude_km}")
 
-    if args.emulator_base is not None and mean_altitude_km > 99:
-        if not args.emulator_base.endswith(".jld2"):
+    if emulator_base is not None and mean_altitude_km > 99:
+        if not emulator_base.endswith(".jld2"):
             logging.info(
                 "Adjusting altitude to 99 km for integration with 6S, because emulator is"
                 " chosen."
@@ -432,7 +443,7 @@ def apply_oe(args):
 
     # We will use the model discrepancy with covariance OR uncorrelated
     # Calibration error, but not both.
-    if args.model_discrepancy_path is not None:
+    if model_discrepancy_path is not None:
         uncorrelated_radiometric_uncertainty = 0
     else:
         uncorrelated_radiometric_uncertainty = UNCORRELATED_RADIOMETRIC_UNCERTAINTY
@@ -447,11 +458,11 @@ def apply_oe(args):
                 spectra=(paths.radiance_working_path, paths.lbl_working_path),
                 nodata_value=-9999,
                 npca=5,
-                segsize=args.segmentation_size,
+                segsize=segmentation_size,
                 nchunk=CHUNKSIZE,
-                n_cores=args.n_cores,
-                loglevel=args.logging_level,
-                logfile=args.log_file,
+                n_cores=n_cores,
+                loglevel=logging_level,
+                logfile=log_file,
             )
 
         # Extract input data per segment
@@ -468,15 +479,15 @@ def apply_oe(args):
                     output=outp,
                     chunksize=CHUNKSIZE,
                     flag=-9999,
-                    n_cores=args.n_cores,
-                    loglevel=args.logging_level,
-                    logfile=args.log_file,
+                    n_cores=n_cores,
+                    loglevel=logging_level,
+                    logfile=log_file,
                 )
 
-    if args.presolve:
+    if presolve:
         # write modtran presolve template
         tmpl.write_modtran_template(
-            atmosphere_type=args.atmosphere_type,
+            atmosphere_type=atmosphere_type,
             fid=paths.fid,
             altitude_km=mean_altitude_km,
             dayofyear=dayofyear,
@@ -490,7 +501,7 @@ def apply_oe(args):
             ihaze_type="AER_NONE",
         )
 
-        if args.emulator_base is None and args.prebuilt_lut is None:
+        if emulator_base is None and prebuilt_lut is None:
             max_water = tmpl.calc_modtran_max_water(paths)
         else:
             max_water = 6
@@ -506,12 +517,12 @@ def apply_oe(args):
             tmpl.build_presolve_config(
                 paths=paths,
                 h2o_lut_grid=h2o_grid,
-                n_cores=args.n_cores,
+                n_cores=n_cores,
                 use_emp_line=use_superpixels,
-                surface_category=args.surface_category,
-                emulator_base=args.emulator_base,
+                surface_category=surface_category,
+                emulator_base=emulator_base,
                 uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
-                prebuilt_lut_path=args.prebuilt_lut,
+                prebuilt_lut_path=prebuilt_lut,
                 inversion_windows=INVERSION_WINDOWS,
             )
 
@@ -520,13 +531,13 @@ def apply_oe(args):
             retrieval_h2o = isofit.Isofit(
                 paths.h2o_config_path,
                 level="INFO",
-                logfile=args.log_file,
+                logfile=log_file,
             )
             retrieval_h2o.run()
             del retrieval_h2o
 
             # clean up unneeded storage
-            if args.emulator_base is None:
+            if emulator_base is None:
                 for to_rm in RTM_CLEANUP_LIST:
                     cmd = "rm " + join(paths.lut_h2o_directory, to_rm)
                     logging.info(cmd)
@@ -565,7 +576,7 @@ def apply_oe(args):
         or not exists(paths.rfl_subs_path)
     ):
         tmpl.write_modtran_template(
-            atmosphere_type=args.atmosphere_type,
+            atmosphere_type=atmosphere_type,
             fid=paths.fid,
             altitude_km=mean_altitude_km,
             dayofyear=dayofyear,
@@ -607,27 +618,27 @@ def apply_oe(args):
             mean_longitude=mean_longitude,
             dt=dt,
             use_emp_line=use_superpixels,
-            n_cores=args.n_cores,
-            surface_category=args.surface_category,
-            emulator_base=args.emulator_base,
+            n_cores=n_cores,
+            surface_category=surface_category,
+            emulator_base=emulator_base,
             uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
-            multiple_restarts=args.multiple_restarts,
-            segmentation_size=args.segmentation_size,
-            pressure_elevation=args.pressure_elevation,
-            prebuilt_lut_path=args.prebuilt_lut,
+            multiple_restarts=multiple_restarts,
+            segmentation_size=segmentation_size,
+            pressure_elevation=pressure_elevation,
+            prebuilt_lut_path=prebuilt_lut,
             inversion_windows=INVERSION_WINDOWS,
         )
 
         # Run retrieval
         logging.info("Running ISOFIT with full LUT")
         retrieval_full = isofit.Isofit(
-            paths.isofit_full_config_path, level="INFO", logfile=args.log_file
+            paths.isofit_full_config_path, level="INFO", logfile=log_file
         )
         retrieval_full.run()
         del retrieval_full
 
         # clean up unneeded storage
-        if args.emulator_base is None:
+        if emulator_base is None:
             for to_rm in RTM_CLEANUP_LIST:
                 cmd = "rm " + join(paths.full_lut_directory, to_rm)
                 logging.info(cmd)
@@ -636,12 +647,12 @@ def apply_oe(args):
     if not exists(paths.rfl_working_path) or not exists(paths.uncert_working_path):
         # Determine the number of neighbors to use.  Provides backwards stability and works
         # well with defaults, but is arbitrary
-        if not args.num_neighbors:
-            nneighbors = [int(round(3950 / 9 - 35 / 36 * args.segmentation_size))]
+        if not num_neighbors:
+            nneighbors = [int(round(3950 / 9 - 35 / 36 * segmentation_size))]
         else:
-            nneighbors = [n for n in args.num_neighbors]
+            nneighbors = [n for n in num_neighbors]
 
-        if args.empirical_line:
+        if empirical_line:
             # Empirical line
             logging.info("Empirical line inference")
             empirical_line(
@@ -656,26 +667,89 @@ def apply_oe(args):
                 output_uncertainty_file=paths.uncert_working_path,
                 isofit_config=paths.isofit_full_config_path,
                 nneighbors=nneighbors[0],
-                n_cores=args.n_cores,
+                n_cores=n_cores,
             )
-        elif args.analytical_line:
+        elif analytical_line:
             logging.info("Analytical line inference")
             analytical_line(
                 paths.radiance_working_path,
                 paths.loc_working_path,
                 paths.obs_working_path,
-                args.working_directory,
+                working_directory,
                 output_rfl_file=paths.rfl_working_path,
                 output_unc_file=paths.uncert_working_path,
-                loglevel=args.logging_level,
-                logfile=args.log_file,
+                loglevel=logging_level,
+                logfile=log_file,
                 n_atm_neighbors=nneighbors,
-                n_cores=args.n_cores,
-                smoothing_sigma=args.atm_sigma,
+                n_cores=n_cores,
+                smoothing_sigma=atm_sigma,
             )
 
     logging.info("Done.")
     ray.shutdown()
+
+
+# Input arguments
+@click.command(name="apply_oe", help=apply_oe.__doc__, no_args_is_help=True)
+@click.argument("input_radiance")
+@click.argument("input_loc")
+@click.argument("input_obs")
+@click.argument("working_directory")
+@click.argument("sensor")
+@click.option("--surface_path", "-sp", required=True, type=str)
+@click.option("--copy_input_files", is_flag=True, default=False)
+@click.option("--modtran_path")
+@click.option("--wavelength_path")
+@click.option("--surface_category", default="multicomponent_surface")
+@click.option("--aerosol_climatology_path")
+@click.option("--rdn_factors_path")
+@click.option("--atmosphere_type", default="ATM_MIDLAT_SUMMER")
+@click.option("--channelized_uncertainty_path")
+@click.option("--model_discrepancy_path")
+@click.option("--lut_config_file")
+@click.option("--multiple_restarts", is_flag=True, default=False)
+@click.option("--logging_level", default="INFO")
+@click.option("--log_file")
+@click.option("--n_cores", type=int, default=1)
+@click.option("--presolve", is_flag=True, default=False)
+@click.option("--empirical_line", is_flag=True, default=False)
+@click.option("--analytical_line", is_flag=True, default=False)
+@click.option("--ray_temp_dir", default="/tmp/ray")
+@click.option("--emulator_base")
+@click.option("--segmentation_size", default=40)
+@click.option("--num_neighbors", "-nn", type=int, multiple=True)
+@click.option("--atm_sigma", "-as", type=float, multiple=True, default=[2])
+@click.option("--pressure_elevation", is_flag=True, default=False)
+@click.option("--prebuilt_lut", type=str)
+@click.option("--no_min_lut_spacing", is_flag=True, default=False)
+@click.option("--inversion_windows", type=float, nargs=2, multiple=True, default=None)
+@click.option(
+    "--debug-args",
+    help="Prints the arguments list without executing the command",
+    is_flag=True,
+)
+@click.option("--profile")
+def cli_apply_oe(debug_args, profile, **kwargs):
+    if debug_args:
+        print("Arguments to be passed:")
+        for key, value in kwitems():
+            print(f"  {key} = {value!r}")
+    else:
+        if profile:
+            import cProfile
+            import pstats
+
+            profiler = cProfile.Profile()
+            profiler.enable()
+
+        apply_oe(**kwargs)
+
+        if profile:
+            profiler.disable()
+            stats = pstats.Stats(profiler)
+            stats.dump_stats(profile)
+
+    print("Done")
 
 
 if __name__ == "__main__":

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -262,6 +262,7 @@ def apply_oe(
         copy_input_files,
         modtran_path,
         rdn_factors_path,
+        model_discrepancy_path,
         aerosol_climatology_path,
         channelized_uncertainty_path,
         ray_temp_dir,

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -317,6 +317,9 @@ def apply_oe(
         )
 
     if args.inversion_windows:
+        assert all(
+            [len(window) == 2 for window in args.inversion_windows]
+        ), "Inversion windows must be in pairs"
         INVERSION_WINDOWS = args.inversion_windows
     logging.info(f"Using inversion windows: {INVERSION_WINDOWS}")
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -259,6 +259,7 @@ def apply_oe(
         sensor,
         surface_path,
         working_directory,
+        copy_input_files,
         modtran_path,
         rdn_factors_path,
         aerosol_climatology_path,

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -223,7 +223,6 @@ def apply_oe(
         filename=log_file,
         datefmt="%Y-%m-%d,%H:%M:%S",
     )
-    logging.info(args)
 
     logging.info("Checking input data files...")
     rdn_dataset = envi.open(envi_header(input_radiance))
@@ -253,7 +252,19 @@ def apply_oe(
     lut_params = tmpl.LUTConfig(lut_config_file, emulator_base, no_min_lut_spacing)
 
     logging.info("Setting up files and directories....")
-    paths = tmpl.Pathnames(args)
+    paths = tmpl.Pathnames(
+        input_radiance,
+        input_loc,
+        input_obs,
+        sensor,
+        surface_path,
+        working_directory,
+        modtran_path,
+        rdn_factors_path,
+        aerosol_climatology_path,
+        channelized_uncertainty_path,
+        ray_temp_dir,
+    )
     paths.make_directories()
     paths.stage_files()
     logging.info("...file/directory setup complete")

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -42,6 +42,7 @@ class Pathnames:
         sensor,
         surface_path,
         working_directory,
+        copy_input_files,
         modtran_path,
         rdn_factors_path,
         aerosol_climatology_path,

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -32,48 +32,58 @@ from isofit.utils import surface_model
 class Pathnames:
     """Class to determine and hold the large number of relative and absolute paths that are needed for isofit and
     MODTRAN configuration files.
-
-    Args:
-        args: an argparse Namespace object with all inputs
     """
 
-    def __init__(self, args):
+    def __init__(
+        self,
+        input_radiance,
+        input_loc,
+        input_obs,
+        sensor,
+        surface_path,
+        working_directory,
+        modtran_path,
+        rdn_factors_path,
+        aerosol_climatology_path,
+        channelized_uncertainty_path,
+        ray_temp_dir,
+    ):
         # Determine FID based on sensor name
-        if args.sensor == "ang":
-            self.fid = split(args.input_radiance)[-1][:18]
-        elif args.sensor == "av3":
-            self.fid = split(args.input_radiance)[-1][:18]
-        elif args.sensor == "avcl":
-            self.fid = split(args.input_radiance)[-1][:16]
-        elif args.sensor == "emit":
-            self.fid = split(args.input_radiance)[-1][:19]
-        elif args.sensor == "enmap":
-            self.fid = split(args.input_radiance)[-1].split("_")[5]
-        elif args.sensor == "hyp":
-            self.fid = split(args.input_radiance)[-1][:22]
-        elif args.sensor == "neon":
-            self.fid = split(args.input_radiance)[-1][:21]
-        elif args.sensor == "prism":
-            self.fid = split(args.input_radiance)[-1][:18]
-        elif args.sensor == "prisma":
-            self.fid = args.input_radiance.split("/")[-1].split("_")[1]
-        elif args.sensor == "gao":
-            self.fid = split(args.input_radiance)[-1][:23]
-        elif args.sensor[:3] == "NA-":
-            self.fid = os.path.splitext(os.path.basename(args.input_radiance))[0]
+        if sensor == "ang":
+            self.fid = split(input_radiance)[-1][:18]
+        elif sensor == "av3":
+            self.fid = split(input_radiance)[-1][:18]
+        elif sensor == "avcl":
+            self.fid = split(input_radiance)[-1][:16]
+        elif sensor == "emit":
+            self.fid = split(input_radiance)[-1][:19]
+        elif sensor == "enmap":
+            self.fid = split(input_radiance)[-1].split("_")[5]
+        elif sensor == "hyp":
+            self.fid = split(input_radiance)[-1][:22]
+        elif sensor == "neon":
+            self.fid = split(input_radiance)[-1][:21]
+        elif sensor == "prism":
+            self.fid = split(input_radiance)[-1][:18]
+        elif sensor == "prisma":
+            self.fid = input_radiance.split("/")[-1].split("_")[1]
+        elif sensor == "gao":
+            self.fid = split(input_radiance)[-1][:23]
+        elif sensor[:3] == "NA-":
+            self.fid = os.path.splitext(os.path.basename(input_radiance))[0]
 
         logging.info("Flightline ID: %s" % self.fid)
 
         # Names from inputs
-        self.aerosol_climatology = args.aerosol_climatology_path
-        self.input_radiance_file = args.input_radiance
-        self.input_loc_file = args.input_loc
-        self.input_obs_file = args.input_obs
-        self.working_directory = abspath(args.working_directory)
+        self.aerosol_climatology = aerosol_climatology_path
+        self.input_radiance_file = input_radiance
+        self.input_loc_file = input_loc
+        self.input_obs_file = input_obs
+        self.working_directory = abspath(working_directory)
 
         self.full_lut_directory = abspath(join(self.working_directory, "lut_full/"))
 
-        self.surface_path = args.surface_path
+        self.surface_path = surface_path
 
         # set up some sub-directories
         self.lut_h2o_directory = abspath(join(self.working_directory, "lut_h2o/"))
@@ -98,7 +108,7 @@ class Pathnames:
         )
         self.surface_working_path = abspath(join(self.data_directory, "surface.mat"))
 
-        if args.copy_input_files is True:
+        if copy_input_files is True:
             self.radiance_working_path = abspath(
                 join(self.input_data_directory, rdn_fname)
             )
@@ -113,8 +123,8 @@ class Pathnames:
             self.obs_working_path = abspath(self.input_obs_file)
             self.loc_working_path = abspath(self.input_loc_file)
 
-        if args.channelized_uncertainty_path:
-            self.input_channelized_uncertainty_path = args.channelized_uncertainty_path
+        if channelized_uncertainty_path:
+            self.input_channelized_uncertainty_path = channelized_uncertainty_path
         else:
             self.input_channelized_uncertainty_path = os.getenv(
                 "ISOFIT_CHANNELIZED_UNCERTAINTY"
@@ -124,8 +134,8 @@ class Pathnames:
             join(self.data_directory, "channelized_uncertainty.txt")
         )
 
-        if args.model_discrepancy_path:
-            self.input_model_discrepancy_path = args.model_discrepancy_path
+        if model_discrepancy_path:
+            self.input_model_discrepancy_path = model_discrepancy_path
         else:
             self.input_model_discrepancy_path = None
 
@@ -174,16 +184,16 @@ class Pathnames:
             join(self.config_directory, self.fid + "_h2o.json")
         )
 
-        if args.modtran_path:
-            self.modtran_path = args.modtran_path
+        if modtran_path:
+            self.modtran_path = modtran_path
         else:
             self.modtran_path = os.getenv("MODTRAN_DIR", env.modtran)
 
         self.sixs_path = os.getenv("SIXS_DIR", env.sixs)
 
-        if args.sensor == "avcl":
+        if sensor == "avcl":
             self.noise_path = str(env.path("data", "avirisc_noise.txt"))
-        elif args.sensor == "emit":
+        elif sensor == "emit":
             self.noise_path = str(env.path("data", "emit_noise.txt"))
             if self.input_channelized_uncertainty_path is None:
                 self.input_channelized_uncertainty_path = str(
@@ -208,10 +218,10 @@ class Pathnames:
 
         self.aerosol_tpl_path = str(env.path("data", "aerosol_template.json"))
         self.rdn_factors_path = None
-        if args.rdn_factors_path is not None:
-            self.rdn_factors_path = abspath(args.rdn_factors_path)
+        if rdn_factors_path is not None:
+            self.rdn_factors_path = abspath(rdn_factors_path)
 
-        self.ray_temp_dir = args.ray_temp_dir
+        self.ray_temp_dir = ray_temp_dir
 
     def make_directories(self):
         """Build required subdirectories inside working_directory"""

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -45,6 +45,7 @@ class Pathnames:
         copy_input_files,
         modtran_path,
         rdn_factors_path,
+        model_discrepancy_path,
         aerosol_climatology_path,
         channelized_uncertainty_path,
         ray_temp_dir,


### PR DESCRIPTION
While working on the NEON tutorial updates, I saw it fit to clean up the docs of ApplyOE to be a bit more user-friendly as well as make it all available to the CLI. 

Changes:
- Deprecated the use of the dot-notational `args` dict in favour of parameters. This makes it a bit more user-friendly to use the function within a notebook, such as the NEON tutorial
- Updated the docs with missing parameters and fixed a number of typos
- Changed docstring format to Numpy format (style choice, we've been inconsistent and I've implemented this style in other modules such as `data/` and `radiative_transfer`) IMO it's easier to read as it's less a giant block of text
- Added `apply_oe.__doc__` to the `isofit apply_oe` command. This required moving the CLI function to the bottom of the file. This enables us to only need to update docs in one function and not maintain a `help` param for each click option. Maybe a tad less clean, but definitely less work
- `isofit apply_oe` with no additional arguments auto-prints the `--help` message.

This is what it looks like:
```
$ isofit apply_oe
Usage: isofit apply_oe [OPTIONS] INPUT_RADIANCE INPUT_LOC INPUT_OBS
                       WORKING_DIRECTORY SENSOR

  Applies OE over a flightline using a radiative transfer engine. This
  executes ISOFIT in a generalized way, accounting for the types of variation
  that might be considered typical.

  Observation (obs) and location (loc) files are used to determine appropriate
  geometry lookup tables and provide a heuristic means of determining
  atmospheric water ranges.

  Parameters
  ----------
  input_radiance : str
      Radiance data cube. Expected to be ENVI format
  input_loc : str
      Location data cube of shape (Lon, Lat, Elevation). Expected to be ENVI format
  input_obs : str
      Observation data cube of shape:
          (path length, to-sensor azimuth, to-sensor zenith,
          to-sun azimuth, to-sun zenith, phase,
          slope, aspect, cosine i, UTC time)
      Expected to be ENVI format
  working_directory : str
      Directory to stage multiple outputs, will contain subdirectories
  sensor : str
      The sensor used for acquisition, will be used to set noise and datetime
      settings
  surface_path : str
      Path to surface model or json dict of surface model configuration
  copy_input_files : bool, default=False
      Flag to choose to copy input_radiance, input_loc, and input_obs locally into
      the working_directory
  modtran_path : str, default=None
      Location of MODTRAN utility. Alternately set with `MODTRAN_DIR` environment
      variable
  wavelength_path : str, default=None
      Location to get wavelength information from, if not specified the radiance
      header will be used
  surface_category : str, default="multicomponent_surface"
      The type of ISOFIT surface priors to use.  Default is multicomponent_surface
  aerosol_climatology_path : str, default=None
      Specific aerosol climatology information to use in MODTRAN
  rdn_factors_path : str, default=None
      Specify a radiometric correction factor, if desired
  atmosphere_type : str, default="ATM_MIDLAT_SUMMER"
      TODO
  channelized_uncertainty_path : str, default=None
      Path to a channelized uncertainty file
  model_discrepancy_path : str, default=None
      TODO
  lut_config_file : str, default=None
      Path to a look up table configuration file, which will override defaults
      choices
  multiple_restarts : bool, default=False
      TODO
  logging_level : str, default="INFO"
      Logging level with which to run ISOFIT
  log_file : str, default=None
      File path to write ISOFIT logs to
  n_cores : int, default=1
      Number of cores to run ISOFIT with. Substantial parallelism is available, and
      full runs will be very slow in serial. Suggested to max this out on the
      available system
  presolve : int, default=False
      Flag to use a presolve mode to estimate the available atmospheric water range.
      Runs a preliminary inversion over the image with a 1-D LUT of water vapor, and
      uses the resulting range (slightly expanded) to bound determine the full LUT.
      Advisable to only use with small cubes or in concert with the empirical_line
      setting, or a significant speed penalty will be incurred
  empirical_line : bool, default=False
      Use an empirical line interpolation to run full inversions over only a subset
      of pixels, determined using a SLIC superpixel segmentation, and use a KDTREE of
      local solutions to interpolate radiance->reflectance. Generally a good option
      if not trying to analyze the atmospheric state at fine scale resolution.
      Mutually exclusive with analytical_line
  analytical_line : bool, default=False
      TODO
      Mutually exclusive with empirical_line
  ray_temp_dir : str, default="/tmp/ray"
      Location of temporary directory for ray parallelization engine
  emulator_base : str, default=None
      Location of emulator base path. Point this at the model folder (or h5 file) of
      sRTMnet to use the emulator instead of MODTRAN. An additional file with the
      same basename and the extention _aux.npz must accompany
      e.g. /path/to/emulator.h5 /path/to/emulator_aux.npz
  segmentation_size : int, default=40
      If empirical_line is enabled, sets the size of segments to construct
  num_neighbors : list[int], default=[]
      Forced number of neighbors for empirical line extrapolation - overides default
      set from segmentation_size parameter
  atm_sigma : list[int], default=[2]
      TODO
  pressure_elevation : bool, default=False
      Flag to retrieve elevation
  prebuilt_lut : str, default=None
      Use this pre-constructed look up table for all retrievals. Must be an
      ISOFIT-compatible RTE NetCDF
  no_min_lut_spacing : bool, default=False
      TODO

  References
  ----------
  D.R. Thompson, A. Braverman,P.G. Brodrick, A. Candela, N. Carbon, R.N. Clark,D. Connelly, R.O. Green, R.F.
  Kokaly, L. Li, N. Mahowald, R.L. Miller, G.S. Okin, T.H.Painter, G.A. Swayze, M. Turmon, J. Susilouto, and
  D.S. Wettergreen. Quantifying Uncertainty for Remote Spectroscopy of Surface Composition. Remote Sensing of
  Environment, 2020. doi: https://doi.org/10.1016/j.rse.2020.111898.

  sRTMnet emulator:
  P.G. Brodrick, D.R. Thompson, J.E. Fahlen, M.L. Eastwood, C.M. Sarture, S.R. Lundeen, W. Olson-Duvall,
  N. Carmon, and R.O. Green. Generalized radiative transfer emulation for imaging spectroscopy reflectance
  retrievals. Remote Sensing of Environment, 261:112476, 2021.doi: 10.1016/j.rse.2021.112476.

Options:
  -sp, --surface_path TEXT        [required]
  --copy_input_files
  --modtran_path TEXT
  --wavelength_path TEXT
  --surface_category TEXT
  --aerosol_climatology_path TEXT
  --rdn_factors_path TEXT
  --atmosphere_type TEXT
  --channelized_uncertainty_path TEXT
  --model_discrepancy_path TEXT
  --lut_config_file TEXT
  --multiple_restarts
  --logging_level TEXT
  --log_file TEXT
  --n_cores INTEGER
  --presolve
  --empirical_line
  --analytical_line
  --ray_temp_dir TEXT
  --emulator_base TEXT
  --segmentation_size INTEGER
  -nn, --num_neighbors INTEGER
  -as, --atm_sigma FLOAT
  --pressure_elevation
  --prebuilt_lut TEXT
  --no_min_lut_spacing
  --debug-args                    Prints the arguments list without executing
                                  the command
  --profile TEXT
  --help                          Show this message and exit.
```