### PR TITLE
Patch to run calibration cases with new surface structure

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -77,11 +77,24 @@ class ForwardModel:
         if self.surface.n_wl != len(self.RT.wl) or not np.all(
             np.isclose(self.surface.wl, self.RT.wl, atol=0.01)
         ):
-            Logger.warning(
-                "Surface and RTM wavelengths differ - if running at higher RTM"
-                " spectral resolution or with variable wavelength position, this"
-                " is expected.  Otherwise, consider checking the surface model."
-            )
+            if self.config.surface.surface_category == "glint_model_surface":
+                Logger.error(
+                    "Surface and RTM wavelengths differ and you are attempting"
+                    " to run the glint_model_surface. This behavior is not currently"
+                    " implemented for the glint_model. If this functionality is"
+                    " needed for the run case, e.g. calibration, please use"
+                    " a different surface model"
+                )
+                raise Valueerror(
+                    "Using glint_model_surface with differing surface and"
+                    " RT wavelenths is not implemented. See log for detail"
+                )
+            else:
+                Logger.warning(
+                    "Surface and RTM wavelengths differ - if running at higher RTM"
+                    " spectral resolution or with variable wavelength position, this"
+                    " is expected.  Otherwise, consider checking the surface model."
+                )
 
         # Build combined vectors from surface, RT, and instrument
         bounds, scale, init, statevec, bvec, bval = ([] for i in range(6))

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -74,27 +74,15 @@ class ForwardModel:
         # Build the surface model
         self.surface = Surface(full_config)
 
+        # Check to see if using supported calibration surface model
         if self.surface.n_wl != len(self.RT.wl) or not np.all(
             np.isclose(self.surface.wl, self.RT.wl, atol=0.01)
         ):
-            if self.config.surface.surface_category == "glint_model_surface":
-                Logger.error(
-                    "Surface and RTM wavelengths differ and you are attempting"
-                    " to run the glint_model_surface. This behavior is not currently"
-                    " implemented for the glint_model. If this functionality is"
-                    " needed for the run case, e.g. calibration, please use"
-                    " a different surface model"
-                )
-                raise Valueerror(
-                    "Using glint_model_surface with differing surface and"
-                    " RT wavelenths is not implemented. See log for detail"
-                )
-            else:
-                Logger.warning(
-                    "Surface and RTM wavelengths differ - if running at higher RTM"
-                    " spectral resolution or with variable wavelength position, this"
-                    " is expected.  Otherwise, consider checking the surface model."
-                )
+            Logger.warning(
+                "Surface and RTM wavelengths differ - if running at higher RTM"
+                " spectral resolution or with variable wavelength position, this"
+                " is expected.  Otherwise, consider checking the surface model."
+            )
 
         # Build combined vectors from surface, RT, and instrument
         bounds, scale, init, statevec, bvec, bval = ([] for i in range(6))

--- a/isofit/data/build_examples.py
+++ b/isofit/data/build_examples.py
@@ -243,6 +243,7 @@ Examples = {
     ),
     "Pasadena": IsofitExample(name="20171108_Pasadena", requires=["data"]),
     "ThermalIR": IsofitExample(name="20190806_ThermalIR", requires=["data"]),
