### PR TITLE
Sensor altitude check.

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -415,7 +415,7 @@ def apply_oe(args):
 
     if mean_altitude_km < 0:
         raise ValueError(
-            "Detected sensor altitude is negative, which is physically implausible and cannot be handled by ISOFIT."
+            "Detected sensor altitude is negative, which is very unlikely and cannot be handled by ISOFIT."
             "Please check your input files and adjust."
         )
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -413,6 +413,12 @@ def apply_oe(args):
         mean_elevation_km + np.cos(np.deg2rad(mean_to_sensor_zenith)) * mean_path_km
     )
 
+    if mean_altitude_km < 0:
+        raise ValueError(
+            "Detected sensor altitude is negative, which is physically implausible and cannot be handled by ISOFIT."
+            "Please check your input files and adjust."
+        )
+
     logging.info("Observation means:")
     logging.info(f"Path (km): {mean_path_km}")
     logging.info(f"To-sensor azimuth (deg): {mean_to_sensor_azimuth}")


### PR DESCRIPTION
Both MODTRAN and 6s cannot handle negative sensor altitudes, which are physically implausible anyway. This PR adds a check that raises a `ValueError` in case detected `mean_altitude_km < 0`.