### PR TITLE
Handling multipart transmittances from 6s

### DIFF
--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -114,36 +114,20 @@ class SixSRT(RadiativeTransferEngine):
         # Retrieve the files to process
         name = self.point_to_filename(point)
 
-        if self.multipart_transmittance:
-            outp = os.path.join(self.sim_path, name, name)
-            inpt = os.path.join(self.sim_path, name, f"LUT_{name}_{self.wl[0]}.inp")
-        else:
-            outp = os.path.join(self.sim_path, name)
-            inpt = os.path.join(self.sim_path, f"LUT_{name}.inp")
+        outp = os.path.join(self.sim_path, name)
+        inpt = os.path.join(self.sim_path, f"LUT_{name}.inp")
 
         # Only execute when either the 6S input (ext.inp) or output (no extension) files are missing
         if os.path.exists(outp) and os.path.exists(inpt):
             Logger.warning(f"6S sim files already exist: {outp}, {inpt}")
             return
 
-        if self.multipart_transmittance:
-            io_dir = os.path.join(self.sim_path, name)
-            os.mkdir(io_dir)
-            # in multipart transmittance mode, we need to run 6s for ech wavelength separately
-            for wl in self.wl:
-                cmd = self.rebuild_cmd(point=point, wlinf=wl, wlsup=wl)
+        cmd = self.rebuild_cmd(point, wlinf=self.wl[0], wlsup=self.wl[-1])
 
-                if not self.engine_config.rte_configure_and_exit:
-                    call = subprocess.run(cmd, shell=True, capture_output=True)
-                    if call.stdout:
-                        Logger.error(call.stdout.decode())
-        else:
-            cmd = self.rebuild_cmd(point, wlinf=self.wl[0], wlsup=self.wl[-1])
-
-            if not self.engine_config.rte_configure_and_exit:
-                call = subprocess.run(cmd, shell=True, capture_output=True)
-                if call.stdout:
-                    Logger.error(call.stdout.decode())
+        if not self.engine_config.rte_configure_and_exit:
+            call = subprocess.run(cmd, shell=True, capture_output=True)
+            if call.stdout:
+                Logger.error(call.stdout.decode())
 
     def readSim(self, point: np.array):
         """
@@ -163,7 +147,12 @@ class SixSRT(RadiativeTransferEngine):
         name = self.point_to_filename(point)
         file = os.path.join(self.sim_path, name)
 
-        return self.parse_file(file=file, wl=self.wl, wl_size=self.wl.size)
+        return self.parse_file(
+            file=file,
+            wl=self.wl,
+            multipart_transmittance=self.multipart_transmittance,
+            wl_size=self.wl.size,
+        )
 
     def postSim(self):
         """
@@ -201,18 +190,9 @@ class SixSRT(RadiativeTransferEngine):
         sixS = os.path.join(self.engine_base_dir, "sixsV2.1")  # 6S Emulator path
         name = self.point_to_filename(point)
 
