### PR TITLE
Simplified  Logging

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -743,7 +743,10 @@ def ray_start(num_cores, num_cpus=2, memory_b=-1):
         result = subprocess.run(base_args, capture_output=True)
 
 
+import logging
 from datetime import datetime as dtt
+
+Logger = logging.getLogger(__file__)
 
 
 class Track:
@@ -799,14 +802,13 @@ class Track:
             current = 1 - current
         current *= 100
 
+        self.elap = dtt.now() - self.start
         if current >= self.percent:
-            elap = dtt.now() - self.start
-            rate = elap / self.total
-            esti = 100 / self.percent * elap - elap
+            rate = self.elap / self.total
+            esti = 100 / self.percent * self.elap - self.elap
 
-            self.print(
-                f"{current:6.2f}% {self.message} (elapsed: {elap}, rate: {rate}, eta: {esti})"
-            )
+            Logger.info(f"{current:6.2f}% {self.message}")
+            Logger.debug(f"Elapsed: {self.elap}, ETA: {esti}")
             self.percent += self.step
 
             return True

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -531,14 +531,15 @@ class IO:
             flush_immediately: IO argument telling us to immediately write to disk, ignoring config settings
 
         """
-
+        logging.debug(
+            f"Writing datasets for ({row}, {col}): {list(self.output_datasets)}"
+        )
         for product in self.output_datasets:
-            logging.debug("IO: Writing " + product)
             self.output_datasets[product].write_spectrum(row, col, output[product])
 
         # Special case! samples file is matlab format.
         if self.config.output.mcmc_samples_file is not None:
-            logging.debug("IO: Writing mcmc_samples_file")
+            logging.debug("Writing mcmc_samples_file")
             mdict = {"samples": states}
             scipy.io.savemat(self.config.output.mcmc_samples_file, mdict)
 

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -28,7 +28,7 @@ import click
 import numpy as np
 from spectral.io import envi
 
-from isofit import ray
+from isofit import ray, setupLogging
 from isofit.configs import configs
 from isofit.core.common import envi_header, load_spectrum
 from isofit.core.fileio import IO, write_bil_chunk
@@ -237,12 +237,8 @@ class Worker(object):
             loglevel: output logging level
             logfile: output logging file
         """
-        logging.basicConfig(
-            format="%(levelname)s:%(asctime)s ||| %(message)s",
-            level=loglevel,
-            filename=logfile,
-            datefmt="%Y-%m-%d,%H:%M:%S",
-        )
+        setupLogging(level=loglevel, path=logfile)
+
         self.config = config
         self.fm = fm
         self.iv = Inversion(self.config, self.fm)

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -16,6 +16,7 @@ import ray
 from spectral.io import envi
 
 import isofit.utils.template_construction as tmpl
+from isofit import setupLogging
 from isofit.core import isofit
 from isofit.core.common import envi_header
 from isofit.utils import analytical_line as ALAlg
@@ -219,12 +220,7 @@ def apply_oe(
                 "If num_neighbors has multiple elements, only --analytical_line is valid"
             )
 
-    logging.basicConfig(
-        format="%(levelname)s:%(asctime)s || %(filename)s:%(funcName)s() | %(message)s",
-        level=logging_level,
-        filename=log_file,
-        datefmt="%Y-%m-%d,%H:%M:%S",
-    )
+    setupLogging(path=f"{working_directory}/logs", reset=True)
 
     logging.info("Checking input data files...")
     rdn_dataset = envi.open(envi_header(input_radiance))
