### PR TITLE
Fixing calibration for multiple surface models

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -189,12 +189,14 @@ class ForwardModel:
         The forward calculation is done at RT wavelengths.
         Then downsampled to instrument.
         """
-        # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(
-            x_surface, geom, L_down_dir, L_down_dif
+        lamb_rfl_hi = self.upsample(
+            self.surface.wl, self.surface.calc_lamb(x_surface, geom)
         )
-        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
-        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
+
+        # Call surface reflectance w.r.t. surface, upsample
+        rho_dir_dir_hi, rho_dif_dir_hi = self.surface.calc_rfl(
+            lamb_rfl_hi, x_surface, geom, L_down_dir, L_down_dif
+        )
 
         # Call surface emission, upsample
         Ls = self.calc_Ls(x_surface, geom)
@@ -214,10 +216,12 @@ class ForwardModel:
         Then downsampled to instrument.
         """
         # Call surface reflectance derivative w.r.t. surface, upsample
-        drfl_dsurface_hi = self.upsample(
-            self.surface.wl,
-            self.surface.drfl_dsurface(x_surface, geom, L_down_dir, L_down_dif).T,
-        ).T
+        lamb_rfl_hi = self.upsample(
+            self.surface.wl, self.surface.calc_lamb(x_surface, geom)
+        )
+        drfl_dsurface_hi = self.surface.drfl_dsurface(
+            lamb_rfl_hi, geom, L_down_dir, L_down_dif
+        )
 
         # Call surface emission w.r.t. surface, upsample
         dLs_dsurface_hi = self.upsample(

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -199,7 +199,7 @@ class ForwardModel:
         )
 
         # Call surface emission, upsample
