### PR TITLE
Patch for Analytical Line write

### DIFF
--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -512,7 +512,7 @@ class Worker(object):
             logging.info(f"Analytical line writing line {r}")
 
             write_bil_chunk(
-                output_rfl[r - start_line, c, :].T,
+                output_rfl[r - start_line, ...].T,
                 self.analytical_rfl_file,
                 r,
                 (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
@@ -526,7 +526,7 @@ class Worker(object):
 
             if self.analytical_non_rfl_surf_file:
                 write_bil_chunk(
-                    output_non_rfl[r - start_line, c, :].T,
+                    output_non_rfl[r - start_line, ...].T,
                     self.analytical_non_rfl_surf_file,
                     r,
                     (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -512,7 +512,7 @@ class Worker(object):
             logging.info(f"Analytical line writing line {r}")
 
             write_bil_chunk(
-                output_rfl.T,
+                output_rfl[r - start_line, c, :].T,
                 self.analytical_rfl_file,
                 r,
                 (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
@@ -526,7 +526,7 @@ class Worker(object):
 
             if self.analytical_non_rfl_surf_file:
                 write_bil_chunk(
-                    output_non_rfl.T,
+                    output_non_rfl[r - start_line, c, :].T,
                     self.analytical_non_rfl_surf_file,
                     r,
                     (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -358,24 +358,16 @@ class Worker(object):
         lbl = envi.open(envi_header(self.lbl_file)).open_memmap(interleave="bip")
 
         start_line, stop_line = startstop
-        output_rfl = (
-            np.zeros(
-                (stop_line - start_line, rt_state.shape[1], len(self.fm.idx_surf_rfl))
-            )
-            - 9999
-        )
+        output_rfl = np.zeros((1, rt_state.shape[1], len(self.fm.idx_surf_rfl))) - 9999
         output_rfl_unc = (
-            np.zeros(
-                (stop_line - start_line, rt_state.shape[1], len(self.fm.idx_surf_rfl))
-            )
-            - 9999
+            np.zeros((1, rt_state.shape[1], len(self.fm.idx_surf_rfl))) - 9999
         )
 
         if self.analytical_non_rfl_surf_file:
             output_non_rfl = (
                 np.zeros(
                     (
-                        stop_line - start_line,
+                        1,
                         rt_state.shape[1],
                         len(self.fm.idx_surf_nonrfl),
                     )
@@ -385,7 +377,7 @@ class Worker(object):
             output_non_rfl_unc = (
                 np.zeros(
                     (
-                        stop_line - start_line,
+                        1,
                         rt_state.shape[1],
                         len(self.fm.idx_surf_nonrfl),
                     )
@@ -479,16 +471,12 @@ class Worker(object):
                         f"Row, Col: {r, c} - Sa matrix is non-invertible. Statevector is likely NaNs."
                     )
 
-                output_rfl[r - start_line, c, :] = states[-1, self.fm.idx_surf_rfl]
-                output_rfl_unc[r - start_line, c, :] = unc[self.fm.idx_surf_rfl]
+                output_rfl[0, c, :] = states[-1, self.fm.idx_surf_rfl]
+                output_rfl_unc[0, c, :] = unc[self.fm.idx_surf_rfl]
 
                 if self.analytical_non_rfl_surf_file:
-                    output_non_rfl[r - start_line, c, :] = states[
-                        -1, self.fm.idx_surf_nonrfl
-                    ]
-                    output_non_rfl_unc[r - start_line, c, :] = unc[
-                        self.fm.idx_surf_nonrfl
-                    ]
+                    output_non_rfl[0, c, :] = states[-1, self.fm.idx_surf_nonrfl]
+                    output_non_rfl_unc[0, c, :] = unc[self.fm.idx_surf_nonrfl]
 
             # What do we want to do with the negative reflectances?
             # state = output_state[r - start_line, ...]
@@ -502,34 +490,34 @@ class Worker(object):
             # )
             # state[mask] = 0
 
-        logging.info(f"Writing lines {start_line} to {stop_line}")
+            logging.info(f"Writing line: {r}")
 
-        write_bil_chunk(
-            output_rfl.T,
-            self.analytical_rfl_file,
-            start_line,
-            (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
-        )
-        write_bil_chunk(
-            output_rfl_unc.T,
-            self.analytical_rfl_unc_file,
-            start_line,
-            (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
-        )
-
-        if self.analytical_non_rfl_surf_file:
             write_bil_chunk(
-                output_non_rfl.T,
-                self.analytical_non_rfl_surf_file,
-                start_line,
-                (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),
+                output_rfl.T,
+                self.analytical_rfl_file,
+                r,
+                (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
             )
             write_bil_chunk(
-                output_non_rfl_unc.T,
-                self.analytical_non_rfl_surf_unc_file,
-                start_line,
-                (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),
+                output_rfl_unc.T,
+                self.analytical_rfl_unc_file,
+                r,
+                (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
             )
+
+            if self.analytical_non_rfl_surf_file:
+                write_bil_chunk(
+                    output_non_rfl.T,
+                    self.analytical_non_rfl_surf_file,
+                    r,
+                    (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),
+                )
+                write_bil_chunk(
+                    output_non_rfl_unc.T,
+                    self.analytical_non_rfl_surf_unc_file,
+                    r,
+                    (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),
+                )
 
 
 @click.command(name="analytical_line")

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -191,16 +191,9 @@ def analytical_line(
         output_metadata["band names"] = np.array(fm.surface.statevec_names)[
             fm.idx_surf_nonrfl
         ]
-        ret = [
-            output_metadata.pop(k)
-            for k in [
-                "bbl",
-                "wavelength",
-                "wavelength units",
-                "fwhm",
-                "smoothing factors",
-            ]
-        ]
+        for k in ["bbl", "wavelength", "wavelength units", "fwhm", "smoothing factors"]:
+            if output_metadata.get(k):
+                ret = output_metadata.pop(k)
 
         img = envi.create_image(
             envi_header(analytical_non_rfl_surf_file),

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -509,34 +509,34 @@ class Worker(object):
             # )
             # state[mask] = 0
 
-            logging.info(f"Analytical line writing line {r}")
+        logging.info(f"Writing lines {start_line} to {stop_line}")
 
+        write_bil_chunk(
+            output_rfl.T,
+            self.analytical_rfl_file,
+            start_line,
+            (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
+        )
+        write_bil_chunk(
+            output_rfl_unc.T,
+            self.analytical_rfl_unc_file,
+            start_line,
+            (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
+        )
+
+        if self.analytical_non_rfl_surf_file:
             write_bil_chunk(
-                output_rfl[r - start_line, ...].T,
-                self.analytical_rfl_file,
-                r,
-                (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
+                output_non_rfl.T,
+                self.analytical_non_rfl_surf_file,
+                start_line,
+                (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),
             )
             write_bil_chunk(
-                output_rfl_unc[r - start_line, ...].T,
-                self.analytical_rfl_unc_file,
-                r,
-                (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_rfl)),
+                output_non_rfl_unc.T,
+                self.analytical_non_rfl_surf_unc_file,
+                start_line,
+                (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),
             )
-
-            if self.analytical_non_rfl_surf_file:
-                write_bil_chunk(
-                    output_non_rfl[r - start_line, ...].T,
-                    self.analytical_non_rfl_surf_file,
-                    r,
-                    (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),
-                )
-                write_bil_chunk(
-                    output_non_rfl_unc[r - start_line, ...].T,
-                    self.analytical_non_rfl_surf_unc_file,
-                    r,
-                    (rdn.shape[0], rdn.shape[1], len(self.fm.idx_surf_nonrfl)),
-                )
 
 
 @click.command(name="analytical_line")


### PR DESCRIPTION
These two lines were changed with [this commit](https://github.com/isofit/isofit/commit/b8a5144740321ed7ee6a122f6fe79e6c1a03b845). 

I didn't catch the error with my primary testing cube, which continues to write successfully. However, I hit an issue running a different line and was able to reproduce with two additional cubes. The updated syntax is consistent with prior commits ([e.g.](https://github.com/isofit/isofit/blob/75d2ab488103d909639398ee841d60d627b331de/isofit/utils/analytical_line.py)) 