### PR TITLE
Downloaders Bugfixes

### DIFF
--- a/isofit/data/build_examples.py
+++ b/isofit/data/build_examples.py
@@ -128,7 +128,7 @@ class Example:
         Creates configs based off the template files from an example directory
         """
         print(f"Generating configs")
-        templates = list((self.path / "templates").glob("*"))
+        templates = list((self.path / "templates").glob("*.json"))
 
         if not templates:
             print(

--- a/isofit/data/build_examples.py
+++ b/isofit/data/build_examples.py
@@ -128,7 +128,7 @@ class Example:
         Creates configs based off the template files from an example directory
         """
         print(f"Generating configs")
-        templates = list((self.path / "templates").glob("*.json"))
+        templates = list((self.path / "templates").glob("*"))
 
         if not templates:
             print(
@@ -139,15 +139,16 @@ class Example:
         configs = self.path / "configs"
         configs.mkdir(parents=True, exist_ok=True)
         for template in templates:
-            print(f"Creating {template.name}")
-
             if template.is_dir():
                 output = configs / template.name
                 output.mkdir(parents=True, exist_ok=True)
 
-                for tmpl in template.glob("*"):
+                for tmpl in template.glob("*.json"):
+                    print(f"Creating {tmpl.parent}/{tmpl.name}")
                     updateTemplate(tmpl, output)
-            else:
+
+            elif template.suffix == ".json":
+                print(f"Creating {template.name}")
                 updateTemplate(template, configs)
 
 

--- a/isofit/data/cli/image_cube.py
+++ b/isofit/data/cli/image_cube.py
@@ -90,7 +90,8 @@ def validate(path=None, size="both", debug=print, error=print, **_):
         return validate(path, "small") & validate(path, "medium")
 
     if path is None:
-        path = Path(env.imagecube)
+        path = env.imagecube
+    path = Path(path)
 
     debug(f"Verifying path for ISOFIT {size} image cube: {path}")
 

--- a/isofit/data/cli/sixs.py
+++ b/isofit/data/cli/sixs.py
@@ -55,7 +55,7 @@ def build(directory):
         f"make -j {os.cpu_count()}",
         shell=True,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        # stderr=subprocess.PIPE,
         cwd=directory,
     )
 
@@ -127,7 +127,9 @@ def validate(path=None, debug=print, error=print, **_):
         return False
 
     if not (path / f"sixsV2.1").exists():
-        error("[x] 6S does not appear to be installed correctly")
+        error(
+            "[x] 6S is missing the built 'sixsV2.1', this is likely caused by make failing"
+        )
         return False
 
     debug("[✓] Path is valid")
@@ -172,10 +174,10 @@ def download_cli(**kwargs):
         - `isofit download sixs --path /path/sixs`: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
     It is recommended to use the first style so the download path is remembered in the future.
     """
-    if validate_:
-        validate(**kwargs)
-    else:
+    if kwargs.get("overwrite"):
         download(**kwargs)
+    else:
+        update(**kwargs)
 
 
 @shared.validate.command(name=CMD)


### PR DESCRIPTION
Fixed a few issues with the downloader modules when working with a user to fix their installation:
- `isofit download sixs` was broken due to having the wrong parameters
- Added more context to one of the validation errors
- Disabled piping the error output of the `make` call, hopefully future errors will be outputted rather than quietly being discarded
- Fixed `isofit download imagecube` broken when using a non-default path
- Fixed the example building from templates retrieving non-json files
  - MacOS Finder likes to create `.DS_Store` in every directory to casually pollute users' systems which was causing issues with our examples building

The user's issue had to do with their Mac system not having xtools installed correctly. Took a bit of debugging to discover and resolve, so this PR is an attempt to help notice these problems in the future

Closes #649 