### PR TITLE
Patch to fix interpolate spectra for ApplyOE

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -535,7 +535,7 @@ def apply_oe(
         interpolate_spectra(
             paths.radiance_working_path,
             paths.radiance_interp_path,
-            interpolate_inplace,
+            inplace=interpolate_inplace,
             logfile=log_file,
         )
         paths.radiance_working_path = paths.radiance_interp_path

--- a/isofit/utils/interpolate_spectra.py
+++ b/isofit/utils/interpolate_spectra.py
@@ -149,8 +149,8 @@ class Worker(object):
 
 def interpolate_spectra(
     infile: str,
-    inplace: bool,
     outfile: str = "",
+    inplace: bool = False,
     nodata_value: float = -9999.0,
     n_cores: int = -1,
     ray_address: str = None,
@@ -271,8 +271,8 @@ def interpolate_spectra(
     name="interpolate_spectra", help=interpolate_spectra.__doc__, no_args_is_help=True
 )
 @click.argument("infile")
-@click.option("--inplace", is_flag=True, default=False)
 @click.option("--outfile")
+@click.option("--inplace", is_flag=True, default=False)
 @click.option("--nodata_value", default=-9999)
 @click.option("--n_cores", default=-1)
 @click.option("--logfile")


### PR DESCRIPTION
Managed to slip by my testing. The argument order between the interpolate_spectra function and the apply_oe call was inconsistent.

In the spirit of some other design comments, the inplace flag is now a kwarg. 