### PR TITLE
Config Templating

### DIFF
--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -64,7 +64,13 @@ class CLI(click.Group):
 
     def _lazy_load(self, cmd_name):
         try:
-            return importlib.import_module(self.lazy_subcommands[cmd_name]).cli
+            path = self.lazy_subcommands[cmd_name]
+            func = "cli"
+            if ":" in path:
+                path, func = path.split(":")
+
+            module = importlib.import_module(path)
+            return getattr(module, func)
         except Exception as e:
             pass
             # print(f"Failed {cmd_name}, reason: {e}")
@@ -90,6 +96,7 @@ class CLI(click.Group):
         "download": "isofit.data.download",
         "validate": "isofit.data.validate",
         "path": "isofit.data",
+        "dev": "isofit.data:dev",
         "HRRR_to_modtran": "isofit.utils.add_HRRR_profiles_to_modtran_config",
         "analytical_line": "isofit.utils.analytical_line",
         "apply_oe": "isofit.utils.apply_oe",

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -67,6 +67,9 @@ class Isofit:
         self.cols = None
         self.config = None
 
+        if config_file.endswith(".tmpl"):
+            config_file = env.fromTemplate(config_file)
+
         # Load configuration file
         self.config = configs.create_new_config(config_file)
         self.config.get_config_errors()

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -37,6 +37,7 @@ from isofit import checkNumThreads, ray
 from isofit.configs import configs
 from isofit.core.fileio import IO
 from isofit.core.forward import ForwardModel
+from isofit.data import env
 from isofit.inversion import Inversion
 
 

--- a/isofit/data/__init__.py
+++ b/isofit/data/__init__.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import click
 
@@ -24,7 +25,7 @@ def dev():
     """\
     Extra commands for developers
     """
-    pass
+    logging.basicConfig(level="DEBUG", format="%(levelname)-8s %(message)s")
 
 
 data = click.argument("data")
