### PR TITLE
Added check in calc_rdn for s_alb = 0

### DIFF
--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -216,6 +216,14 @@ class RadiativeTransfer:
             # eliminate spherical albedo and one reflectance term from numerator if using 1-component model
             L_tot = L_tot / (s_alb * rho_dif_dif)
 
+            if len(s_alb[s_alb == 0]):
+                Logger.debug(
+                    "Zeros found in LUT Spherical albedo (s_alb). Setting L_tot = 0."
+                )
+                # Confirm what to set this too. Shouldn't matter much.
+                # if s_alb = 0, (L_tot * s_alb * rho_dif_dif**2) = 0
+                L_tot[s_alb == 0] = 0
+
         # Thermal transmittance
         L_up = Ls * (r["transm_up_dir"] + r["transm_up_dif"])
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -199,6 +199,7 @@ class RadiativeTransfer:
 
         # Atmospheric spherical albedo
         s_alb = r["sphalb"]
+        atm_surface_scattering = s_alb * rho_dif_dif
 
         # Radiance terms along all optical paths
         L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(
@@ -214,15 +215,7 @@ class RadiativeTransfer:
             # we assume rho_dir_dir = rho_dif_dir = rho_dir_dif = rho_dif_dif
             rho_dif_dif = rho_dir_dir
             # eliminate spherical albedo and one reflectance term from numerator if using 1-component model
-            L_tot = L_tot / (s_alb * rho_dif_dif)
-
-            if len(s_alb[s_alb == 0]):
-                Logger.debug(
-                    "Zeros found in LUT Spherical albedo (s_alb). Setting L_tot = 0."
-                )
-                # Confirm what to set this too. Shouldn't matter much.
-                # if s_alb = 0, (L_tot * s_alb * rho_dif_dif**2) = 0
-                L_tot[s_alb == 0] = 0
+            atm_surface_scattering = 1
 
         # Thermal transmittance
         L_up = Ls * (r["transm_up_dir"] + r["transm_up_dif"])
@@ -264,7 +257,7 @@ class RadiativeTransfer:
             + L_dif_dir * rho_dif_dir
             + L_dir_dif * rho_dir_dif
             + L_dif_dif * rho_dif_dif
-            + (L_tot * s_alb * rho_dif_dif**2) / (1 - s_alb * rho_dif_dif)
+            + (L_tot * atm_surface_scattering * rho_dif_dif) / (1 - s_alb * rho_dif_dif)
             + L_up
         )
 


### PR DESCRIPTION
Cases when the spherical albedo term in the lut table are 0 currently produce nan values, which leads exceptions when calculating inverse matrices.

When `s_alb` contains nans, `calc_rdn` returns a vector with partial nans (indexes where `s_alb = 0`). The resample function does not include a check for nans within the `x` vector (only `H`). When `x` contains partial nans, `resample` returns a vector of full nans.

As far as I can tell, this is only an issue with the 1c model. This fix adds a narrow check to the `calc_rdn` function within the 1c if statement for cases when `s_alb = 0`. I tried to make it verbose with a debug log, which could be warning if we want it to always be printed.

With how things are currently structured, the value we replace the nans with does not matter, as the 1c model will _always_ return 0s where `s_alb = 0`. Potentially a behavior this doesn't share with Isofit 2.