-        if self.multipart_transmittance:
-            outp = os.path.join(self.sim_path, name, f"{name}_{wlinf}")  # Output path
-            inpt = os.path.join(
-                self.sim_path, name, f"LUT_{name}_{wlinf}.inp"
-            )  # Input path
-            bash = os.path.join(
-                self.sim_path, name, f"LUT_{name}_{wlinf}.sh"
-            )  # Script path
-        else:
-            outp = os.path.join(self.sim_path, name)  # Output path
-            inpt = os.path.join(self.sim_path, f"LUT_{name}.inp")  # Input path
-            bash = os.path.join(self.sim_path, f"LUT_{name}.sh")  # Script path
+        outp = os.path.join(self.sim_path, name)  # Output path
+        inpt = os.path.join(self.sim_path, f"LUT_{name}.inp")  # Input path
+        bash = os.path.join(self.sim_path, f"LUT_{name}.sh")  # Script path
 
         # Prepare template values
         vals = {
@@ -292,7 +272,7 @@ class SixSRT(RadiativeTransferEngine):
         self.irr_factor = self.esd[self.day_of_year - 1, 1]
 
     @staticmethod
-    def parse_file(file, wl, wl_size=0) -> dict:
+    def parse_file(file, wl, multipart_transmittance=False, wl_size=0) -> dict:
         """
         Parses a 6S sim file
 
@@ -302,6 +282,8 @@ class SixSRT(RadiativeTransferEngine):
             Path to simulation file to parse
         wl: np.array
             Simulation wavelengths
+        multipart_transmittance: bool
+            Flag to tell program to parse up-down split transmittances
         wl_size: int, default=0
             Size of the wavelengths dim, will trim data to this size. If zero, does no
             trimming
@@ -325,122 +307,29 @@ class SixSRT(RadiativeTransferEngine):
         """
         path, name = os.path.split(file)
 
-        # multipart transmittance mode
-        if os.path.isdir(file):
-            # in multipart transmittance mode, we need to read 6s results for ech wavelength separately
-            # extractions from the 6s output file include TOA solar irradiance,
-            # as well as direct and diffuse incoming flux at the surface
-            sza = None
-            I = np.zeros(len(wl))
-            Edir = np.zeros(len(wl))
-            Edif = np.zeros(len(wl))
-            rhoatm = np.zeros(len(wl))
-            sphalb = np.zeros(len(wl))
-            gt = np.zeros(len(wl))
-            scat = np.zeros(len(wl))
+        inpt = os.path.join(path, f"LUT_{name}.inp")
 
-            for ind, sim in enumerate(wl):
-                file_dir = os.path.join(file, f"{name}_{sim}")
+        with open(file, "r") as f:
+            lines = f.readlines()
 
-                with open(file_dir, "r") as f:
-                    lines = f.readlines()
+        with open(inpt, "r") as f:
+            solzen = float(f.readlines()[1].strip().split()[0])
+        coszen = np.cos(solzen / 360 * 2.0 * np.pi)
 
-                values = {}
-                current = 0
+        # `data` stores the return values, `append` will append to existing keys and creates them if they don't
+        # Easy append to keys whether they exist or not
+        data = {}
+        append = lambda key, val: data.setdefault(key, []).append(val)
 
-                extractors = {
-                    "solar zenith angle": (current, 4, "solar_zenith_angle", float),
-                    "swl": (3, 6, "TOA_solar_irradiance", float),
-                    "direct solar irr.": (1, 1, "direct_solar_irradiance", float),
-                    "atm. diffuse irr.": (1, 2, "diffuse_solar_irradiance", float),
-                    "atm. intrin. ref.": (1, 1, "path_reflectance", float),
-                    "spherical albedo": (0, 6, "spherical_albedo", float),
-                    "global gas. trans.": (0, 6, "upward_gas_transmittance", float),
-                    "total  sca.": (0, 6, "upward_scattering_transmittance", float),
-                }
+        start = None
+        start_multi = None
+        for end, line in enumerate(lines):
+            if start is not None:
+                # Find all ints/floats for this line
+                tokens = re.findall(r"NaN|\d+\.?\d+", line.replace("******", "0.0"))
 
-                for index in range(len(lines)):
-                    current_line = lines[index]
-
-                    for label, details in extractors.items():
-                        if label.lower() in current_line.lower():
-                            # See if the data is in the current line (as specified above)
-                            if details[0] == current:
-                                extracting_line = current_line
-                            # Otherwise, work out which line to use and get it
-                            else:
-                                extracting_line = lines[index + details[0]]
-
-                            funct = details[3]
-                            items = extracting_line.split()
-                            a = details[1]
-                            data_for_func = items[a]
-                            values[details[2]] = funct(data_for_func)
-
-                sza = values["solar_zenith_angle"]
-                I[ind] = values["TOA_solar_irradiance"]
-                Edir[ind] = values["direct_solar_irradiance"]
-                Edif[ind] = values["diffuse_solar_irradiance"]
-                rhoatm[ind] = values["path_reflectance"]
-                sphalb[ind] = values["spherical_albedo"]
-                gt[ind] = values["upward_gas_transmittance"]
-                scat[ind] = values["upward_scattering_transmittance"]
-
-            # some very little algebra to get needed atmospheric functions
-            coszen = np.cos(np.deg2rad(sza))
-            t_dir_down = Edir / I / coszen
-            t_dif_down = Edif / I / coszen
-            t_up_total = gt * scat
-
-            data = {
-                "transm_down_dir": t_dir_down,
-                "transm_down_dif": t_dif_down,
-                "transm_up_dir": t_up_total,
-                "rhoatm": rhoatm,
-                "sphalb": sphalb,
-            }
-
-            total = len(wl)
-            if total < wl_size:
-                Logger.error(
-                    f"The following file parsed shorter than expected ({wl_size}), got ({total}): {file}"
-                )
-
-            # Cast to numpy and trim excess
-            data = {k: np.array(v) for k, v in data.items()}
-            if wl_size > 0:
-                data = {k: v[:wl_size] for k, v in data.items()}
-
-            # Add extras
-            data["solzen"] = sza
-            data["coszen"] = coszen
-        else:
-            path, name = os.path.split(file)
-
-            inpt = os.path.join(path, f"LUT_{name}.inp")
-
-            with open(file, "r") as f:
-                lines = f.readlines()
-
-            with open(inpt, "r") as f:
-                solzen = float(f.readlines()[1].strip().split()[0])
-            coszen = np.cos(solzen / 360 * 2.0 * np.pi)
-
-            # `data` stores the return values, `append` will append to existing keys and creates them if they don't
-            # Easy append to keys whether they exist or not
-            data = {}
-            append = lambda key, val: data.setdefault(key, []).append(val)
-
-            start = None
-            for end, line in enumerate(lines):
-                if start is not None:
-                    # Find all ints/floats for this line
-                    tokens = re.findall(r"NaN|\d+\.?\d+", line.replace("******", "0.0"))
-
-                    # End of table
-                    if len(tokens) != 11:
-                        break
-
+                # End of table
+                if len(tokens) == 11:
                     (  # Split the tokens
                         w,
                         gt,
@@ -454,43 +343,70 @@ class SixSRT(RadiativeTransferEngine):
                         dsol,
                         toar,
                     ) = tokens
-
-                    # Preprocess the tokens and prepare to save them to LUT
-                    # transm = float(scau) * float(scad) * float(gt)
-
                     append("grid", float(w))
                     append("sphalb", float(salb))
                     append("rhoatm", float(rhoa))
-                    append("transm_down_dif", float(scau) * float(scad) * float(gt))
-                    # REVIEW: How should these be populated?
-                    # append("transm_down_dir", None)
-                    # append("transm_up_dir", None)
-                    # append("transm_up_dif", None)
 
-                # Found beginning of table
-                elif line.startswith("*        trans  down   up"):
-                    start = end
+                    # Only append this if not a multipart_transm run
+                    if not multipart_transmittance:
+                        append("transm_down_dif", float(scau) * float(scad) * float(gt))
 
-            if start is None:
-                Logger.error(f"Failed to parse any data for file: {file}")
-                return {}
+            # Found beginning of primary table
+            elif line.startswith("*        trans  down   up"):
+                start = end
 
-            total = len(data["grid"])
-            if total < wl_size:
-                Logger.error(
-                    f"The following file parsed shorter than expected ({wl_size}), got ({total}): {file}"
-                )
+            if start_multi and len(tokens) == 5 and multipart_transmittance:
+                (
+                    w,
+                    tddir,
+                    tddif,
+                    tudir,
+                    tudif,
+                ) = tokens
+                append("transm_down_dir", float(tddir))
+                append("transm_down_dif", float(tddif))
+                append("transm_up_dir", float(tudir))
+                append("transm_up_dif", float(tudif))
 
-            # Cast to numpy and trim excess
-            data = {k: np.array(v) for k, v in data.items()}
-            if wl_size > 0:
-                data = {k: v[:wl_size] for k, v in data.items()}
+            # Found beginning of multipart table
+            elif line.startswith("*           down      down      up"):
+                start_multi = end
 
-            # Add extras
-            data["solzen"] = solzen
-            data["coszen"] = coszen
+            # Two break conditions:
+            # You hit the multipart_transm part of file and don't use it
+            if start_multi and not multipart_transmittance:
+                break
 
-            # Remove before saving to LUT file since this doesn't go in there
-            data.pop("grid")
+            # You move past the multipart_transm part of file
+            elif line.startswith("*                         integrated values of"):
+                break
+
+        if start is None:
+            Logger.error(f"Failed to parse any data for file: {file}")
+            return {}
+
+        if start_multi is None and multipart_transmittance:
+            Logger.error(
+                f"Failed to parse any multipart transmittance data for file: {file}"
+            )
+            return {}
+
+        total = len(data["grid"])
+        if total < wl_size:
+            Logger.error(
+                f"The following file parsed shorter than expected ({wl_size}), got ({total}): {file}"
+            )
+
+        # Cast to numpy and trim excess
+        data = {k: np.array(v) for k, v in data.items()}
+        if wl_size > 0:
+            data = {k: v[:wl_size] for k, v in data.items()}
+
+        # Add extras
+        data["solzen"] = solzen
+        data["coszen"] = coszen
+
+        # Remove before saving to LUT file since this doesn't go in there
+        data.pop("grid")
 
         return data


### PR DESCRIPTION
Changes to the engines/six_s.py file to handle 6s outputs that now can provide separated upwards, downwards, direct and diffuse transmittance. 

Note: parse_file function is specific to how we've changed the output files. The outputs are also specific to an edited version of 6s.

Separated 6s transmittance:
![Multipart_transm_from_6s](https://github.com/user-attachments/assets/a45717af-db10-4914-81a4-fa166cee28a6)

Total 6s transmittance from separated values and dev-branch total transmittance:
![Reconstructing_total_transm](https://github.com/user-attachments/assets/50ec6a6d-2898-4243-9aac-51435a106428)
