### PR TITLE
LUT Spacing conditionals

### DIFF
--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -390,7 +390,10 @@ class LUTConfig:
             )
             return None
         elif (
-            np.abs(grid[1] - grid[0]) < min_spacing and self.no_min_lut_spacing is False
+            # Need this first conditional to rule out rounding errors
+            len(grid) == 2
+            and np.abs(grid[1] - grid[0]) < min_spacing
+            and self.no_min_lut_spacing is False
         ):
             logging.debug(
                 f"Grid spacing is {grid[1]-grid[0]}, which is less than {min_spacing}. "


### PR DESCRIPTION
We encountered an edge-case, where rounding in the lut spacing led to the minimum spacing condition being met.  This should only be triggered in the case where we have two grid elements, so rather than modify the rounding (which is convenient), this just adds to that conditional.