### PR TITLE
Added spectra interpolation function for input RDN files.

### DIFF
--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -97,6 +97,7 @@ class CLI(click.Group):
         "empirical_line": "isofit.utils.empirical_line",
         "ewt": "isofit.utils.ewt_from_reflectance",
         "reconstruct_subs": "isofit.utils.reconstruct",
+        "interpolate_spectra": "isofit.utils.interpolate_spectra",
         "sun": "isofit.utils.solar_position",
         "surface_model": "isofit.utils.surface_model",
         "plot": "isoplots",

--- a/isofit/utils/__init__.py
+++ b/isofit/utils/__init__.py
@@ -3,6 +3,7 @@ from .empirical_line import empirical_line
 from .extractions import extractions
 from .generate_noise import generate_noise
 from .instrument_model import instrument_model
+from .interpolate_spectra import interpolate_spectra
 from .reconstruct import reconstruct_subs
 from .remap import remap
 from .segment import segment

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -20,7 +20,7 @@ from isofit.core import isofit
 from isofit.core.common import envi_header
 from isofit.utils import analytical_line as ALAlg
 from isofit.utils import empirical_line as ELAlg
-from isofit.utils import extractions, segment
+from isofit.utils import extractions, interpolate_spectra, segment
 
 EPS = 1e-6
 CHUNKSIZE = 256
