### PR TITLE
key fixes to 6s and srtmnet

### DIFF
--- a/isofit/radiative_transfer/engines/sRTMnet.py
+++ b/isofit/radiative_transfer/engines/sRTMnet.py
@@ -49,8 +49,12 @@ class tfLikeModel:
         biases = []
         for _n, n in enumerate(self.model["model_weights"].keys()):
             if "dense" in n:
-                weights.append(np.array(self.model["model_weights"][n][n]["kernel:0"]))
-                biases.append(np.array(self.model["model_weights"][n][n]["bias:0"]))
+                if 'kernel:0' in self.model["model_weights"][n][n]:
+                    weights.append(np.array(self.model["model_weights"][n][n]["kernel:0"]))
+                    biases.append(np.array(self.model["model_weights"][n][n]["bias:0"]))
+                else:
+                    weights.append(np.array(self.model["model_weights"][n][n]["kernel"]))
+                    biases.append(np.array(self.model["model_weights"][n][n]["bias"]))
 
         self.weights = weights
         self.biases = biases

--- a/isofit/radiative_transfer/engines/sRTMnet.py
+++ b/isofit/radiative_transfer/engines/sRTMnet.py
@@ -49,11 +49,15 @@ class tfLikeModel:
         biases = []
         for _n, n in enumerate(self.model["model_weights"].keys()):
             if "dense" in n:
-                if 'kernel:0' in self.model["model_weights"][n][n]:
-                    weights.append(np.array(self.model["model_weights"][n][n]["kernel:0"]))
+                if "kernel:0" in self.model["model_weights"][n][n]:
+                    weights.append(
+                        np.array(self.model["model_weights"][n][n]["kernel:0"])
+                    )
                     biases.append(np.array(self.model["model_weights"][n][n]["bias:0"]))
                 else:
-                    weights.append(np.array(self.model["model_weights"][n][n]["kernel"]))
+                    weights.append(
+                        np.array(self.model["model_weights"][n][n]["kernel"])
+                    )
                     biases.append(np.array(self.model["model_weights"][n][n]["bias"]))
 
         self.weights = weights

--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -238,6 +238,9 @@ class SixSRT(RadiativeTransferEngine):
         if "observer_zenith" in vals:
             vals["viewzen"] = vals["observer_zenith"]
 
+        if "solar_zenith" in vals:
+            vals["solzen"] = vals["solar_zenith"]
+
         if "relative_azimuth" in vals:
             vals["solaz"] = np.minimum(
                 vals["viewaz"] + vals["relative_azimuth"],


### PR DESCRIPTION
Replacing #619 .  Facilitates new multicomponent RTM.

See this model for testing (prelim only, tuned to EMIT wavelengths, to be updated):

[model](https://popo.jpl.nasa.gov/pub/PBrodrick/isofit/multicomponent_test_20241221.h5)
[aux](https://popo.jpl.nasa.gov/pub/PBrodrick/isofit/multicomponent_test_20241221_aux.npz)