### PR TITLE
Relax Dependencies

### DIFF
--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         pytest-flags: ["-m unmarked", "-m slow", "-m examples"]
 
     steps:

--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         pytest-flags: ["-m unmarked", "-m slow", "-m examples"]
 
     steps:

--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         pytest-flags: ["-m unmarked", "-m slow", "-m examples"]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "click",
   "dask",
   "h5py",
-  "netCDF4 < 1.7.1",
+  "netCDF4",
   "numpy >= 1.20",
   "pandas >= 0.24.0",
   "pyyaml >= 5.3.2",
@@ -44,7 +44,7 @@ dependencies = [
   "scipy >= 1.3.0",
   "spectral >= 0.19",
   "utm",
-  "xarray < 2024.1.1",
+  "xarray",
   "xxhash >= 1.2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "isofit"
 dynamic = ["version"]
 description = "Imaging Spectrometer Optimal FITting"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 keywords = ["isofit"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ maintainers = [
 classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "dask",
   "h5py",
   "netCDF4 < 1.7.1",
-  "numpy >= 1.20, < 2.0.0",
+  "numpy >= 1.20",
   "pandas >= 0.24.0",
   "pyyaml >= 5.3.2",
   "ray >= 1.2.0",

--- a/recipe/isofit.yml
+++ b/recipe/isofit.yml
@@ -9,8 +9,8 @@ dependencies:
   - click
   - dask
   - h5py
-  - netCDF4<1.7.1
-  - numpy>=1.20.0,<2.0.0
+  - netCDF4
+  - numpy>=1.20.0
   - pandas>=0.24
   - pre-commit
   - pytest>=3.5.1
@@ -21,7 +21,7 @@ dependencies:
   - scipy>=1.3.0
   - spectral>=0.19
   - utm
-  - xarray<2024.1.1
+  - xarray
 
   - pip:
     - ray[default]


### PR DESCRIPTION
- Removed `numpy < 2.0` install dependency
- ~~Added Python 3.13 to workflows~~
  - Ray still doesn't support it ☹️ 
- Removed version pin on:
  - xarray - This was pinned due to a bugged release awhile ago but is now resolved
  - netCDF4 - Pinned version didn't work with unpinned numpy

Closes #639 