+    "AV3Cal": IsofitExample(name="20250308_AV3Cal_wltest", requires=["data"]),
     "ImageCube-small": ApplyOEExample(
         name="image_cube/small",
         requires=["sixs", "srtmnet", "image_cube"],

--- a/isofit/data/cli/examples.py
+++ b/isofit/data/cli/examples.py
@@ -105,18 +105,23 @@ def validate(path=None, checkForUpdate=True, debug=print, error=print, **_):
         error("[x] Examples path does not exist")
         return False
 
-    expected = [
-        "20151026_SantaMonica",
-        "20171108_Pasadena",
-        "20190806_ThermalIR",
-        "LICENSE",
-        "README.md",
-        "image_cube",
-        "profiling_cube",
-        "py-hypertrace",
-    ]
-    if not list(path.glob("*")) != expected:
+    expected = set(
+        [
+            "20151026_SantaMonica",
+            "20171108_Pasadena",
+            "20190806_ThermalIR",
+            "LICENSE",
+            "README.md",
+            "image_cube",
+            "profiling_cube",
+        ]
+    )
+    names = set([file.name for file in path.glob("*")])
+    if missing := (expected - names):
         error("[x] ISOFIT examples do not appear to be installed correctly")
+        debug(f"Expected: {expected}")
+        debug(f"Got: {names}")
+        debug(f"Missing: {missing}")
         return False
 
     debug("[✓] Path is valid")

--- a/isofit/surface/surface_additive_glint.py
+++ b/isofit/surface/surface_additive_glint.py
@@ -127,20 +127,19 @@ class AdditiveGlintSurface(ThermalSurface):
         resolution entering this function.
         """
 
-        # Element wise multiplication between
-        # drdn_drfl (vector) and eye matrix to construct
-        # drdn_drfl (diagonal)
-        drdn_drfl = np.multiply(
-            self.drdn_drfl(L_tot, s_alb, rho_dif_dir)[:, np.newaxis],
-            np.eye(*drfl_dsurface.shape),
+        # Construct the output matrix
+        # Dimensions should be (len(RT.wl), len(x_surface))
+        # which is correctly handled by the instrument resampling
+        drdn_dsurface = np.zeros(drfl_dsurface.shape)
+        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
+        drdn_dsurface[:, : self.n_wl] = np.multiply(
+            drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
         )
+
         # Glint derivatives
         drdn_dglint = self.drdn_dglint(L_tot, s_alb, rho_dif_dir)
         # Last columns is glint derivative
-        drdn_drfl[:, -1] = drdn_dglint
-
-        # Chain rule to get derivative w.r.t. surface complete state
-        drdn_dsurface = np.multiply(drdn_drfl, drfl_dsurface)
+        drdn_dsurface[:, -1] = drdn_dglint * drfl_dsurface[:, -1]
 
         # Get the derivative w.r.t. surface emission
         drdn_dLs = np.multiply(self.drdn_dLs(t_total_up)[:, np.newaxis], dLs_dsurface)

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -204,10 +204,16 @@ class LUTSurface(Surface):
         full surface vector"""
 
         drdn_dLs = t_total_up
+
+        drdn_dsurface = np.zeros(drfl_dsurface.shape)
         drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
 
-        # Chain rule to get derivative w.r.t. surface complete state
-        drdn_dsurface = np.multiply(drdn_drfl, drfl_dsurface)
+        # Construct the output matrix:
+        # Dimensions should be (len(RT.wl), len(x_surface))
+        # which is correctly handled by the instrument resampling
+        drdn_dsurface[:, : self.n_wl] = np.multiply(
+            drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
+        )
 
         # Get the derivative w.r.t. surface emission
         drdn_dLs = np.multiply(self.drdn_dLs(t_total_up)[:, np.newaxis], dLs_dsurface)

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -273,16 +273,15 @@ class MultiComponentSurface(Surface):
         """Derivative of radiance with respect to
         full surface vector"""
 
-        # Element wise multiplication between
-        # drdn_drfl (vector) and eye matrix to construct
-        # drdn_drfl (diagonal)
-        drdn_drfl = np.multiply(
-            self.drdn_drfl(L_tot, s_alb, rho_dif_dir)[:, np.newaxis],
-            np.eye(len(self.wl), drfl_dsurface.shape[1]),
-        )
+        # Construct the output matrix:
+        # Dimensions should be (len(RT.wl), len(x_surface))
+        # which is correctly handled by the instrument resampling
+        drdn_dsurface = np.zeros(drfl_dsurface.shape)
+        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
 
-        # Chain rule to get derivative w.r.t. surface complete state
-        drdn_dsurface = np.multiply(drdn_drfl, drfl_dsurface)
+        drdn_dsurface[:, : self.n_wl] = np.multiply(
+            drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
+        )
 
         # Get the derivative w.r.t. surface emission
         drdn_dLs = np.multiply(self.drdn_dLs(t_total_up)[:, np.newaxis], dLs_dsurface)

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -124,16 +124,15 @@ class ThermalSurface(MultiComponentSurface):
         """Derivative of radiance with respect to
         full surface vector"""
 
-        # Element wise multiplication between
-        # drdn_drfl (vector) and eye matrix to construct
-        # drdn_drfl (diagonal)
-        drdn_drfl = np.multiply(
-            self.drdn_drfl(L_tot, s_alb, rho_dif_dir)[:, np.newaxis],
-            np.eye(len(self.wl), drfl_dsurface.shape[1]),
-        )
+        # Construct the output matrix:
+        # Dimensions should be (len(RT.wl), len(x_surface))
+        # which is correctly handled by the instrument resampling
+        drdn_dsurface = np.zeros(drfl_dsurface.shape)
+        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
 
-        # Chain rule to get derivative w.r.t. surface complete state
-        drdn_dsurface = np.multiply(drdn_drfl, drfl_dsurface)
+        drdn_dsurface[:, : self.n_wl] = np.multiply(
+            drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
+        )
 
         # Get the derivative w.r.t. surface emission
         drdn_dLs = np.multiply(self.drdn_dLs(t_total_up)[:, np.newaxis], dLs_dsurface)

--- a/isofit/test/test_examples.py
+++ b/isofit/test/test_examples.py
@@ -72,6 +72,27 @@ def test_pasadena_topoflux(monkeypatch):
     model.run()
 
 
+@pytest.mark.examples
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("--level", "DEBUG", "configs/AV320250308t200738_isofit.json"),
+        ("--level", "DEBUG", "configs/AV320250308t200738_isofit_swir_shift.json"),
+        ("--level", "DEBUG", "configs/AV320250308t200738_isofit_swir_spline.json"),
+    ],
+)
+# fmt: on
+def test_av3_calibration(args, monkeypatch):
+    """Run the calibration test dataset."""
+
+    monkeypatch.chdir(env.path("examples", "20250308_AV3Calibration/"))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run"] + list(args), catch_exceptions=False)
+
+    assert result.exit_code == 0
+
+
 @pytest.mark.xfail
 @pytest.mark.examples
 def test_modtran_one(monkeypatch):