@@ -57,7 +58,7 @@ kwargs = click.option(
 @save
 @kwargs
 def toTemplate(no_save, kwargs, *args, **opts):
-    data = env.fromTemplate(*args, save=not no_save, **dict(kwargs), **opts)
+    data = env.toTemplate(*args, save=not no_save, **dict(kwargs), **opts)
 
     if no_save:
         print(json.dumps(data, indent=4))

--- a/isofit/data/__init__.py
+++ b/isofit/data/__init__.py
@@ -1,3 +1,5 @@
+import json
+
 import click
 
 from .ini import Ini
@@ -15,3 +17,64 @@ def cli(product):
     Prints the path to a specific product
     """
     print(env[product])
+
+
+@click.group("dev", invoke_without_command=True, no_args_is_help=True)
+def dev():
+    """\
+    Extra commands for developers
+    """
+    pass
+
+
+data = click.argument("data")
+save = click.option(
+    "-ns",
+    "--no-save",
+    is_flag=True,
+    default=False,
+    help="Disables saving to file, will print to terminal",
+)
+kwargs = click.option(
+    "-k",
+    "--kwargs",
+    multiple=True,
+    nargs=2,
+    help="Example: -k working_directory /path/to/output",
+)
+
+
+@dev.command(
+    name="totmpl",
+    no_args_is_help=True,
+    help=env.toTemplate.__doc__,
+    short_help="Convert a config to a template",
+)
+@data
+@click.option(
+    "-r", "--replace", type=click.Choice(["dirs", "keys", "None"]), default="dirs"
+)
+@save
+@kwargs
+def toTemplate(no_save, kwargs, *args, **opts):
+    data = env.fromTemplate(*args, save=not no_save, **dict(kwargs), **opts)
+
+    if no_save:
+        print(json.dumps(data, indent=4))
+
+
+@dev.command(
+    name="fromtmpl",
+    no_args_is_help=True,
+    help=env.fromTemplate.__doc__,
+    short_help="Convert a template to a config",
+)
+@data
+@save
+@click.option("-p", "--prepend")
+@kwargs
+def fromTemplate(no_save, kwargs, *args, **opts):
+    data = env.fromTemplate(*args, save=not no_save, **dict(kwargs), **opts)
+
+    if no_save:
+        print(json.dumps(data, indent=4))

--- a/isofit/data/download.py
+++ b/isofit/data/download.py
@@ -227,5 +227,5 @@ def preview_paths():
         - examples = /different/path/examples
     """
     print("Download paths will default to:")
-    for key, path in env.items():
+    for key, path in env.items("dirs"):
         print(f"- {key} = {path}")

--- a/isofit/data/ini.py
+++ b/isofit/data/ini.py
@@ -281,6 +281,7 @@ class Ini:
         converted back using Ini.fromTemplate(). Template values are in the form of
         "{env.[value]}".
 
+        \b
         Parameters
         ----------
         data : str | dict
@@ -299,16 +300,14 @@ class Ini:
         **kwargs : dict
             Additional strings to replace. The values are replaced in a string with the
             key of the kwarg. For example:
-
             >>> kwargs = {"xyz": "abc"}
             >>> data["some_key"] = "replace abc here"
             will be replaced as:
             >>> data["some_key"] = "replace {xyz} here"
-
             This is to be used with Ini.fromTemplate to replace values that are not
             found in the ini object
 
-
+        \b
         Returns
         -------
         data : dict
@@ -353,6 +352,7 @@ class Ini:
         real value from the ini. Template values are in the form of "{env.[value]}".
         This is an in-place operation.
 
+        \b
         Parameters
         ----------
         data : str | dict
@@ -363,21 +363,20 @@ class Ini:
             to another file. If the input file ends with ".tmpl" then it will simply be
             cut. If it doesn't or already exists, then the output filename will be the
             input filename prepended with `prepend` value.
-        prepend : str, default="replaced"
+        prepend : str, default=None
             Prepend a string to the output filename. If not set and the input filename
             doesn't end with ".tmpl", then this is auto-set to "replaced"
         **kwargs : dict
             Additional strings to replace. The values are replaced in a string with the
             key of the kwarg. For example:
-
             >>> kwargs = {"xyz": "abc"}
             >>> data["some_key"] = "replace {xyz} here"
             will be replaced as:
             >>> data["some_key"] = "replace abc here"
-
             This is to be used with Ini.toTemplate to replace values that are not found
             in the ini object
 
+        \b
         Returns
         -------
         data : dict
@@ -413,10 +412,11 @@ class Ini:
                 if out.exists() and not prepend:
                     prepend = "replaced"
             elif not prepend:
+                out = file
                 prepend = "replaced"
 
             if prepend:
-                out = file.with_name(f"{prepend}.{file.name}")
+                out = out.with_name(f"{prepend}.{out.name}")
 
             with open(out, "w") as f:
                 f.write(json.dumps(data, indent=4))

--- a/isofit/data/ini.py
+++ b/isofit/data/ini.py
@@ -324,7 +324,7 @@ class Ini:
 
         for key, value in data.items():
             if isinstance(value, dict):
-                self.toTemplate(value)
+                self.toTemplate(value, **kwargs)
             elif isinstance(value, str):
                 for k, v in self.items(replace):
                     if v in value:
@@ -394,7 +394,7 @@ class Ini:
 
         for key, value in data.items():
             if isinstance(value, dict):
-                self.fromTemplate(value)
+                self.fromTemplate(value, **kwargs)
             elif isinstance(value, str):
                 # Find all "{env.[value]}"
                 for dir in re.findall(r"{env\.(\w+)}", value):

--- a/isofit/data/ini.py
+++ b/isofit/data/ini.py
@@ -20,7 +20,7 @@ class Ini:
     # Additional keys with default values
     _keys: Dict[str, str] = {"srtmnet.file": "", "srtmnet.aux": ""}
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reset()
         self.load()
 
@@ -59,7 +59,7 @@ class Ini:
     def __iter__(self) -> Iterable:
         return iter(self.config[self.section])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"[{self.section}]\n" + "\n".join(
             [f"{key} = {value}" for key, value in self.items()]
         )
@@ -67,11 +67,29 @@ class Ini:
     def keys(self) -> Iterable[str]:
         return iter(self.config[self.section])
 
-    def items(self) -> Iterable[Tuple[str, str]]:
+    def items(self, kind: str = None) -> Iterable[Tuple[str, str]]:
         """
         Passthrough to the items() function on the working section of the config.
+
+        Parameters
+        ----------
+        kind : "dirs" | "keys" | None
+            Returns an iterable for the specific items:
+            - "dirs" only keys in Ini._dirs
+            - "dirs" only keys in Ini._keys
+            - None returns combined both
         """
-        return self.config[self.section].items()
+        items = self.config[self.section].items()
+        if kind == "dirs":
+            for key, value in items:
+                if key in self._dirs:
+                    yield key, value
+        elif kind == "keys":
+            for key, value in items:
+                if key in self._keys:
+                    yield key, value
+        else:
+            yield from items
 
     def changeBase(self, base: str) -> None:
         """
@@ -88,7 +106,7 @@ class Ini:
         for key in self._dirs:
             self.changePath(key, self.base / key)
 
-    def changeKey(self, key: str, value: str = ""):
+    def changeKey(self, key: str, value: str = "") -> None:
         """
         Change the value associated with the specified key in the CONFIG[SECTION].
 
@@ -255,7 +273,63 @@ class Ini:
 
         return path
 
-    def replace(self, data: str | dict, save: bool = True, prepend: str = None) -> dict:
+    def toTemplate(data: str | dict, replace="dirs", save: bool = True) -> dict:
+        """
+        Recursively converts string values in a dict to be template values which can be
+        converted back using Ini.fromTemplate(). Template values are in the form of
+        "{env.[value]}".
+
+        Parameters
+        ----------
+        data : str | dict
+            The dictionary to walk over and update values. If string, checks if this
+            exists as a file and loads that in as the data dict
+        replace : "dirs" | "keys" | None, default="dirs"
+            Defines what kind of values from the ini to replace in strings:
+            - "dirs" only replace directory paths
+            - "keys" only replace key strings
+            - None replaces both
+            Recommended to only use "dirs" to remain consistent. "keys" can have
+            unintended consequences and may replace more than it should
+        save : bool, default=True
+            If the data was a file and this is enabled, saves the converted data dict
+            to another file. The new file will simply append ".tmpl" to its name
+
+        Returns
+        -------
+        data : dict
+            In-place replaced string values with template values
+        """
+        file = None
+        if isinstance(data, str):
+            if (file := Path(data)).exists():
+                with open(data, "rb") as f:
+                    data = json.load(f)
+            else:
+                raise FileNotFoundError("If `data` is not a dict, it must be a file")
+
+        for key, value in data.items():
+            if isinstance(value, dict):
+                self.toTemplate(value)
+            elif isinstance(value, str):
+                # Only replace paths, not keys to remain consistent
+                for k, v in self.items(replace):
+                    if v in value:
+                        value = value.replace(v, "{env." + k + "}")
+                data[key] = value
+
+        if save and file:
+            out = file.with_suffix(f"{file.suffix}.tmpl")
+            with open(out, "w") as f:
+                f.write(json.dumps(data, indent=4))
+
+            Logger.debug(f"Saved converted json to: {out}")
+
+        return data
+
+    def fromTemplate(
+        self, data: str | dict, save: bool = True, prepend: str = None
+    ) -> dict:
         """
         Recursively replaces the template values in found in string values with the
         real value from the ini. Template values are in the form of "{env.[value]}".
@@ -269,8 +343,8 @@ class Ini:
         save : bool, default=True
             If the data was a file and this is enabled, saves the converted data dict
             to another file. If the input file ends with ".tmpl" then it will simply be
-            cut. If it doesn't, then the output filename will be the input filename
-            prepended with `prepend` value
+            cut. If it doesn't or already exists, then the output filename will be the
+            input filename prepended with `prepend` value.
         prepend : str, default="replaced"
             Prepend a string to the output filename. If not set and the input filename
             doesn't end with ".tmpl", then this is auto-set to "replaced"
@@ -291,16 +365,19 @@ class Ini:
 
         for key, value in data.items():
             if isinstance(value, dict):
-                self.replace(value)
+                self.fromTemplate(value)
             elif isinstance(value, str):
                 # Find all "{env.[value]}"
                 for dir in re.findall(r"{env\.(\w+)}", value):
                     # Replace in-place
-                    data[key] = value.replace("{env." + dir + "}", self[dir])
+                    value = value.replace("{env." + dir + "}", self[dir])
+                data[key] = value
 
         if save and file:
             if file.suffix == ".tmpl":
                 out = file.with_suffix("")
+                if out.exists() and not prepend:
+                    prepend = "replaced"
             elif not prepend:
                 prepend = "replaced"
 
@@ -314,7 +391,7 @@ class Ini:
 
         return data
 
-    def reset(self, save: bool = False):
+    def reset(self, save: bool = False) -> None:
         """
         Resets the object to the defaults defined by ISOFIT
 

--- a/isofit/data/ini.py
+++ b/isofit/data/ini.py
@@ -273,7 +273,7 @@ class Ini:
 
         return path
 
-    def toTemplate(data: str | dict, replace="dirs", save: bool = True) -> dict:
+    def toTemplate(self, data: str | dict, replace="dirs", save: bool = True) -> dict:
         """
         Recursively converts string values in a dict to be template values which can be
         converted back using Ini.fromTemplate(). Template values are in the form of

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -198,33 +198,27 @@ class Pathnames:
         self.sixs_path = os.getenv("SIXS_DIR", env.sixs)
 
         if sensor == "avcl":
-            self.noise_path = str(env.path("data", "avirisc_noise.txt", template=True))
+            self.noise_path = str(env.path("data", "avirisc_noise.txt"))
         elif sensor == "oci":
-            self.noise_path = str(
-                env.path("data", "oci", "oci_noise.txt", template=True)
-            )
+            self.noise_path = str(env.path("data", "oci", "oci_noise.txt"))
         elif sensor == "emit":
-            self.noise_path = str(env.path("data", "emit_noise.txt", template=True))
+            self.noise_path = str(env.path("data", "emit_noise.txt"))
             if self.input_channelized_uncertainty_path is None:
                 self.input_channelized_uncertainty_path = str(
-                    env.path("data", "emit_osf_uncertainty.txt", template=True)
+                    env.path("data", "emit_osf_uncertainty.txt")
                 )
             if self.input_model_discrepancy_path is None:
                 self.input_model_discrepancy_path = str(
-                    env.path("data", "emit_model_discrepancy.mat", template=True)
+                    env.path("data", "emit_model_discrepancy.mat")
                 )
         elif sensor == "tanager":
-            self.noise_path = str(
-                env.path("data", "tanager1_noise_20241016.txt", template=True)
-            )
+            self.noise_path = str(env.path("data", "tanager1_noise_20241016.txt"))
         else:
             self.noise_path = None
             logging.info("no noise path found, proceeding without")
             # quit()
 
-        self.earth_sun_distance_path = str(
-            env.path("data", "earth_sun_distance.txt", template=True)
-        )
+        self.earth_sun_distance_path = str(env.path("data", "earth_sun_distance.txt"))
 
         irr_path = [
             "examples",
@@ -235,11 +229,9 @@ class Pathnames:
         if sensor == "oci":
             irr_path = ["data", "oci", "tsis_f0_0p1.txt"]
 
-        self.irradiance_file = str(env.path(*irr_path, template=True))
+        self.irradiance_file = str(env.path(*irr_path))
 
-        self.aerosol_tpl_path = str(
-            env.path("data", "aerosol_template.json", template=True)
-        )
+        self.aerosol_tpl_path = str(env.path("data", "aerosol_template.json"))
         self.rdn_factors_path = None
         if rdn_factors_path is not None:
             self.rdn_factors_path = abspath(rdn_factors_path)
@@ -1183,7 +1175,7 @@ def load_climatology(
 
     """
 
-    aerosol_model_path = str(env.path("data", "aerosol_model.txt", template=True))
+    aerosol_model_path = str(env.path("data", "aerosol_model.txt"))
     aerosol_state_vector = {}
     aerosol_lut_grid = {}
     aerosol_lut_ranges = [

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -671,7 +671,7 @@ def build_presolve_config(
         )
 
     # Create a template version of the config
-    env.toTemplate(paths.h2o_config_path)
+    env.toTemplate(paths.h2o_config_path, working_directory=paths.working_directory)
 
 
 def build_main_config(
@@ -1030,7 +1030,9 @@ def build_main_config(
         )
 
     # Create a template version of the config
-    env.toTemplate(paths.isofit_full_config_path)
+    env.toTemplate(
+        paths.isofit_full_config_path, working_directory=paths.working_directory
+    )
 
 
 def get_lut_subset(vals):

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -673,14 +673,13 @@ def build_presolve_config(
         isofit_config_h2o["input"]["obs_file"] = paths.obs_working_path
 
     # write presolve config
-    out = paths.h2o_config_path + ".tmpl"
-    with open(out, "w") as fout:
+    with open(paths.h2o_config_path, "w") as fout:
         fout.write(
             json.dumps(isofit_config_h2o, cls=SerialEncoder, indent=4, sort_keys=True)
         )
 
-    # Convert the template config to a full one
-    env.replace(out)
+    # Create a template version of the config
+    env.toTemplate(paths.h2o_config_path)
 
 
 def build_main_config(
@@ -1031,16 +1030,15 @@ def build_main_config(
         ] = paths.rdn_factors_path
 
     # write main config file
-    out = paths.isofit_full_config_path + ".tmpl"
-    with open(out, "w") as fout:
+    with open(paths.isofit_full_config_path, "w") as fout:
         fout.write(
             json.dumps(
                 isofit_config_modtran, cls=SerialEncoder, indent=4, sort_keys=True
             )
         )
 
-    # Convert the template config to a full one
-    env.replace(out)
+    # Create a template version of the config
+    env.toTemplate(paths.isofit_full_config_path)
 
 
 def get_lut_subset(vals):

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -198,27 +198,33 @@ class Pathnames:
         self.sixs_path = os.getenv("SIXS_DIR", env.sixs)
 
         if sensor == "avcl":
-            self.noise_path = str(env.path("data", "avirisc_noise.txt"))
+            self.noise_path = str(env.path("data", "avirisc_noise.txt", template=True))
         elif sensor == "oci":
-            self.noise_path = str(env.path("data", "oci", "oci_noise.txt"))
+            self.noise_path = str(
+                env.path("data", "oci", "oci_noise.txt", template=True)
+            )
         elif sensor == "emit":
-            self.noise_path = str(env.path("data", "emit_noise.txt"))
+            self.noise_path = str(env.path("data", "emit_noise.txt", template=True))
             if self.input_channelized_uncertainty_path is None:
                 self.input_channelized_uncertainty_path = str(
-                    env.path("data", "emit_osf_uncertainty.txt")
+                    env.path("data", "emit_osf_uncertainty.txt", template=True)
                 )
             if self.input_model_discrepancy_path is None:
                 self.input_model_discrepancy_path = str(
-                    env.path("data", "emit_model_discrepancy.mat")
+                    env.path("data", "emit_model_discrepancy.mat", template=True)
                 )
         elif sensor == "tanager":
-            self.noise_path = str(env.path("data", "tanager1_noise_20241016.txt"))
+            self.noise_path = str(
+                env.path("data", "tanager1_noise_20241016.txt", template=True)
+            )
         else:
             self.noise_path = None
             logging.info("no noise path found, proceeding without")
             # quit()
 
-        self.earth_sun_distance_path = str(env.path("data", "earth_sun_distance.txt"))
+        self.earth_sun_distance_path = str(
+            env.path("data", "earth_sun_distance.txt", template=True)
+        )
 
         irr_path = [
             "examples",
@@ -229,9 +235,11 @@ class Pathnames:
         if sensor == "oci":
             irr_path = ["data", "oci", "tsis_f0_0p1.txt"]
 
-        self.irradiance_file = str(env.path(*irr_path))
+        self.irradiance_file = str(env.path(*irr_path, template=True))
 
-        self.aerosol_tpl_path = str(env.path("data", "aerosol_template.json"))
+        self.aerosol_tpl_path = str(
+            env.path("data", "aerosol_template.json", template=True)
+        )
         self.rdn_factors_path = None
         if rdn_factors_path is not None:
             self.rdn_factors_path = abspath(rdn_factors_path)
@@ -664,11 +672,15 @@ def build_presolve_config(
         isofit_config_h2o["input"]["loc_file"] = paths.loc_working_path
         isofit_config_h2o["input"]["obs_file"] = paths.obs_working_path
 
-    # write modtran_template
-    with open(paths.h2o_config_path, "w") as fout:
+    # write presolve config
+    out = paths.h2o_config_path + ".tmpl"
+    with open(out, "w") as fout:
         fout.write(
             json.dumps(isofit_config_h2o, cls=SerialEncoder, indent=4, sort_keys=True)
         )
+
+    # Convert the template config to a full one
+    env.replace(out)
 
 
 def build_main_config(
@@ -1019,12 +1031,16 @@ def build_main_config(
         ] = paths.rdn_factors_path
 
     # write main config file
-    with open(paths.isofit_full_config_path, "w") as fout:
+    out = paths.isofit_full_config_path + ".tmpl"
+    with open(out, "w") as fout:
         fout.write(
             json.dumps(
                 isofit_config_modtran, cls=SerialEncoder, indent=4, sort_keys=True
             )
         )
+
+    # Convert the template config to a full one
+    env.replace(out)
 
 
 def get_lut_subset(vals):
@@ -1169,7 +1185,7 @@ def load_climatology(
 
     """
 
-    aerosol_model_path = str(env.path("data", "aerosol_model.txt"))
+    aerosol_model_path = str(env.path("data", "aerosol_model.txt", template=True))
     aerosol_state_vector = {}
     aerosol_lut_grid = {}
     aerosol_lut_ranges = [


### PR DESCRIPTION
Added new functionality to `ini.py` to convert to/from template configuration files which will make it easier to move a config from one system to another. 
- `toTemplate` converts an existing config file to a template version
  - This must be done by the system that created the config to start with as it uses the ini to replace values in strings
  - Values found in the ini are replaced with strings `{env.[path]}`, eg. `{env.data}`, `{env.examples}`
  - By default, only converts **paths** from the ini, not keys. This is to ensure things like sRTMnet version remains consistent. 
  - `template_construction.py` auto does this now for presolve and full, creates the same config but with `.tmpl`
- `fromTemplate` converts a template config back using a different ini. The idea here is:
  - A user runs `apply_oe.py`
  - `full.json` and `full.json.tmpl` config files are generated
  - User hits an error, seeks help, uploads their entire `working_directory` (ie. output dir)
  - Devs use options to convert:
    - Python: 
    ```python
    >>> env.fromTemplate("/path/to/working_directory/config/full.json.tmpl", working_directory="/path/to/working_directory")
    ```
    - CLI: 
    ```bash
    $ isofit dev fromtmpl /path/to/working_directory/config/full.json.tmpl -k working_directory /path/to/working_directory
    ```
    - Note the additional keyword `working_directory`, this is not found in the ini but is an additional replaceable item in the template
  - Devs execute config, should be fully working with whatever environment / ini is loaded

- If a given config is detected to be within a valid ISOFIT output directory then the `working_directory` will be auto-set. If not, the user will have to set it (such as the examples)
- `isofit.py` will attempt to call the `fromTemplate` function if it detects an input config is a template version, and then use the converted return

Additionally, added the above capabilities to our CLI:

<details>
<summary>isofit dev</summary>

```
$ isofit dev
Usage: isofit dev [OPTIONS] COMMAND [ARGS]...

  Extra commands for developers

Options:
  --help  Show this message and exit.

Commands:
  fromtmpl  Convert a template to a config
  totmpl    Convert a config to a template
```

</details>

<details>
<summary>isofit dev totmpl</summary>

```
$ isofit dev totmpl
Usage: isofit dev totmpl [OPTIONS] DATA

  Recursively converts string values in a dict to be template values which can
  be converted back using Ini.fromTemplate(). Template values are in the form
  of "{env.[value]}".

  Parameters
  ----------
  data : str | dict
      The dictionary to walk over and update values. If string, checks if this
      exists as a file and loads that in as the data dict
  replace : "dirs" | "keys" | None, default="dirs"
      Defines what kind of values from the ini to replace in strings:
      - "dirs" only replace directory paths
      - "keys" only replace key strings
      - None replaces both
      Recommended to only use "dirs" to remain consistent. "keys" can have
      unintended consequences and may replace more than it should
  save : bool, default=True
      If the data was a file and this is enabled, saves the converted data dict
      to another file. The new file will simply append ".tmpl" to its name
  **kwargs : dict
      Additional strings to replace. The values are replaced in a string with the
      key of the kwarg. For example:
      >>> kwargs = {"xyz": "abc"}
      >>> data["some_key"] = "replace abc here"
      will be replaced as:
      >>> data["some_key"] = "replace {xyz} here"
      This is to be used with Ini.fromTemplate to replace values that are not
      found in the ini object

  Returns
  -------
  data : dict
      In-place replaced string values with template values

Options:
  -r, --replace [dirs|keys|None]
  -ns, --no-save                  Disables saving to file, will print to
                                  terminal
  -k, --kwargs TEXT...            Example: -k working_directory
                                  /path/to/output
  --help                          Show this message and exit.
```

</details>

<details>
<summary>isofit dev fromtmpl</summary>

```
$ isofit dev fromtmpl
Usage: isofit dev fromtmpl [OPTIONS] DATA

  Recursively replaces the template values in found in string values with the
  real value from the ini. Template values are in the form of "{env.[value]}".
  This is an in-place operation.

  Parameters
  ----------
  data : str | dict
      The dictionary to walk over and update values. If string, checks if this
      exists as a file and loads that in as the data dict
  save : bool, default=True
      If the data was a file and this is enabled, saves the converted data dict
      to another file. If the input file ends with ".tmpl" then it will simply be
      cut. If it doesn't or already exists, then the output filename will be the
      input filename prepended with `prepend` value.
  prepend : str, default=None
      Prepend a string to the output filename. If not set and the input filename
      doesn't end with ".tmpl", then this is auto-set to "replaced"
  **kwargs : dict
      Additional strings to replace. The values are replaced in a string with the
      key of the kwarg. For example:
      >>> kwargs = {"xyz": "abc"}
      >>> data["some_key"] = "replace {xyz} here"
      will be replaced as:
      >>> data["some_key"] = "replace abc here"
      This is to be used with Ini.toTemplate to replace values that are not found
      in the ini object

  Returns
  -------
  data : dict
      In-place replaced template values with actual from a loaded ini

Options:
  -ns, --no-save        Disables saving to file, will print to terminal
  -p, --prepend TEXT
  -k, --kwargs TEXT...  Example: -k working_directory /path/to/output
  --help                Show this message and exit.
```

</details>

Example
---
Trimmed the configs some so they're not so long

<details>
<summary>Working config generated by `template_construction.py`</summary>

```json
{
    "forward_model": {
        "instrument": {
            "integrations": 200,
            "parametric_noise_file": "/store/jamesmo/isofit/extras/data/emit_noise.txt",
            "unknowns": {
                "channelized_radiometric_uncertainty_file": "/local/jemit/data/channelized_uncertainty.txt",
                "uncorrelated_radiometric_uncertainty": 0.01
            },
            "wavelength_file": "/local/jemit/data/wavelengths.txt"
        },
        "model_discrepancy_file": "/local/jemit/data/model_discrepancy.mat",
        "radiative_transfer": {
            "radiative_transfer_engines": {
                "vswir": {
                    "aerosol_model_file": "/store/jamesmo/isofit/extras/data/aerosol_model.txt",
                    "aerosol_template_file": "/store/jamesmo/isofit/extras/data/aerosol_template.json",
                    "earth_sun_distance_file": "/store/jamesmo/isofit/extras/data/earth_sun_distance.txt",
                    "emulator_aux_file": "/store/jamesmo/isofit/extras/srtmnet/sRTMnet_v120_aux.npz",
                    "emulator_file": "/store/jamesmo/isofit/extras/srtmnet/sRTMnet_v120.h5",
                    "engine_base_dir": "/store/jamesmo/isofit/extras/sixs",
                    "engine_name": "sRTMnet",
                    "glint_model": false,
                    "interpolator_base_path": "/local/jemit/lut_full/sRTMnet_v120_vi",
                    "irradiance_file": "/store/jamesmo/isofit/extras/examples/20151026_SantaMonica/data/prism_optimized_irr.dat",
                    "lut_names": {
                        "AOT550": null,
                        "H2OSTR": null,
                        "observer_zenith": null,
                        "relative_azimuth": null,
                        "surface_elevation_km": null
                    },
                    "lut_path": "/local/jemit/lut_full/lut.nc",
                    "multipart_transmittance": false,
                    "sim_path": "/local/jemit/lut_full",
                    "statevector_names": [
                        "H2OSTR",
                        "surface_elevation_km",
                        "AOT550"
                    ],
                    "template_file": "/local/jemit/config/emit20220820t131606_modtran_tpl.json"
                }
            },
        },
        "surface": {
            "select_on_init": true,
            "surface_category": "multicomponent_surface",
            "surface_file": "/local/jemit/data/surface.mat"
        }
    },
    "input": {
        "loc_file": "/local/jemit/input/emit20220820t131606_subs_loc",
        "measured_radiance_file": "/local/jemit/input/emit20220820t131606_subs_rdn",
        "obs_file": "/local/jemit/input/emit20220820t131606_subs_obs"
    },
    "output": {
        "atmospheric_coefficients_file": "/local/jemit/output/emit20220820t131606_subs_atm",
        "estimated_reflectance_file": "/local/jemit/output/emit20220820t131606_subs_rfl",
        "estimated_state_file": "/local/jemit/output/emit20220820t131606_subs_state",
        "posterior_uncertainty_file": "/local/jemit/output/emit20220820t131606_subs_uncert"
    }
}
```

</details>

<details>
<summary>Template config generated by `template_construction.py`</summary>

```json
{
    "forward_model": {
        "instrument": {
            "integrations": 200,
            "parametric_noise_file": "{env.data}/emit_noise.txt",
            "unknowns": {
                "channelized_radiometric_uncertainty_file": "{working_directory}/data/channelized_uncertainty.txt",
                "uncorrelated_radiometric_uncertainty": 0.01
            },
            "wavelength_file": "{working_directory}/data/wavelengths.txt"
        },
        "model_discrepancy_file": "{working_directory}/data/model_discrepancy.mat",
        "radiative_transfer": {
            "radiative_transfer_engines": {
                "vswir": {
                    "aerosol_model_file": "{env.data}/aerosol_model.txt",
                    "aerosol_template_file": "{env.data}/aerosol_template.json",
                    "earth_sun_distance_file": "{env.data}/earth_sun_distance.txt",
                    "emulator_aux_file": "{env.srtmnet}/sRTMnet_v120_aux.npz",
                    "emulator_file": "{env.srtmnet}/sRTMnet_v120.h5",
                    "engine_base_dir": "{env.sixs}",
                    "engine_name": "sRTMnet",
                    "glint_model": false,
                    "interpolator_base_path": "{working_directory}/lut_full/sRTMnet_v120_vi",
                    "irradiance_file": "{env.examples}/20151026_SantaMonica/data/prism_optimized_irr.dat",
                    "lut_names": {
                        "AOT550": null,
                        "H2OSTR": null,
                        "observer_zenith": null,
                        "relative_azimuth": null,
                        "surface_elevation_km": null
                    },
                    "lut_path": "{working_directory}/lut_full/lut.nc",
                    "multipart_transmittance": false,
                    "sim_path": "{working_directory}/lut_full",
                    "statevector_names": [
                        "H2OSTR",
                        "surface_elevation_km",
                        "AOT550"
                    ],
                    "template_file": "{working_directory}/config/emit20220820t131606_modtran_tpl.json"
                }
            },
        },
        "surface": {
            "select_on_init": true,
            "surface_category": "multicomponent_surface",
            "surface_file": "{working_directory}/data/surface.mat"
        }
    },
    "input": {
        "loc_file": "{working_directory}/input/emit20220820t131606_subs_loc",
        "measured_radiance_file": "{working_directory}/input/emit20220820t131606_subs_rdn",
        "obs_file": "{working_directory}/input/emit20220820t131606_subs_obs"
    },
    "output": {
        "atmospheric_coefficients_file": "{working_directory}/output/emit20220820t131606_subs_atm",
        "estimated_reflectance_file": "{working_directory}/output/emit20220820t131606_subs_rfl",
        "estimated_state_file": "{working_directory}/output/emit20220820t131606_subs_state",
        "posterior_uncertainty_file": "{working_directory}/output/emit20220820t131606_subs_uncert"
    }
}
```

</details>

<details>
<summary>Template converted to my local Mac</summary>

Below commands generate the same thing

```python
>>> env.fromTemplate("emit20220820t131606_isofit.json.tmpl", working_directory="/example/directory/replacement")
```

```bash
$ isofit dev fromtmpl emit20220820t131606_isofit.json.tmpl -k working_directory /example/directory/replacement
```

```json
{
    "forward_model": {
        "instrument": {
            "integrations": 200,
            "parametric_noise_file": "/Users/jamesmo/projects/isofit/extras/data/emit_noise.txt",
            "unknowns": {
                "channelized_radiometric_uncertainty_file": "/example/directory/replacement/data/channelized_uncertainty.txt",
                "uncorrelated_radiometric_uncertainty": 0.01
            },
            "wavelength_file": "/example/directory/replacement/data/wavelengths.txt"
        },
        "model_discrepancy_file": "/example/directory/replacement/data/model_discrepancy.mat",
        "radiative_transfer": {
            "radiative_transfer_engines": {
                "vswir": {
                    "aerosol_model_file": "/Users/jamesmo/projects/isofit/extras/data/aerosol_model.txt",
                    "aerosol_template_file": "/Users/jamesmo/projects/isofit/extras/data/aerosol_template.json",
                    "earth_sun_distance_file": "/Users/jamesmo/projects/isofit/extras/data/earth_sun_distance.txt",
                    "emulator_aux_file": "/Users/jamesmo/projects/isofit/extras/srtmnet/sRTMnet_v120_aux.npz",
                    "emulator_file": "/Users/jamesmo/projects/isofit/extras/srtmnet/sRTMnet_v120.h5",
                    "engine_base_dir": "/Users/jamesmo/projects/isofit/extras/sixs",
                    "engine_name": "sRTMnet",
                    "glint_model": false,
                    "interpolator_base_path": "/example/directory/replacement/lut_full/sRTMnet_v120_vi",
                    "irradiance_file": "/Users/jamesmo/projects/isofit/extras/examples/20151026_SantaMonica/data/prism_optimized_irr.dat",
                    "lut_names": {
                        "AOT550": null,
                        "H2OSTR": null,
                        "observer_zenith": null,
                        "relative_azimuth": null,
                        "surface_elevation_km": null
                    },
                    "lut_path": "/example/directory/replacement/lut_full/lut.nc",
                    "multipart_transmittance": false,
                    "sim_path": "/example/directory/replacement/lut_full",
                    "statevector_names": [
                        "H2OSTR",
                        "surface_elevation_km",
                        "AOT550"
                    ],
                    "template_file": "/example/directory/replacement/config/emit20220820t131606_modtran_tpl.json"
                }
            },
        },
        "surface": {
            "select_on_init": true,
            "surface_category": "multicomponent_surface",
            "surface_file": "/example/directory/replacement/data/surface.mat"
        }
    },
    "input": {
        "loc_file": "/example/directory/replacement/input/emit20220820t131606_subs_loc",
        "measured_radiance_file": "/example/directory/replacement/input/emit20220820t131606_subs_rdn",
        "obs_file": "/example/directory/replacement/input/emit20220820t131606_subs_obs"
    },
    "output": {
        "atmospheric_coefficients_file": "/example/directory/replacement/output/emit20220820t131606_subs_atm",
        "estimated_reflectance_file": "/example/directory/replacement/output/emit20220820t131606_subs_rfl",
        "estimated_state_file": "/example/directory/replacement/output/emit20220820t131606_subs_state",
        "posterior_uncertainty_file": "/example/directory/replacement/output/emit20220820t131606_subs_uncert"
    }
}
```

</details>