-        Ls = self.calc_Ls(x_surface, geom)
+        Ls = self.surface.calc_Ls(lamb_rfl_hi, x_surface, geom)
         Ls_hi = self.upsample(self.surface.wl, Ls)
 
         return (

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -216,11 +216,12 @@ class ForwardModel:
         Then downsampled to instrument.
         """
         # Call surface reflectance derivative w.r.t. surface, upsample
-        lamb_rfl_hi = self.upsample(
-            self.surface.wl, self.surface.calc_lamb(x_surface, geom)
-        )
+        dlamb_dsurface_hi = self.upsample(
+            self.surface.wl,
+            self.surface.dlamb_dsurface(self.surface.calc_lamb(x_surface, geom)).T,
+        ).T
         drfl_dsurface_hi = self.surface.drfl_dsurface(
-            lamb_rfl_hi, geom, L_down_dir, L_down_dif
+            dlamb_dsurface_hi, geom, L_down_dir, L_down_dif
         )
 
         # Call surface emission w.r.t. surface, upsample

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -199,7 +199,7 @@ class ForwardModel:
         )
 
         # Call surface emission, upsample
-        Ls = self.surface.calc_Ls(lamb_rfl_hi, x_surface, geom)
+        Ls = self.surface.calc_Ls(x_surface, geom)
         Ls_hi = self.upsample(self.surface.wl, Ls)
 
         return (

--- a/isofit/surface/surface_additive_glint.py
+++ b/isofit/surface/surface_additive_glint.py
@@ -80,17 +80,20 @@ class AdditiveGlintSurface(ThermalSurface):
 
         return x
 
-    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def calc_rfl(self, lamb_rfl, x_surface, geom, L_down_dir=None, L_down_dif=None):
         """Reflectance (includes specular glint)."""
-        rfl = self.calc_lamb(x_surface, geom) + x_surface[self.glint_ind]
+        rho_dir_dir, rho_dif_dir = super().calc_rfl(
+            lamb_rfl, x_surface, geom, L_down_dir, L_down_dif
+        )
+        rho_dir_dir += x_surface[self.glint_ind]
 
-        return rfl, rfl
+        return rho_dir_dir, rho_dir_dir
 
-    def drfl_dsurface(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def drfl_dsurface(self, dlamb_dsurface, geom, L_down_dir=None, L_down_dif=None):
         """Partial derivative of reflectance with respect to state vector,
         calculated at x_surface."""
 
-        drfl = self.dlamb_dsurface(x_surface, geom)
+        drfl = super().drfl_dsurface(dlamb_dsurface, geom, L_down_dir, L_down_dif)
         drfl[:, self.glint_ind] = 1
 
         return drfl
@@ -127,20 +130,19 @@ class AdditiveGlintSurface(ThermalSurface):
         resolution entering this function.
         """
 
-        # Element wise multiplication between
-        # drdn_drfl (vector) and eye matrix to construct
-        # drdn_drfl (diagonal)
-        drdn_drfl = np.multiply(
-            self.drdn_drfl(L_tot, s_alb, rho_dif_dir)[:, np.newaxis],
-            np.eye(*drfl_dsurface.shape),
+        # Construct the output matrix
+        # Dimensions should be (len(RT.wl), len(x_surface))
+        # which is correctly handled by the instrument resampling
+        drdn_dsurface = np.zeros(drfl_dsurface.shape)
+        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
+        drdn_dsurface[:, : self.n_wl] = np.multiply(
+            drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
         )
+
         # Glint derivatives
         drdn_dglint = self.drdn_dglint(L_tot, s_alb, rho_dif_dir)
         # Last columns is glint derivative
-        drdn_drfl[:, -1] = drdn_dglint
-
-        # Chain rule to get derivative w.r.t. surface complete state
-        drdn_dsurface = np.multiply(drdn_drfl, drfl_dsurface)
+        drdn_dsurface[:, -1] = drdn_dglint
 
         # Get the derivative w.r.t. surface emission
         drdn_dLs = np.multiply(self.drdn_dLs(t_total_up)[:, np.newaxis], dLs_dsurface)

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -234,7 +234,7 @@ class MultiComponentSurface(Surface):
 
         return L_tot / ((1.0 - s_alb * rho_dif_dir) ** 2)
 
-    def calc_Ls(self, x_surface, geom):
+    def calc_Ls(self, lamb_rfl, x_surface, geom):
         """Emission of surface, as a radiance."""
 
         return np.zeros(self.n_wl, dtype=float)
@@ -270,11 +270,13 @@ class MultiComponentSurface(Surface):
         """Derivative of radiance with respect to
         full surface vector"""
 
-        # Element wise multiplication between
-        # drdn_drfl (vector) and eye matrix to construct
-        # drdn_drfl (diagonal)
-        drdn_dsurface = np.multiply(
-            self.drdn_drfl(L_tot, s_alb, rho_dif_dir)[:, np.newaxis], drfl_dsurface
+        # Construct the output matrix
+        # Dimensions should be (len(RT.wl), len(x_surface))
+        # which is correctly handled by the instrument resampling
+        drdn_dsurface = np.zeros(drfl_dsurface.shape)
+        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
+        drdn_dsurface[:, : self.n_wl] = np.multiply(
+            drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
         )
 
         # Get the derivative w.r.t. surface emission

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -214,11 +214,11 @@ class MultiComponentSurface(Surface):
 
         return x_surface[self.idx_lamb]
 
-    def drfl_dsurface(self, lamb_rfl, geom, L_down_dir=None, L_down_dif=None):
+    def drfl_dsurface(self, dlamb_dsurface, geom, L_down_dir=None, L_down_dif=None):
         """Partial derivative of reflectance with respect to state vector,
         calculated at x_surface."""
 
-        return self.dlamb_dsurface(lamb_rfl)
+        return dlamb_dsurface
 
     def dlamb_dsurface(self, lamb_rfl):
         """Partial derivative of Lambertian reflectance with respect to

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -234,7 +234,7 @@ class MultiComponentSurface(Surface):
 
         return L_tot / ((1.0 - s_alb * rho_dif_dir) ** 2)
 
-    def calc_Ls(self, lamb_rfl, x_surface, geom):
+    def calc_Ls(self, x_surface, geom):
         """Emission of surface, as a radiance."""
 
         return np.zeros(self.n_wl, dtype=float)

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -86,10 +86,12 @@ class ThermalSurface(MultiComponentSurface):
 
         return dlamb
 
-    def calc_Ls(self, lamb_rfl, x_surface, geom):
+    def calc_Ls(self, x_surface, geom):
         """Emission of surface, as a radiance."""
 
         T = x_surface[self.surf_temp_ind]
+        lamb_rfl = self.calc_lamb(x_surface, geom)
+
         rfl = self.calc_rfl(lamb_rfl, x_surface, geom)
         # ToDo: direct and diffuse reflectance vectors not supported yet
         rfl[0][rfl[0] > 1.0] = 1.0


### PR DESCRIPTION
Problem: #637 broke the ability to run with different wavelength grids between RT and surface. 

This fixes that case for `multicomponent_surface` for the most common use case of that scenario. This also proposes changes to make this functionality possible across all surface models.


Summary of short fix:
The requirement to handle the resampling is that the high-resolution K matrix must be of size: `len(RT.wl), len(surface_states)` To accommodate this, the `drdn_dsurface` matrix is initialized [following](https://github.com/evan-greenbrg/isofit/blob/27c5648ffc053d0acce8c214f7d9318b9d49439b/isofit/surface/surface_multicomp.py#L273-L280): 

```python
        # Construct the output matrix
        # Dimensions should be (len(RT.wl), len(x_surface))
        # which is correctly handled by the instrument resampling
        drdn_dsurface = np.zeros(drfl_dsurface.shape)
        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
        drdn_dsurface[:, : self.n_wl] = np.multiply(
            drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
        )
```

where `drfl_dsurface` is already resampled to the correct dimensions and is/has been handled by `foreward.py`.

This is all that needs to be updated to accommodate the calibration run cases using the `multicomponent_surface`. Things get more complicated if you are using a different surface model, particularly `glint_model_surface`.

Extending the fix to other surface models:

The crux of the challenge is that we have to [add together portions of the surface statevector directly with glint quantities that are carried at the RT resolution](https://github.com/isofit/isofit/blob/564305b34a027f253e12bbfed58487e61529b7fc/isofit/surface/surface_glint_model.py#L125-L136).

```python
    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
        """Direct and diffuse Reflectance (includes sun and sky glint)."""
        # fresnel reflectance factor (approx. 0.02 for nadir view)
        g_dir, g_dif = self.glint_spectra(geom, L_down_dir, L_down_dif)

        sun_glint = x_surface[-2] * g_dir
        sky_glint = x_surface[-1] * g_dif

        rho_dir_dir = self.calc_lamb(x_surface, geom) + sun_glint
        rho_dif_dir = self.calc_lamb(x_surface, geom) + sky_glint

        return rho_dir_dir, rho_dif_dir
```
`calc_lamb` pulls directly from the statevector (which is not upsampled) and errors arise.

The proposed fix is carry rfl values into the surface functions. [e.g.](https://github.com/evan-greenbrg/isofit/blob/27c5648ffc053d0acce8c214f7d9318b9d49439b/isofit/surface/surface_glint_model.py#L131-L150):

```python
    def calc_rfl(self, lamb_rfl, x_surface, geom, L_down_dir=None, L_down_dif=None):
        """Direct and diffuse Reflectance (includes sun and sky glint).

        lamb_rfl has to be at same resolution as L_down_dir/L_down_dif
        """
        # Inherit from inherited surface
        rho_dir_dir, rho_dif_dir = super().calc_rfl(
            lamb_rfl, x_surface, geom, L_down_dir, L_down_dif
        )

        # fresnel reflectance factor (approx. 0.02 for nadir view)
        g_dir, g_dif = self.glint_spectra(geom, L_down_dir, L_down_dif)

        sun_glint = x_surface[-2] * g_dir
        sky_glint = x_surface[-1] * g_dif

        rho_dir_dir += sun_glint
        rho_dif_dir += sky_glint

        return rho_dir_dir, rho_dif_dir
```

Where `lamb_rfl` is upsampled within `foreward.py` and the dimensions match.
```python
        lamb_rfl_hi = self.upsample(
            self.surface.wl, self.surface.calc_lamb(x_surface, geom)
        )

        # Call surface reflectance w.r.t. surface, upsample
        rho_dir_dir_hi, rho_dif_dir_hi = self.surface.calc_rfl(
            lamb_rfl_hi, x_surface, geom, L_down_dir, L_down_dif
        )
```

The same is repeated for the derivative matrices.