@@ -77,6 +77,8 @@ def apply_oe(
     prebuilt_lut=None,
     no_min_lut_spacing=False,
     inversion_windows=None,
+    interpolate_bad_rdn=False,
+    interpolate_inplace=False,
 ):
     """\
     Applies OE over a flightline using a radiative transfer engine. This executes
@@ -190,6 +192,15 @@ def apply_oe(
         Override the default inversion windows.  Will supercede any sensor specific
         defaults that are in place.
         Must be in 2-item tuples
+    interpolate_bad_rdn : bool, default=False
+        Flag to perform a per-pixel interpolation across no-data and NaN data bands.
+        Does not interpolate vectors that are entire no-data or NaN, only partial.
+        Currently only designed for wavelength interpolation on spectra.
+        Does NOT do any spatial interpolation
+    interpolate_inplace : bool, default=False
+        Flag to tell interpolation to work on the file in place, or generate a
+        new interpolated rdn file. The location of the new file will be in the
+        "input" directory within the working directory.
 
     \b
     References
@@ -229,12 +240,12 @@ def apply_oe(
         # This is the MODTRAN case. Do we want to enable the 4c mode by default?
         multipart_transmittance = True
 
-    ray.init(
-        num_cpus=n_cores,
-        _temp_dir=ray_temp_dir,
-        include_dashboard=False,
-        local_mode=n_cores == 1,
-    )
+    # ray.init(
+    #     num_cpus=n_cores,
+    #     _temp_dir=ray_temp_dir,
+    #     include_dashboard=False,
+    #     local_mode=n_cores == 1,
+    # )
 
     if sensor not in SUPPORTED_SENSORS:
         if sensor[:3] != "NA-":
@@ -302,6 +313,7 @@ def apply_oe(
         aerosol_climatology_path,
         channelized_uncertainty_path,
         ray_temp_dir,
+        interpolate_inplace,
     )
     paths.make_directories()
     paths.stage_files()
@@ -512,6 +524,20 @@ def apply_oe(
     else:
         uncorrelated_radiometric_uncertainty = UNCORRELATED_RADIOMETRIC_UNCERTAINTY
 
+    # Interpolate bad rdn data.
+    if interpolate_bad_rdn:
+        # if interpolate_inplace == True,
+        # paths.radiance_working_path = paths.radiance_interp_path
+        interpolate_spectra(
+            paths.radiance_working_path,
+            paths.radiance_interp_path,
+            interpolate_inplace,
+            logfile=log_file,
+        )
+        paths.radiance_working_path = paths.radiance_interp_path
+
+    logging.debug("Radiance working path:")
+    logging.debug(paths.radiance_working_path)
     # Superpixel segmentation
     if use_superpixels:
         if not exists(paths.lbl_working_path) or not exists(
@@ -789,6 +815,8 @@ def apply_oe(
 @click.option("--prebuilt_lut", type=str)
 @click.option("--no_min_lut_spacing", is_flag=True, default=False)
 @click.option("--inversion_windows", type=float, nargs=2, multiple=True, default=None)
+@click.option("--interpolate_bad_rdn", is_flag=True, default=False)
+@click.option("--interpolate_inplace", is_flag=True, default=False)
 @click.option(
     "--debug-args",
     help="Prints the arguments list without executing the command",

--- a/isofit/utils/interpolate_spectra.py
+++ b/isofit/utils/interpolate_spectra.py
@@ -1,0 +1,230 @@
+#! /usr/bin/env python3
+#
+#  Copyright 2025 California Institute of Technology
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ISOFIT: Imaging Spectrometer Optimal FITting
+# Author: Evan Greenberg, evan.greenberg@jpl.nasa.gov
+import logging
+import multiprocessing
+import time
+
+import numpy as np
+import scipy
+from spectral.io import envi
+
+from isofit import ray
+from isofit.core.common import envi_header
+from isofit.core.fileio import write_bil_chunk
+
+
+@ray.remote(num_cpus=1)
+class Worker(object):
+    def __init__(
+        self,
+        infile,
+        outfile,
+        inplace,
+        nodata_value=-9999.0,
+        logfile=None,
+        loglevel="INFO",
+    ):
+
+        logging.basicConfig(
+            format="%(levelname)s:%(asctime)s ||| %(message)s",
+            level=loglevel,
+            filename=logfile,
+            datefmt="%Y-%m-%d,%H:%M:%S",
+        )
+
+        self.infile = infile
+        self.inplace = inplace
+
+        if inplace:
+            self.outfile = infile
+        else:
+            self.outfile = outfile
+
+        self.nodata_value = nodata_value
+
+        self.in_img = envi.open(envi_header(self.infile))
+        self.nl, self.nb, self.ns = self.in_img.shape
+
+        # Get wavelength grid
+        self.wl = np.array(self.in_img.metadata["wavelength"]).astype(float)
+
+    def interpolate_values(self, meas, replace_nan=False):
+        if replace_nan:
+            non_nan_locs = np.argwhere(~np.isnan(meas))
+            all_replace = np.all(np.isnan(meas))
+        else:
+            non_nan_locs = np.argwhere(meas != self.nodata_value)
+            all_replace = np.all(meas == self.nodata_value)
+
+        if all_replace:
+            return meas, 10
+
+        elif len(non_nan_locs) != np.prod(meas.shape):
+            interp = scipy.interpolate.interp1d(
+                np.squeeze(self.wl[non_nan_locs]),
+                np.squeeze(meas[non_nan_locs]),
+                kind="linear",
+                fill_value="extrapolate",
+            )
+            return interp(self.wl), 1
+        else:
+            return meas, 0
+
+    def interpolate_chunk(self, startstop):
+        lstart, lend = startstop
+
+        logging.info(f"{lstart}: starting")
+        img_mm = self.in_img.open_memmap(interleave="bip", writable=False)
+
+        # Set up output
+        output_state = (
+            np.ones((lend - lstart, img_mm.shape[1], img_mm.shape[2]))
+            * self.nodata_value
+        )
+
+        # Check if chunk is only null data
+        use = np.logical_not(
+            np.isclose(np.array(img_mm[lstart:lend, :, :]), self.nodata_value)
+        )
+        if np.sum(use) == 0:
+            write_bil_chunk(
+                output_state.T,
+                self.outfile,
+                lstart,
+                (self.nl, self.nb, self.ns),
+            )
+            logging.warning(f"{lstart}: No non null data present, continuing")
+            return 0
+
+        # Iterate through the chunk
+        for r in range(lstart, lend):
+            for c in range(img_mm.shape[1]):
+                meas = img_mm[r, c, :]
+                # Replace no data flags
+                meas_interp, exit_code_nodata = self.interpolate_values(meas)
+
+                # Replace nans if there is both no data and nan
+                if np.any(np.isnan(meas)):
+                    meas_interp, exit_code_nan = self.interpolate_values(
+                        meas, replace_nan=True
+                    )
+                else:
+                    exit_code_nan = 0
+
+                if exit_code_nodata + exit_code_nan >= 10:
+                    logging.warning(
+                        f"Entire pixel is NaN or no data leaving as-is: {r, c}"
+                    )
+                elif exit_code_nodata + exit_code_nan >= 1:
+                    logging.warning(f"Interpolated NaN or no data in pixel: {r, c}")
+
+                output_state[r - lstart, c, :] = meas_interp
+
+            logging.info(f"Interpolation writing line {r}")
+            write_bil_chunk(
+                output_state[r - lstart, ...].T,
+                self.outfile,
+                r,
+                (self.nl, self.nb, self.ns),
+            )
+
+        return 0
+
+
+def interpolate_spectra(
+    infile: str,
+    outfile: str,
+    inplace: bool,
+    nodata_value: float = -9999.0,
+    n_cores: int = -1,
+    ray_address: str = None,
+    ray_redis_password: str = None,
+    ray_temp_dir: str = None,
+    ray_ip_head=None,
+    task_inflation_factor: int = 10,
+    logfile: str = None,
+    loglevel: str = "INFO",
+):
+
+    # Get size of the image to interpolate
+    ds = envi.open(envi_header(infile))
+    ds_shape = ds.shape
+    del ds
+
+    # If you want to make a new file
+    if not inplace:
+        output_metadata = envi.open(envi_header(infile)).metadata
+        img = envi.create_image(
+            envi_header(outfile),
+            ext="",
+            metadata=output_metadata,
+            force=True,
+        )
+        del img, output_metadata
+
+    if n_cores == -1:
+        n_cores = multiprocessing.cpu_count()
+
+    # Define ray dict in the same way as extractions.py
+    ray_dict = {
+        "ignore_reinit_error": True,
+        "address": ray_address,
+        "include_dashboard": False,
+        "_temp_dir": ray_temp_dir,
+        "_redis_password": ray_redis_password,
+    }
+    if ray_ip_head is None and ray_redis_password is None:
+        ray_dict["num_cpus"] = n_cores
+
+    ray.init(**ray_dict)
+
+    # Initialize workers
+    n_workers = n_cores
+    wargs = [
+        ray.put(obj)
+        for obj in (
+            infile,
+            outfile,
+            inplace,
+            nodata_value,
+            logfile,
+            loglevel,
+        )
+    ]
+    workers = ray.util.ActorPool([Worker.remote(*wargs) for _ in range(n_workers)])
+
+    # Assign chunks to each worker
+    line_breaks = np.linspace(
+        0, ds_shape[0], n_workers * task_inflation_factor, dtype=int
+    )
+    line_breaks = [
+        (line_breaks[n], line_breaks[n + 1]) for n in range(len(line_breaks) - 1)
+    ]
+
+    start_time = time.time()
+    res = list(
+        workers.map_unordered(lambda a, b: a.interpolate_chunk.remote(b), line_breaks)
+    )
+    total_time = time.time() - start_time
+
+    logging.info(
+        f"Interpolations complete.  {round(total_time,2)}s total, "
+        f"{round(ds_shape[0]*ds_shape[1]/total_time,4)} spectra/s, "
+        f"{round(ds_shape[0]*ds_shape[1]/total_time/n_workers,4)} spectra/s/core"
+    )

--- a/isofit/utils/interpolate_spectra.py
+++ b/isofit/utils/interpolate_spectra.py
@@ -164,7 +164,7 @@ def interpolate_spectra(
     """\
     Interpolate wavelength bands that are either no data or Nan.
     The interpolation will only be applied to pixel-vectors that include partial NaNs.
