### PR TITLE
Update data documentation

### DIFF
--- a/docs/source/custom/data.rst
+++ b/docs/source/custom/data.rst
@@ -299,8 +299,8 @@ The small image cube example's ``default.args.json`` is currently defined as:
 
     [
     "{imagecube}/medium/ang20170323t202244_rdn_7k-8k",
-    "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
     "{imagecube}/medium/ang20170323t202244_loc_7k-8k",
+    "{imagecube}/medium/ang20170323t202244_obs_7k-8k",
     "{examples}/image_cube/medium",
     "ang",
     "--surface_path {examples}/image_cube/medium/configs/surface.json",
@@ -317,8 +317,8 @@ This will generate ``default.sh``:
 
     isofit apply_oe \
       ~/.isofit/examples/imagecube/small/ang20170323t202244_rdn_7000-7010 \
-      ~/.isofit/examples/imagecube/small/ang20170323t202244_obs_7000-7010 \
       ~/.isofit/examples/imagecube/small/ang20170323t202244_loc_7000-7010 \
+      ~/.isofit/examples/imagecube/small/ang20170323t202244_obs_7000-7010 \
       ~/.isofit/examples/examples/image_cube/small \
       ang \
       --surface_path ~/.isofit/examples/examples/image_cube/small/configs/surface.json \


### PR DESCRIPTION
The templates for the small and medium image cube examples showed the wrong order of input loc and obs files, leading to failing runs.  This PR updates the documentation respectively.

Prior to merging this PR, [#12](https://github.com/isofit/isofit-tutorials/pull/12) of the ISOFIT tutorials repo should be merged following a new release.