### PR TITLE
Removed L_dir(dif)/L_tot ratio in glint model

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -271,15 +271,17 @@ def invert_analytical(
 
     # Get all the surface quantities
     sub_surface, sub_RT, sub_instrument = fm.unpack(sub_state)
-    rho_dir_dir, rho_dif_dir, Ls = fm.upsample_surface_vectors_to_RT(
-        x_surface, geom, L_down_dir, L_down_dif
-    )
+
+    rho_dir_dir, rho_dif_dir = fm.calc_rfl(sub_surface, geom)
+    rho_dir_dir = fm.upsample(fm.surface.wl, rho_dir_dir)
+    rho_dif_dir = fm.upsample(fm.surface.wl, rho_dif_dir)
+
     # background conditions
     bg = s * rho_dif_dir
 
     # Special case: 1-component model
     if type(L_tot) != np.ndarray or len(L_tot) == 1:
-        L_tot = L_down_tot
+        L_tot = L_down_dir + L_down_dif
 
     # Get the inversion indices; Include glint indices if applicable
     full_idx = np.concatenate((winidx, fm.idx_surf_nonrfl), axis=0)
@@ -356,7 +358,7 @@ def invert_analytical(
 
     # TODO
     """
-    Not currently implemented cleanly if we want to propogate 
+    Not currently implemented cleanly if we want to propogate
     the entire glint spectrum. Need to clean up implementation.
     """
     # if fm.RT.glint_model and fm.surface.return_glint_spectrum:

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -89,7 +89,7 @@ class Surface:
 
         return self.rfl
 
-    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def calc_rfl(self, x_surface, geom):
         """Calculate the directed reflectance (specifically the HRDF) for this
         state vector."""
 
@@ -97,7 +97,7 @@ class Surface:
         #  As long as this is not implemented, return the same reflectance vector for both.
         return self.rfl, self.rfl
 
-    def drfl_dsurface(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,
         calculated at x_surface. In the case that there are no free
         paramters our convention is to return the vector of zeros."""

--- a/isofit/surface/surface_additive_glint.py
+++ b/isofit/surface/surface_additive_glint.py
@@ -80,13 +80,13 @@ class AdditiveGlintSurface(ThermalSurface):
 
         return x
 
-    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def calc_rfl(self, x_surface, geom):
         """Reflectance (includes specular glint)."""
         rfl = self.calc_lamb(x_surface, geom) + x_surface[self.glint_ind]
 
         return rfl, rfl
 
-    def drfl_dsurface(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,
         calculated at x_surface."""
 

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -109,7 +109,7 @@ class LUTSurface(Surface):
 
         return x_surface
 
-    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def calc_rfl(self, x_surface, geom):
         """Non-Lambertian reflectance."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.
@@ -139,7 +139,7 @@ class LUTSurface(Surface):
 
         return lamb
 
-    def drfl_dsurface(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,
         calculated at x_surface."""
 

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -199,7 +199,7 @@ class MultiComponentSurface(Surface):
 
         return x_surface
 
-    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def calc_rfl(self, x_surface, geom):
         """Non-Lambertian reflectance."""
 
         # ToDo: Future use of calc_rfl() is to return a direct and diffuse surface reflectance quantity.
@@ -213,7 +213,7 @@ class MultiComponentSurface(Surface):
 
         return x_surface[self.idx_lamb]
 
-    def drfl_dsurface(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
+    def drfl_dsurface(self, x_surface, geom):
         """Partial derivative of reflectance with respect to state vector,
         calculated at x_surface."""
 


### PR DESCRIPTION
This PR includes two changes:
1. Removed the ratio that was included in the glint model 

For example,  [the old implementation](https://github.com/isofit/isofit/blob/559bc1206a81b1ce834d124793d847b257bf80c9/isofit/surface/surface_glint_model.py#L115-L136):

```python
    def glint_spectra(self, geom, L_down_dir, L_down_dif):
        """Calculates the sun (dir) and sky (dif) glint spectrums"""
        rho_ls = self.fresnel_rf(geom.observer_zenith)
        # direct sky transmittance
        g_dir = rho_ls * (L_down_dir / (L_down_dir + L_down_dif))
        # diffuse sky transmittance
        g_dif = rho_ls * (L_down_dif / (L_down_dir + L_down_dif))

        return g_dir, g_dif

    def calc_rfl(self, x_surface, geom, L_down_dir=None, L_down_dif=None):
        """Direct and diffuse Reflectance (includes sun and sky glint)."""
        # fresnel reflectance factor (approx. 0.02 for nadir view)
        g_dir, g_dif = self.glint_spectra(geom, L_down_dir, L_down_dif)

        sun_glint = x_surface[-2] * g_dir
        sky_glint = x_surface[-1] * g_dif

        rho_dir_dir = self.calc_lamb(x_surface, geom) + sun_glint
        rho_dif_dir = self.calc_lamb(x_surface, geom) + sky_glint

        return rho_dir_dir, rho_dif_dir
```

[Changed to:](https://github.com/evan-greenbrg/isofit/blob/21c63a4bfc3620042854bf330418505d45ff1fd0/isofit/surface/surface_glint_model.py#L115-L126)
```python
    def calc_rfl(self, x_surface, geom):
        """Direct and diffuse Reflectance (includes sun and sky glint)."""
        # fresnel reflectance factor (approx. 0.02 for nadir view)
        rho_ls = self.fresnel_rf(geom.observer_zenith)

        sun_glint = x_surface[-2] * rho_ls
        sky_glint = x_surface[-1] * rho_ls

        rho_dir_dir = self.calc_lamb(x_surface, geom) + sun_glint
        rho_dif_dir = self.calc_lamb(x_surface, geom) + sky_glint

        return rho_dir_dir, rho_dif_dir
```

The derivatives are also [updated](https://github.com/evan-greenbrg/isofit/blob/21c63a4bfc3620042854bf330418505d45ff1fd0/isofit/surface/surface_glint_model.py#L128-L144) 


2. The second change is that I made a first pass on some simplification/walking back previous changes to support the glint model. This includes: removing L_ddir and L_ddif arguments in the `calc_rfl` and `drfl_dsurface` and removing the surface upsampling functions within `forward.py`