-    This is emant to be used if the number of wavelengths missing is minor, and has not
+    This is meant to be used if the number of wavelengths missing is minor, and has not
     been widely tested if a large number of wavelength vlues are missing.
 
     The interpolation will do two checks. One for "nodata values," the
@@ -187,7 +187,7 @@ def interpolate_spectra(
         float or int
     n_cores: int
         Number of cores to run. Substantial parallelism is available
-        Suggested to max this out on the available system
+        Defaults to maxing this out on the available system (-1)
     logfile: str
         File path to write logs to
     loglevel: str

--- a/isofit/utils/interpolate_spectra.py
+++ b/isofit/utils/interpolate_spectra.py
@@ -162,7 +162,7 @@ def interpolate_spectra(
     loglevel: str = "INFO",
 ):
     """\
-    Utility function to interpolate wavelength bands that are either no data or Nan.
+    Interpolate wavelength bands that are either no data or Nan.
     The interpolation will only be applied to pixel-vectors that include partial NaNs.
     This is emant to be used if the number of wavelengths missing is minor, and has not
     been widely tested if a large number of wavelength vlues are missing.
@@ -193,7 +193,6 @@ def interpolate_spectra(
     loglevel: str
         Logging level with which to run ISOFIT
     """
-
     # Get size of the image to interpolate
     ds = envi.open(envi_header(infile))
     ds_shape = ds.shape
@@ -272,10 +271,10 @@ def interpolate_spectra(
     name="interpolate_spectra", help=interpolate_spectra.__doc__, no_args_is_help=True
 )
 @click.argument("infile")
-@click.argument("--inplace", is_flag=True, default=False)
-@click.option("outfile")
-@click.option("--nodata_value")
-@click.option("--n_cores")
+@click.option("--inplace", is_flag=True, default=False)
+@click.option("--outfile")
+@click.option("--nodata_value", default=-9999)
+@click.option("--n_cores", default=-1)
 @click.option("--logfile")
 @click.option("--loglevel")
 def cli(**kwargs):

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -49,6 +49,7 @@ class Pathnames:
         aerosol_climatology_path,
         channelized_uncertainty_path,
         ray_temp_dir,
+        interpolate_inplace,
     ):
         # Determine FID based on sensor name
         if sensor == "ang":
