### PR TITLE
Changes to get configure_and_exit flag to work

### DIFF
--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -320,12 +320,12 @@ class ModtranRT(RadiativeTransferEngine):
             Logger.warning(f"File already exists, skipping execution: {filename_base}")
             return
 
-        if self.engine_config.rte_configure_and_exit:
-            return
-
         # write_config_file
         with open(infilepath, "w") as f:
             f.write(modtran_config_str)
+
+        if self.engine_config.rte_configure_and_exit:
+            return
 
         # Specify location of the proper MODTRAN 6.0 binary for this OS
         xdir = {"linux": "linux", "darwin": "macos", "windows": "windows"}

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -472,7 +472,7 @@ class RadiativeTransferEngine:
             )
 
             # Update the lut as point simulations stream in
-            while jobs and not self.engine_config.rte_configure_and_exit:
+            while jobs:
                 [done], jobs = ray.wait(jobs, num_returns=1)
 
                 # Retrieve the return of the finished job

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -472,7 +472,7 @@ class RadiativeTransferEngine:
             )
 
             # Update the lut as point simulations stream in
-            while jobs:
+            while jobs and not rte_configure_and_exit:
                 [done], jobs = ray.wait(jobs, num_returns=1)
 
                 # Retrieve the return of the finished job

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -472,7 +472,7 @@ class RadiativeTransferEngine:
             )
 
             # Update the lut as point simulations stream in
-            while jobs and not rte_configure_and_exit:
+            while jobs and not self.engine_config.rte_configure_and_exit:
                 [done], jobs = ray.wait(jobs, num_returns=1)
 
                 # Retrieve the return of the finished job


### PR DESCRIPTION
This accompanies: https://github.com/pgbrodrick/sRTMnet/pull/1

Two changes here. 
The first is simple. the configure and exit flag was exiting the function before the .json files were being written.

The second is a little bit stranger. I was getting a silent failure when initiating the 6s RT engine initialization (with configure-and_exit). The class call would successfully exit, but not write the files. The added check here will only enter the logging/run status check portion for when the RTE actually runs only if the configure_and_exit flag isn't used.  It seemed to fix the issue.