### PR TITLE
Raise Bad Config Checking

### DIFF
--- a/isofit/configs/base_config.py
+++ b/isofit/configs/base_config.py
@@ -85,13 +85,9 @@ class BaseConfigSection(object):
         # Now do a full check on each submodule
         for key in self._get_nontype_attributes():
             value = getattr(self, key)
-            try:
-                logging.debug("Configuration check of: {}".format(key))
+            if hasattr(value, "check_config_validity"):
+                logging.debug(f"Configuration check of: {key}")
                 errors.extend(value.check_config_validity())
-            except AttributeError:
-                logging.debug(
-                    "Configuration check: {} is not an object, skipping".format(key)
-                )
 
         return errors
 


### PR DESCRIPTION
Awhile back we had an issue where some downstream checks on the config object weren't being executed due to upstream config sections having a bug that would be caught by this try/except block and then skipped. Ideally, we want those exceptions to be raised so they can be noticed and fixed by devs.