@@ -128,6 +129,13 @@ class Pathnames:
             self.radiance_working_path = abspath(self.input_radiance_file)
             self.obs_working_path = abspath(self.input_obs_file)
             self.loc_working_path = abspath(self.input_loc_file)
+
+        if interpolate_inplace:
+            self.radiance_interp_path = self.radiance_working_path
+        else:
+            self.radiance_interp_path = abspath(
+                join(self.input_data_directory, rdn_fname + "_interp")
+            )
 
         if channelized_uncertainty_path:
             self.input_channelized_uncertainty_path = channelized_uncertainty_path


### PR DESCRIPTION
This is motivated by some of the PRISM data, which has a downtrack stripe of NaN values for one of the wavelengths. We were previously running a code block that did the interpolation within `isofit.run`.  This utility would allow us to call the interpolation once, within ApplyOE, and provide an "interpolated input file" that can propagate downstream.

The interpolation uses the same core code block that has been passed around for the PRISM lines:

```python
    def interpolate_values(self, meas, replace_nan=False):
        if replace_nan:
            non_nan_locs = np.argwhere(~np.isnan(meas))
            all_replace = np.all(np.isnan(meas))
        else:
            non_nan_locs = np.argwhere(meas != self.nodata_value)
            all_replace = np.all(meas == self.nodata_value)

        if all_replace:
            return meas, 10

        elif len(non_nan_locs) != np.prod(meas.shape):
            interp = scipy.interpolate.interp1d(
                np.squeeze(self.wl[non_nan_locs]),
                np.squeeze(meas[non_nan_locs]),
                kind="linear",
                fill_value="extrapolate",
            )
            return interp(self.wl), 1
        else:
            return meas, 0

```

There is also a flag to perform the interpolation in place or onto a new file. This is handled in template_construction.py within the [Pathnames](https://github.com/isofit/isofit/blob/bcd48083e47e4556511dd0fa7dad7124d6948d6a/isofit/utils/template_construction.py#L133-L138) class.
```python
        if interpolate_inplace:
            self.radiance_interp_path = self.radiance_working_path
        else:
            self.radiance_interp_path = abspath(
                join(self.input_data_directory, rdn_fname + "_interp")
            )
```