### PR TITLE
Added missing dependencies to environment_isofit_basic.yml to enable successful readthedocs build.

### DIFF
--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -9,6 +9,7 @@ dependencies:
   - click
   - dask
   - h5py
+  - myst-parser
   - netCDF4<1.7.1
   - numpy>=1.20.0,<2.0.0
   - pandas>=0.24

--- a/recipe/environment_isofit_basic.yml
+++ b/recipe/environment_isofit_basic.yml
@@ -20,6 +20,7 @@ dependencies:
   - scikit-learn>=0.19.1
   - scipy>=1.3.0
   - spectral>=0.19
+  - sphinx-autoapi
   - sphinx_rtd_theme
   - utm
   - xarray<2024.1.1


### PR DESCRIPTION
The latest readthedocs build failed because the environment_isofit_basic.yml was missing two packages that were introduced by @jammont's recent updates. This PR adds them.