@@ -546,13 +542,7 @@ def apply_oe(
 
             # Run modtran retrieval
             logging.info("Run ISOFIT initial guess")
-            retrieval_h2o = isofit.Isofit(
-                paths.h2o_config_path,
-                level="INFO",
-                logfile=log_file,
-            )
-            retrieval_h2o.run()
-            del retrieval_h2o
+            isofit.Isofit(paths.h2o_config_path).run()
 
             # clean up unneeded storage
             if emulator_base is None:
@@ -649,11 +639,7 @@ def apply_oe(
 
         # Run retrieval
         logging.info("Running ISOFIT with full LUT")
-        retrieval_full = isofit.Isofit(
-            paths.isofit_full_config_path, level="INFO", logfile=log_file
-        )
-        retrieval_full.run()
-        del retrieval_full
+        isofit.Isofit(paths.isofit_full_config_path).run()
 
         # clean up unneeded storage
         if emulator_base is None:

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -27,7 +27,7 @@ from scipy.ndimage import gaussian_filter
 from scipy.spatial import KDTree
 from spectral.io import envi
 
-from isofit import ray
+from isofit import ray, setupLogging
 from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
 
@@ -257,12 +257,7 @@ def atm_interpolation(
     if n_cores == -1:
         n_cores = multiprocessing.cpu_count()
 
-    logging.basicConfig(
-        format="%(levelname)s:%(asctime)s ||| %(message)s",
-        level=loglevel,
-        filename=logfile,
-        datefmt="%Y-%m-%d,%H:%M:%S",
-    )
+    setupLogging(level=loglevel, path=logfile)
 
     reference_state_img = envi.open(envi_header(reference_state_file))
     input_locations_img = envi.open(envi_header(input_locations_file))

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -23,7 +23,7 @@ import logging
 import numpy as np
 from spectral.io import envi
 
-from isofit import ray
+from isofit import ray, setupLogging
 from isofit.core.common import envi_header
 from isofit.core.fileio import write_bil_chunk
 
@@ -54,13 +54,7 @@ def extract_chunk(
         out_index: array of output indices (based on labels)
         out_data: array of output data
     """
-
-    logging.basicConfig(
-        format="%(levelname)s:%(asctime)s ||| %(message)s",
-        level=loglevel,
-        filename=logfile,
-        datefmt="%Y-%m-%d,%H:%M:%S",
-    )
+    setupLogging(level=loglevel, path=logfile)
     logging.info(f"{lstart}: starting")
 
     in_img = envi.open(envi_header(in_file))

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -26,7 +26,7 @@ import skimage
 from skimage.segmentation import slic
 from spectral.io import envi
 
-from isofit import ray
+from isofit import ray, setupLogging
 from isofit.core.common import envi_header
 
 
@@ -53,12 +53,7 @@ def segment_chunk(
         labels: labeled image chunk
 
     """
-    logging.basicConfig(
-        format="%(levelname)s:%(asctime)s ||| %(message)s",
-        level=loglevel,
-        filename=logfile,
-        datefmt="%Y-%m-%d,%H:%M:%S",
-    )
+    setupLogging(level=loglevel, path=logfile)
 
     logging.info(f"{lstart}: starting")
 
@@ -177,10 +172,7 @@ def segment(
         loglevel: logging level to use
 
     """
-
-    logging.basicConfig(
-        format="%(levelname)s:%(message)s", level=loglevel, filename=logfile
-    )
+    setupLogging(level=loglevel, path=logfile)
 
     in_file = spectra[0]
     if len(spectra) > 1 and type(spectra) is tuple:


### PR DESCRIPTION
Aiming to improve the logging scheme of ISOFIT by:
- Reducing the verbosity of certain functions in `INFO`
- Focusing`DEBUG` statements to be more useful to developers

A new utility function, `setupLogging`, has been implemented that supports three scenarios:
- No log file set
  - Logs only to the console/terminal
- Log file set to a file path (has an extension)
  - Logs `DEBUG` to the file
- Log file set to a directory path
  - Logs both `INFO` and `DEBUG` to independent files under that directory

In all three cases, setting the `level` for the function sets the level for the console. Files are always set to `DEBUG`. This reduces the verbosity for the user while retaining important log information in case an issue arises and needs developer attention. 

---

Additionally, this PR implements a rather large structural change to `core/isofit.py`; instead of having ray worker objects process pixel-wise inversions over a chunk, this module now distributes each pixel inversion as an independent job. This enables the module to take a similar implementation as the RTE simulations and report every 10% completion. Load balancing should now be more consistently dense as ray handles the balancing rather than our workers potentially being faster/slower than other workers. 

This is still being tested

Builds upon PR #581 