### PR TITLE
Warn if LUT keys are close to known geometry keys

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -21,6 +21,7 @@
 import json
 import os
 from collections import OrderedDict
+from difflib import SequenceMatcher
 from os.path import expandvars
 from typing import List
 
@@ -836,3 +837,41 @@ class Track:
 
             return True
         return False
+
+
+def compare(a, b, threshold=0.8, not_same=True):
+    """
+    Compares strings in `a` to strings in `b`
+
+    Parameters
+    ----------
+    a : str | list[str]
+        A string or list of strings to compare with `b`
+    a : str | list[str]
+        A string or list of strings to compare with `a`
+    threshold : float, default=0.8
+        Ratio threshold to meet to be considered matching. Must be between 0 and 1.
+    not_same : bool, default=True
+        Only include matches in which the two strings are not the same
+
+    Returns
+    -------
+    matching : dict
+        For each string in `a`, return a list of strings in `b` that meet the matching
+        threshold
+    """
+    if isinstance(a, str):
+        a = [a]
+
+    if isinstance(b, str):
+        b = [b]
+
+    matches = {}
+    for x in a:
+        for y in b:
+            if not_same and x == y:
+                continue
+            if SequenceMatcher(None, x, y).ratio() >= threshold:
+                matches.setdefault(x, []).append(y)
+
+    return matches

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -271,10 +271,18 @@ class RadiativeTransferEngine:
         if build_interpolators:
             self.build_interpolators()
 
+            geometry_keys = set(engine_config.statevector_names or self.lut_names)
+
+            for key, matches in common.compare(
+                geometry_keys, self.geometry_input_names
+            ):
+                Logger.warning(
+                    "A key in the statevector was detected to be close to keys in the geometry keys list:"
+                )
+                Logger.warning(f"  {key!r} should it be one of {matches}?")
+
             # Hidden assumption: geometry keys come first, then come RTE keys
-            self.geometry_input_names = set(self.geometry_input_names) - set(
-                engine_config.statevector_names or self.lut_names
-            )
+            self.geometry_input_names = set(self.geometry_input_names) - geometry_keys
             self.indices.geom = {
                 i: key
                 for i, key in enumerate(self.lut_names)

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -273,13 +273,13 @@ class RadiativeTransferEngine:
 
             geometry_keys = set(engine_config.statevector_names or self.lut_names)
 
-            for key, matches in common.compare(
-                geometry_keys, self.geometry_input_names
-            ):
+            matches = common.compare(geometry_keys, self.geometry_input_names)
+            if matches:
                 Logger.warning(
                     "A key in the statevector was detected to be close to keys in the geometry keys list:"
                 )
-                Logger.warning(f"  {key!r} should it be one of {matches}?")
+                for key, strings in matches.items():
+                    Logger.warning(f"  {key!r} should it be one of {strings}?")
 
             # Hidden assumption: geometry keys come first, then come RTE keys
             self.geometry_input_names = set(self.geometry_input_names) - geometry_keys


### PR DESCRIPTION
Addresses an issue in #602 where a LUT had the key `surface_elevation` but ISOFIT expects it to be named `surface_elevation_km`. This PR implements a function in `core/common.py` to compare LUT keys with the known geometry keys and if there's an 80% match, output a warning to the user to possibly change it