### PR TITLE
6S Download Precheck

### DIFF
--- a/isofit/data/download.py
+++ b/isofit/data/download.py
@@ -67,9 +67,9 @@ def download_file(url, dstname=None, overwrite=True):
     """
     response = urllib.request.urlopen(url)
 
-    bar = None
-    if total := response.info()["Content-Length"]:
-        bar = click.progressbar(length=int(total), label="Downloading file")
+    total = 0
+    if length := response.info()["Content-Length"]:
+        total = int(length)
 
     # Using Python's 'email' module for this is certainly odd, but due to an
     # upcoming deprecation, this is actually the officially recommended way
@@ -81,16 +81,11 @@ def download_file(url, dstname=None, overwrite=True):
     if outfile.exists() and not overwrite:
         raise FileExistsError(outfile)
 
-    with open(outfile, "wb") as f:
-        while chunk := response.read(io.DEFAULT_BUFFER_SIZE):
-            f.write(chunk)
-            # bar.update(outfile.stat().st_size)
-            if bar:
+    with click.progressbar(length=int(total), label="Downloading file") as bar:
+        with open(outfile, "wb") as file:
+            while chunk := response.read(io.DEFAULT_BUFFER_SIZE):
+                file.write(chunk)
                 bar.update(io.DEFAULT_BUFFER_SIZE)
-
-    # The bar doesn't close correctly, echo empty to fix the terminal
-    if bar:
-        print()
 
     return outfile
 

--- a/isofit/data/download.py
+++ b/isofit/data/download.py
@@ -81,7 +81,7 @@ def download_file(url, dstname=None, overwrite=True):
     if outfile.exists() and not overwrite:
         raise FileExistsError(outfile)
 
-    with click.progressbar(length=int(total), label="Downloading file") as bar:
+    with click.progressbar(length=total, label="Downloading file") as bar:
         with open(outfile, "wb") as file:
             while chunk := response.read(io.DEFAULT_BUFFER_SIZE):
                 file.write(chunk)


### PR DESCRIPTION
6S depends on gfortran being installed on a system to make properly but we don't check for that currently. Added that as a pre-check before downloading and prompting the user to fix

Changes:
- Added `precheck` function to 6S downloader to check for `gfortran` installation
- Silenced the warning messages on the `make` process. The `-std=legacy` flag is _supposed_ to do that, but it's not so just going to hide the messages from the user as they're not useful
- Fixed an issue with the `click.progressbar` in the download function causing the terminal cursor to be broken after running one of the download commands. Previous solution was to run `reset`, but now that's not needed

Closes #584 

What it looks like (temporarily renamed the check command from `gfortran` to `gfortrans` to trigger it):

```
$ isofit download sixs
/bin/sh: gfortrans: command not found
Failed to validate an existing gfortran installation. Please ensure it is installed on your system.
Skipping downloading 6S. Once above errors are corrected, retry via: isofit download sixs
```