--- a/isofit/test/test_examples.py
+++ b/isofit/test/test_examples.py
@@ -76,16 +76,25 @@ def test_pasadena_topoflux(monkeypatch):
 @pytest.mark.parametrize(
     "args",
     [
-        ("--level", "DEBUG", "configs/AV320250308t200738_isofit.json"),
-        ("--level", "DEBUG", "configs/AV320250308t200738_isofit_swir_shift.json"),
-        ("--level", "DEBUG", "configs/AV320250308t200738_isofit_swir_spline.json"),
+        ("--level", "DEBUG", "configs/AV320250308t200738_wltest_isofit.json"),
+        (
+            "--level",
+            "DEBUG",
+            "configs/AV320250308t200738_wltest_isofit_swir_shift.json",
+        ),
+        (
+            "--level",
+            "DEBUG",
+            "configs/AV320250308t200738_wltest_isofit_swir_spline.json",
+        ),
     ],
 )
 # fmt: on
 def test_av3_calibration(args, monkeypatch):
     """Run the calibration test dataset."""
 
-    monkeypatch.chdir(env.path("examples", "20250308_AV3Calibration/"))
+    monkeypatch.chdir(env.path("examples", "20250308_AV3Cal_wltest/"))
+    os.makedirs("output", exist_ok=True)
 
     runner = CliRunner()
     result = runner.invoke(cli, ["run"] + list(args), catch_exceptions=False)


### PR DESCRIPTION
Changes: 
   - Non-glint surface classes now handle (again) calibration cases where the RT and surface wl grids differ.
   - I've added an explicit exception if the surface and RT wl grids don't match _and_ the surface model is glint.
   - I've added a test for the calibration runs (files and workflow to be package and set up)


Related tutorial PR: https://github.com/isofit/isofit-tutorials/pull/18

Tests are currently failing because the new calibration pytest is grouped with `_examples`.