### PR TITLE
Fix workflows cache rate limiting

### DIFF
--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -82,7 +82,7 @@ jobs:
           key: ${{ env.cache-name }}
 
       - name: Download extras
-        if: ${{ steps.cache-extras.outputs.cache-hit != true }}
+        if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           isofit -b extras download all

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -34,18 +34,19 @@ concurrency:
 jobs:
   # Create a cache before matrix jobs
   cache:
-    - name: Cached Extras
-      id: cache-extras
-      uses: actions/cache@v3
-      with:
-        path: extras
-        key: cache-extras-test
-    - name: Download extras
-      if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
-      shell: bash
-      run: |
-        isofit -b extras download all
-        isofit build
+    steps:
+      - name: Cached Extras
+        id: cache-extras
+        uses: actions/cache@v3
+        with:
+          path: extras
+          key: cache-extras-test
+      - name: Download extras
+        if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          isofit -b extras download all
+          isofit build
 
   test:
     needs: cache

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -42,15 +42,35 @@ jobs:
         with:
           path: extras
           key: cache-extras-test
+
+  download:
+    needs: cache
+    if: ${{ jobs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
+    runs-on: ubuntu-latest
+      - uses: actions/checkout@v3
+
+      - name: Print concurrency group
+        run: echo '${{ github.workflow }}-${{ github.ref }}'
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install ISOFIT
+        shell: bash
+        run: |
+          python3 -m pip install --editable ".[test]"
+
       - name: Download extras
-        if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           isofit -b extras download all
           isofit build
 
   test:
-    needs: cache
+    needs: [cache, download]
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -33,16 +33,6 @@ concurrency:
 
 jobs:
   # Create a cache before matrix jobs
-  # cache:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Pull Cached Extras
-  #       id: cache-extras
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: .isofit
-  #         key: cache-extras-test
-
   cache:
     runs-on: ubuntu-latest
     steps:
@@ -92,12 +82,12 @@ jobs:
 
     steps:
       # Pull the cache on every runner
-      # - name: Cached Extras
-      #   id: cache-extras
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: extras
-      #     key: cache-extras-test
+      - name: Cached Extras
+        id: cache-extras
+        uses: actions/cache@v3
+        with:
+          path: extras
+          key: cache-extras-test
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -33,45 +33,55 @@ concurrency:
 
 jobs:
   # Create a cache before matrix jobs
+  # cache:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Pull Cached Extras
+  #       id: cache-extras
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: .isofit
+  #         key: cache-extras-test
+
   cache:
     runs-on: ubuntu-latest
     steps:
-      - name: Cached Extras
+      - name: Cache Extras
         id: cache-extras
         uses: actions/cache@v3
         with:
-          path: extras
+          path: .isofit
           key: cache-extras-test
 
-  download:
-    needs: cache
-    if: ${{ needs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@v3
 
-      - name: Print concurrency group
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        name: Print concurrency group
         run: echo '${{ github.workflow }}-${{ github.ref }}'
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install ISOFIT
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        name: Install ISOFIT
         shell: bash
         run: |
           python3 -m pip install --editable ".[test]"
 
-      - name: Download extras
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        name: Download extras
         shell: bash
         run: |
-          isofit -b extras download all
+          isofit download all
           isofit build
 
   test:
-    needs: [cache, download]
+    needs: cache
 
     runs-on: ubuntu-latest
     strategy:
@@ -81,6 +91,13 @@ jobs:
         pytest-flags: ["-m unmarked", "-m slow", "-m examples"]
 
     steps:
+      # Pull the cache on every runner
+      # - name: Cached Extras
+      #   id: cache-extras
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: extras
+      #     key: cache-extras-test
 
       - uses: actions/checkout@v3
 
@@ -109,16 +126,6 @@ jobs:
 
           # Ensure ISOFIT has been installed
           python3 -c "import isofit; print(isofit.__file__)"
-
-      # Pull the cache on every runner
-      # - name: Cached Extras
-      #   id: cache-extras
-      #   uses: actions/cache@v3
-      #   env:
-      #     cache-name: cache-extras
-      #   with:
-      #     path: extras
-      #     key: ${{ env.cache-name }}
 
       - name: Execute tests
         shell: bash

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           path: extras
           key: cache-extras-test
+          fail-on-cache-miss: true
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -37,11 +37,9 @@ jobs:
     - name: Cached Extras
       id: cache-extras
       uses: actions/cache@v3
-      env:
-        cache-name: cache-extras
       with:
         path: extras
-        key: ${{ env.cache-name }}
+        key: cache-extras-test
     - name: Download extras
       if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
       shell: bash

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -32,8 +32,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Create a cache before matrix jobs
+  cache:
+    - name: Cached Extras
+      id: cache-extras
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-extras
+      with:
+        path: extras
+        key: ${{ env.cache-name }}
+    - name: Download extras
+      if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        isofit -b extras download all
+        isofit build
 
   test:
+    needs: cache
 
     runs-on: ubuntu-latest
     strategy:
@@ -72,21 +89,15 @@ jobs:
           # Ensure ISOFIT has been installed
           python3 -c "import isofit; print(isofit.__file__)"
 
-      - name: Cached Extras
-        id: cache-extras
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-extras
-        with:
-          path: extras
-          key: ${{ env.cache-name }}
-
-      - name: Download extras
-        if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
-        shell: bash
-        run: |
-          isofit -b extras download all
-          isofit build
+      # Pull the cache on every runner
+      # - name: Cached Extras
+      #   id: cache-extras
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-extras
+      #   with:
+      #     path: extras
+      #     key: ${{ env.cache-name }}
 
       - name: Execute tests
         shell: bash

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   # Create a cache before matrix jobs
   cache:
+    runs-on: ubuntu-latest
     steps:
       - name: Cached Extras
         id: cache-extras

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -47,6 +47,7 @@ jobs:
     needs: cache
     if: ${{ jobs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
     runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v3
 
       - name: Print concurrency group

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -50,7 +50,7 @@ jobs:
         id: cache-extras
         uses: actions/cache@v3
         with:
-          path: .isofit
+          path: ~/.isofit
           key: cache-extras-test
 
       - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.isofit
-          key: cache-extras-test
+          key: cache-extras
 
       - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
         uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: extras
-          key: cache-extras-test
+          key: cache-extras
           fail-on-cache-miss: true
 
       - uses: actions/checkout@v3

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -45,7 +45,7 @@ jobs:
 
   download:
     needs: cache
-    if: ${{ jobs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
+    if: ${{ needs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-pip-package-ubuntu.yml
+++ b/.github/workflows/test-pip-package-ubuntu.yml
@@ -86,7 +86,7 @@ jobs:
         id: cache-extras
         uses: actions/cache@v3
         with:
-          path: extras
+          path: ~/.isofit
           key: cache-extras
           fail-on-cache-miss: true
 

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.isofit
-          key: cache-extras-test
+          key: cache-extras
 
       - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
         uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: extras
-          key: cache-extras-test
+          key: cache-extras
           fail-on-cache-miss: true
 
       - uses: actions/checkout@v3

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -17,11 +17,9 @@ jobs:
     - name: Cached Extras
       id: cache-extras
       uses: actions/cache@v3
-      env:
-        cache-name: cache-extras
       with:
         path: extras
-        key: ${{ env.cache-name }}
+        key: cache-extras-test
     - name: Download extras
       if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
       shell: bash

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -1,155 +1,147 @@
-# Test ISOFIT installed via a local repository checkout and '$PYTHONPATH'.
-
-name: Test '$PYTHONPATH' installation
-
-on:
-  push:
-    branches: ["dev", "main"]
-  pull_request:
-    branches: ["dev", "main"]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-jobs:
-  cache:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cached Extras
-        id: cache-extras
-        uses: actions/cache@v3
-        with:
-          path: extras
-          key: cache-extras-test
-      - name: Download extras
-        if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
-        shell: bash
-        run: |
-          isofit -b extras download all
-          isofit build
-
-  download:
-    needs: cache
-    if: ${{ needs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Print concurrency group
-        run: echo '${{ github.workflow }}-${{ github.ref }}'
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-
-      - name: Install ISOFIT
-        shell: bash
-        run: |
-          python3 -m pip install --editable ".[test]"
-
-      - name: Download extras
-        shell: bash
-        run: |
-          isofit -b extras download all
-          isofit build
-
-  test:
-    needs: [cache, download]
-
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # This tests some very basic and long-lived Python behavior, so it is
-        # likely sufficient to test only on a single Python version to avoid
-        # GitHub worker contention.
-        python-version: ["3.12"]
-        pytest-flags: ["-m unmarked", "-m slow"]
-
-    steps:
-
-      - uses: actions/checkout@v3
-
-      - name: Print concurrency group
-        run: echo '${{ github.workflow }}-${{ github.ref }}'
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-
-      - name: Install ISOFIT and most software dependencies
-        shell: bash
-        run: |
-
-          # WARNING: Do NOT 'export PYTHONPATH=...'. Environment variables seem
-          #          to be shared across all jobs, so this would break the
-          #          the 'isofit' install for some other jobs. Unclear exactly
-          #          which, but presumably any job running after this one.
-
-          # Python packaging dependencies. The presence of 'wheel' triggers
-          # a lot of new Python packaging machinery that will eventually
-          # become the default.
-          python3 -m pip install pip setuptools wheel --upgrade
-          python3 --version
-          python3 -m pip show pip setuptools wheel
-
-          # Install 'isofit' and dependencies. Be sure to uninstall this version
-          # of 'isofit' to ensure we are testing against '$PYTHONPATH'.
-          python3 -m pip install ".[test]"
-
-      # - name: Cached Extras
-      #   id: cache-extras
-      #   uses: actions/cache@v3
-      #   env:
-      #     cache-name: cache-extras
-      #   with:
-      #     path: extras
-      #     key: ${{ env.cache-name }}
-
-      - name: Isolate ISOFIT
-        shell: bash
-        run: |
-          # Uninstall 'isofit', leaving its dependencies.
-          python3 -m pip uninstall --yes isofit
-
-          # Move 'isofit' into a new directory to ensure it is not just inherently available.
-          mkdir isolation/
-          mv isofit/ isolation/
-
-          # Check to see if 'isofit' is still installed. It should not be.
-          # Note that this job is implicitly configured with 'set -e', which
-          # means that any command exiting with a non-zero exit code will cause
-          # the script to halt. The easiest way to see if 'isofit' is still
-          # available is to attempt to import it, however, that rightfully
-          # causes Python to exit with a non-zero exit code. It is possible to
-          # use a heredoc to wrap this import in a 'try/except', print a status,
-          # and have Python exit with a 0 exit code, but all of the options are
-          # painful.
-          #
-          # Instead, disable 'set -e' by calling 'set +e', but be sure to
-          # re-enable by calling 'set -e' again as soon as possible!!
-          set +e
-          ISOFIT_INSTALLED_PATH=$(
-            python3 -c "import isofit; print(isofit.__file__)" 2> /dev/null)
-          ISOFIT_INSTALLED_EXIT_CODE=$?
-          set -e
-          if [ "${ISOFIT_INSTALLED_EXIT_CODE}" -ne 1 ]; then
-              exit 1
-          fi
-
-          # Again, do NOT 'export PYTHONPATH=...' here. See note at top of section.
-
-      - name: Execute tests
-        shell: bash
-        run: |
-
-          # Again, do NOT 'export PYTHONPATH=...'
-          # We define 'testpaths' in 'pytest.ini', however that path is no
-          # longer valid. In this case 'pytest' searches for tests by default,
-          # but we know where they are, so explicitly point to the new location.
-          PYTHONPATH="isolation/:${PYTHONPATH}" python3 -m pytest -s isolation/isofit/test/ "${{ matrix.pytest-flags }}"
+# # Test ISOFIT installed via a local repository checkout and '$PYTHONPATH'.
+#
+# name: Test '$PYTHONPATH' installation
+#
+# on:
+#   push:
+#     branches: ["dev", "main"]
+#   pull_request:
+#     branches: ["dev", "main"]
+#
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
+#
+# jobs:
+#   cache:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Cached Extras
+#         id: cache-extras
+#         uses: actions/cache@v3
+#         with:
+#           path: .isofit
+#           key: cache-extras-test
+#
+#   download:
+#     needs: cache
+#     if: ${{ needs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#
+#       - name: Print concurrency group
+#         run: echo '${{ github.workflow }}-${{ github.ref }}'
+#
+#       - name: Set up Python ${{ matrix.python-version }}
+#         uses: actions/setup-python@v3
+#         with:
+#           python-version: '3.12'
+#           cache: 'pip'
+#
+#       - name: Install ISOFIT
+#         shell: bash
+#         run: |
+#           python3 -m pip install --editable ".[test]"
+#
+#       - name: Download extras
+#         shell: bash
+#         run: |
+#           isofit download all
+#           isofit build
+#
+#   test:
+#     needs: [cache, download]
+#
+#     runs-on: ubuntu-latest
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         # This tests some very basic and long-lived Python behavior, so it is
+#         # likely sufficient to test only on a single Python version to avoid
+#         # GitHub worker contention.
+#         python-version: ["3.12"]
+#         pytest-flags: ["-m unmarked", "-m slow"]
+#
+#     steps:
+#       # Pull the cache on every runner
+#       # - name: Cached Extras
+#       #   id: cache-extras
+#       #   uses: actions/cache@v3
+#       #   with:
+#       #     path: extras
+#       #     key: cache-extras-test
+#
+#       - uses: actions/checkout@v3
+#
+#       - name: Print concurrency group
+#         run: echo '${{ github.workflow }}-${{ github.ref }}'
+#
+#       - name: Set up Python ${{ matrix.python-version }}
+#         uses: actions/setup-python@v3
+#         with:
+#           python-version: ${{ matrix.python-version }}
+#           cache: 'pip'
+#
+#       - name: Install ISOFIT and most software dependencies
+#         shell: bash
+#         run: |
+#
+#           # WARNING: Do NOT 'export PYTHONPATH=...'. Environment variables seem
+#           #          to be shared across all jobs, so this would break the
+#           #          the 'isofit' install for some other jobs. Unclear exactly
+#           #          which, but presumably any job running after this one.
+#
+#           # Python packaging dependencies. The presence of 'wheel' triggers
+#           # a lot of new Python packaging machinery that will eventually
+#           # become the default.
+#           python3 -m pip install pip setuptools wheel --upgrade
+#           python3 --version
+#           python3 -m pip show pip setuptools wheel
+#
+#           # Install 'isofit' and dependencies. Be sure to uninstall this version
+#           # of 'isofit' to ensure we are testing against '$PYTHONPATH'.
+#           python3 -m pip install ".[test]"
+#
+#       - name: Isolate ISOFIT
+#         shell: bash
+#         run: |
+#           # Uninstall 'isofit', leaving its dependencies.
+#           python3 -m pip uninstall --yes isofit
+#
+#           # Move 'isofit' into a new directory to ensure it is not just inherently available.
+#           mkdir isolation/
+#           mv isofit/ isolation/
+#
+#           # Check to see if 'isofit' is still installed. It should not be.
+#           # Note that this job is implicitly configured with 'set -e', which
+#           # means that any command exiting with a non-zero exit code will cause
+#           # the script to halt. The easiest way to see if 'isofit' is still
+#           # available is to attempt to import it, however, that rightfully
+#           # causes Python to exit with a non-zero exit code. It is possible to
+#           # use a heredoc to wrap this import in a 'try/except', print a status,
+#           # and have Python exit with a 0 exit code, but all of the options are
+#           # painful.
+#           #
+#           # Instead, disable 'set -e' by calling 'set +e', but be sure to
+#           # re-enable by calling 'set -e' again as soon as possible!!
+#           set +e
+#           ISOFIT_INSTALLED_PATH=$(
+#             python3 -c "import isofit; print(isofit.__file__)" 2> /dev/null)
+#           ISOFIT_INSTALLED_EXIT_CODE=$?
+#           set -e
+#           if [ "${ISOFIT_INSTALLED_EXIT_CODE}" -ne 1 ]; then
+#               exit 1
+#           fi
+#
+#           # Again, do NOT 'export PYTHONPATH=...' here. See note at top of section.
+#
+#       - name: Execute tests
+#         shell: bash
+#         run: |
+#
+#           # Again, do NOT 'export PYTHONPATH=...'
+#           # We define 'testpaths' in 'pytest.ini', however that path is no
+#           # longer valid. In this case 'pytest' searches for tests by default,
+#           # but we know where they are, so explicitly point to the new location.
+#           PYTHONPATH="isolation/:${PYTHONPATH}" python3 -m pytest -s isolation/isofit/test/ "${{ matrix.pytest-flags }}"

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -13,8 +13,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  cache:
+    - name: Cached Extras
+      id: cache-extras
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-extras
+      with:
+        path: extras
+        key: ${{ env.cache-name }}
+    - name: Download extras
+      if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        isofit -b extras download all
+        isofit build
 
   test:
+    needs: cache
 
     runs-on: ubuntu-latest
     strategy:
@@ -59,21 +75,14 @@ jobs:
           # of 'isofit' to ensure we are testing against '$PYTHONPATH'.
           python3 -m pip install ".[test]"
 
-      - name: Cached Extras
-        id: cache-extras
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-extras
-        with:
-          path: extras
-          key: ${{ env.cache-name }}
-
-      - name: Download extras
-        if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
-        shell: bash
-        run: |
-          isofit -b extras download all
-          isofit build
+      # - name: Cached Extras
+      #   id: cache-extras
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-extras
+      #   with:
+      #     path: extras
+      #     key: ${{ env.cache-name }}
 
       - name: Isolate ISOFIT
         shell: bash

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -14,18 +14,19 @@ concurrency:
 
 jobs:
   cache:
-    - name: Cached Extras
-      id: cache-extras
-      uses: actions/cache@v3
-      with:
-        path: extras
-        key: cache-extras-test
-    - name: Download extras
-      if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
-      shell: bash
-      run: |
-        isofit -b extras download all
-        isofit build
+    steps:
+      - name: Cached Extras
+        id: cache-extras
+        uses: actions/cache@v3
+        with:
+          path: extras
+          key: cache-extras-test
+      - name: Download extras
+        if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          isofit -b extras download all
+          isofit build
 
   test:
     needs: cache

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -70,7 +70,7 @@ jobs:
         id: cache-extras
         uses: actions/cache@v3
         with:
-          path: extras
+          path: ~/.isofit
           key: cache-extras
           fail-on-cache-miss: true
 

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -29,8 +29,34 @@ jobs:
           isofit -b extras download all
           isofit build
 
-  test:
+  download:
     needs: cache
+    if: ${{ jobs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
+    runs-on: ubuntu-latest
+      - uses: actions/checkout@v3
+
+      - name: Print concurrency group
+        run: echo '${{ github.workflow }}-${{ github.ref }}'
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install ISOFIT
+        shell: bash
+        run: |
+          python3 -m pip install --editable ".[test]"
+
+      - name: Download extras
+        shell: bash
+        run: |
+          isofit -b extras download all
+          isofit build
+
+  test:
+    needs: [cache, download]
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           path: extras
           key: cache-extras-test
+          fail-on-cache-miss: true
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   cache:
+    runs-on: ubuntu-latest
     steps:
       - name: Cached Extras
         id: cache-extras

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -33,6 +33,7 @@ jobs:
     needs: cache
     if: ${{ jobs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
     runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v3
 
       - name: Print concurrency group

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -69,7 +69,7 @@ jobs:
           key: ${{ env.cache-name }}
 
       - name: Download extras
-        if: ${{ steps.cache-extras.outputs.cache-hit != true }}
+        if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           isofit -b extras download all

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -1,147 +1,148 @@
-# # Test ISOFIT installed via a local repository checkout and '$PYTHONPATH'.
-#
-# name: Test '$PYTHONPATH' installation
-#
-# on:
-#   push:
-#     branches: ["dev", "main"]
-#   pull_request:
-#     branches: ["dev", "main"]
-#
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
-#
-# jobs:
-#   cache:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Cached Extras
-#         id: cache-extras
-#         uses: actions/cache@v3
-#         with:
-#           path: .isofit
-#           key: cache-extras-test
-#
-#   download:
-#     needs: cache
-#     if: ${{ needs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
-#
-#       - name: Print concurrency group
-#         run: echo '${{ github.workflow }}-${{ github.ref }}'
-#
-#       - name: Set up Python ${{ matrix.python-version }}
-#         uses: actions/setup-python@v3
-#         with:
-#           python-version: '3.12'
-#           cache: 'pip'
-#
-#       - name: Install ISOFIT
-#         shell: bash
-#         run: |
-#           python3 -m pip install --editable ".[test]"
-#
-#       - name: Download extras
-#         shell: bash
-#         run: |
-#           isofit download all
-#           isofit build
-#
-#   test:
-#     needs: [cache, download]
-#
-#     runs-on: ubuntu-latest
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         # This tests some very basic and long-lived Python behavior, so it is
-#         # likely sufficient to test only on a single Python version to avoid
-#         # GitHub worker contention.
-#         python-version: ["3.12"]
-#         pytest-flags: ["-m unmarked", "-m slow"]
-#
-#     steps:
-#       # Pull the cache on every runner
-#       # - name: Cached Extras
-#       #   id: cache-extras
-#       #   uses: actions/cache@v3
-#       #   with:
-#       #     path: extras
-#       #     key: cache-extras-test
-#
-#       - uses: actions/checkout@v3
-#
-#       - name: Print concurrency group
-#         run: echo '${{ github.workflow }}-${{ github.ref }}'
-#
-#       - name: Set up Python ${{ matrix.python-version }}
-#         uses: actions/setup-python@v3
-#         with:
-#           python-version: ${{ matrix.python-version }}
-#           cache: 'pip'
-#
-#       - name: Install ISOFIT and most software dependencies
-#         shell: bash
-#         run: |
-#
-#           # WARNING: Do NOT 'export PYTHONPATH=...'. Environment variables seem
-#           #          to be shared across all jobs, so this would break the
-#           #          the 'isofit' install for some other jobs. Unclear exactly
-#           #          which, but presumably any job running after this one.
-#
-#           # Python packaging dependencies. The presence of 'wheel' triggers
-#           # a lot of new Python packaging machinery that will eventually
-#           # become the default.
-#           python3 -m pip install pip setuptools wheel --upgrade
-#           python3 --version
-#           python3 -m pip show pip setuptools wheel
-#
-#           # Install 'isofit' and dependencies. Be sure to uninstall this version
-#           # of 'isofit' to ensure we are testing against '$PYTHONPATH'.
-#           python3 -m pip install ".[test]"
-#
-#       - name: Isolate ISOFIT
-#         shell: bash
-#         run: |
-#           # Uninstall 'isofit', leaving its dependencies.
-#           python3 -m pip uninstall --yes isofit
-#
-#           # Move 'isofit' into a new directory to ensure it is not just inherently available.
-#           mkdir isolation/
-#           mv isofit/ isolation/
-#
-#           # Check to see if 'isofit' is still installed. It should not be.
-#           # Note that this job is implicitly configured with 'set -e', which
-#           # means that any command exiting with a non-zero exit code will cause
-#           # the script to halt. The easiest way to see if 'isofit' is still
-#           # available is to attempt to import it, however, that rightfully
-#           # causes Python to exit with a non-zero exit code. It is possible to
-#           # use a heredoc to wrap this import in a 'try/except', print a status,
-#           # and have Python exit with a 0 exit code, but all of the options are
-#           # painful.
-#           #
-#           # Instead, disable 'set -e' by calling 'set +e', but be sure to
-#           # re-enable by calling 'set -e' again as soon as possible!!
-#           set +e
-#           ISOFIT_INSTALLED_PATH=$(
-#             python3 -c "import isofit; print(isofit.__file__)" 2> /dev/null)
-#           ISOFIT_INSTALLED_EXIT_CODE=$?
-#           set -e
-#           if [ "${ISOFIT_INSTALLED_EXIT_CODE}" -ne 1 ]; then
-#               exit 1
-#           fi
-#
-#           # Again, do NOT 'export PYTHONPATH=...' here. See note at top of section.
-#
-#       - name: Execute tests
-#         shell: bash
-#         run: |
-#
-#           # Again, do NOT 'export PYTHONPATH=...'
-#           # We define 'testpaths' in 'pytest.ini', however that path is no
-#           # longer valid. In this case 'pytest' searches for tests by default,
-#           # but we know where they are, so explicitly point to the new location.
-#           PYTHONPATH="isolation/:${PYTHONPATH}" python3 -m pytest -s isolation/isofit/test/ "${{ matrix.pytest-flags }}"
+# Test ISOFIT installed via a local repository checkout and '$PYTHONPATH'.
+
+name: Test '$PYTHONPATH' installation
+
+on:
+  push:
+    branches: ["dev", "main"]
+  pull_request:
+    branches: ["dev", "main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Create a cache before matrix jobs
+  cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Extras
+        id: cache-extras
+        uses: actions/cache@v3
+        with:
+          path: ~/.isofit
+          key: cache-extras-test
+
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@v3
+
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        name: Print concurrency group
+        run: echo '${{ github.workflow }}-${{ github.ref }}'
+
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        name: Install ISOFIT
+        shell: bash
+        run: |
+          python3 -m pip install --editable ".[test]"
+
+      - if: ${{ steps.cache-extras.outputs.cache-hit != 'true' }}
+        name: Download extras
+        shell: bash
+        run: |
+          isofit download all
+          isofit build
+
+  test:
+    needs: cache
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # This tests some very basic and long-lived Python behavior, so it is
+        # likely sufficient to test only on a single Python version to avoid
+        # GitHub worker contention.
+        python-version: ["3.12"]
+        pytest-flags: ["-m unmarked", "-m slow"]
+
+    steps:
+      # Pull the cache on every runner
+      - name: Cached Extras
+        id: cache-extras
+        uses: actions/cache@v3
+        with:
+          path: extras
+          key: cache-extras-test
+
+      - uses: actions/checkout@v3
+
+      - name: Print concurrency group
+        run: echo '${{ github.workflow }}-${{ github.ref }}'
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install ISOFIT and most software dependencies
+        shell: bash
+        run: |
+
+          # WARNING: Do NOT 'export PYTHONPATH=...'. Environment variables seem
+          #          to be shared across all jobs, so this would break the
+          #          the 'isofit' install for some other jobs. Unclear exactly
+          #          which, but presumably any job running after this one.
+
+          # Python packaging dependencies. The presence of 'wheel' triggers
+          # a lot of new Python packaging machinery that will eventually
+          # become the default.
+          python3 -m pip install pip setuptools wheel --upgrade
+          python3 --version
+          python3 -m pip show pip setuptools wheel
+
+          # Install 'isofit' and dependencies. Be sure to uninstall this version
+          # of 'isofit' to ensure we are testing against '$PYTHONPATH'.
+          python3 -m pip install ".[test]"
+
+      - name: Isolate ISOFIT
+        shell: bash
+        run: |
+          # Uninstall 'isofit', leaving its dependencies.
+          python3 -m pip uninstall --yes isofit
+
+          # Move 'isofit' into a new directory to ensure it is not just inherently available.
+          mkdir isolation/
+          mv isofit/ isolation/
+
+          # Check to see if 'isofit' is still installed. It should not be.
+          # Note that this job is implicitly configured with 'set -e', which
+          # means that any command exiting with a non-zero exit code will cause
+          # the script to halt. The easiest way to see if 'isofit' is still
+          # available is to attempt to import it, however, that rightfully
+          # causes Python to exit with a non-zero exit code. It is possible to
+          # use a heredoc to wrap this import in a 'try/except', print a status,
+          # and have Python exit with a 0 exit code, but all of the options are
+          # painful.
+          #
+          # Instead, disable 'set -e' by calling 'set +e', but be sure to
+          # re-enable by calling 'set -e' again as soon as possible!!
+          set +e
+          ISOFIT_INSTALLED_PATH=$(
+            python3 -c "import isofit; print(isofit.__file__)" 2> /dev/null)
+          ISOFIT_INSTALLED_EXIT_CODE=$?
+          set -e
+          if [ "${ISOFIT_INSTALLED_EXIT_CODE}" -ne 1 ]; then
+              exit 1
+          fi
+
+          # Again, do NOT 'export PYTHONPATH=...' here. See note at top of section.
+
+      - name: Execute tests
+        shell: bash
+        run: |
+
+          # Again, do NOT 'export PYTHONPATH=...'
+          # We define 'testpaths' in 'pytest.ini', however that path is no
+          # longer valid. In this case 'pytest' searches for tests by default,
+          # but we know where they are, so explicitly point to the new location.
+          PYTHONPATH="isolation/:${PYTHONPATH}" python3 -m pytest -s isolation/isofit/test/ "${{ matrix.pytest-flags }}"

--- a/.github/workflows/test-pythonpath-ubuntu.yml
+++ b/.github/workflows/test-pythonpath-ubuntu.yml
@@ -31,7 +31,7 @@ jobs:
 
   download:
     needs: cache
-    if: ${{ jobs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
+    if: ${{ needs.cache.steps.cache-extras.outputs.cache-hit != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The extras cache was working but not in the intended way. On the line `${{ steps.cache-extras.outputs.cache-hit != true }}` the `true` is supposed to be wrapped in quotes. Because it's not, the "cache-hit" never truly hit, so the `Download extras` step would always execute. This generally wasn't an issue because the cache was actually restored so the files are all present, therefore the download command would just skip any products that already exist. As such, no downloading would occur, and the build command is so fast that there really was no impact to the job. 

However, the real issue is that when the cache _doesn't_ exist, the download command would, well, download stuff. Because we use a matrix to test different python versions in parallel, every runner/job would attempt to create the cache at the same time. One of the servers we download from has some rate limit, and when we have multiple jobs attempting to pull the same file from the server, one or more jobs risked getting rate limited. 

This PR attempts to fix this by running the cache before the matrix jobs start. When the cache is missing and a download has to occur, this should reduce the total downloads from 17 to 2. Reason it's 2 is because `test-pip-package-ubuntu` and `test-pythonpath-ubuntu` will run at the same time, so they should both get the cache-miss at the same time. Maybe we could implement a way for the two files to share a single cache job, but given the download occurs so rarely and 2 jobs won't hit the rate limit, this is good enough. 