### PR TITLE
Added handling for LinalgError and fill_value for failed pixels

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -224,6 +224,7 @@ def invert_analytical(
     hash_size: int = None,
     diag_uncert: bool = True,
     outside_ret_const: float = -0.01,
+    fill_value: float = -9999.0,
 ):
     """Perform an analytical estimate of the conditional MAP estimate for
     a fixed atmosphere.  Based on the "Inner loop" from Susiluoto, 2022.
@@ -303,10 +304,16 @@ def invert_analytical(
             Sa_surface = Sa[fm.idx_surface, :][:, fm.idx_surface]
             Sa_inv = svd_inv_sqrt(Sa_surface, hash_table, hash_size)[0]
 
+        except np.linalg.LinAlgError:
+            C_rcond = []
+            trajectory[n + 1, :] = [fill_value for i in x]
+            EXIT_CODE = -15
+            continue
+
         except ValueError:
             # On invertible matrix error, save NaN array on step and update exit code
             C_rcond = []
-            trajectory[n + 1, :] = x
+            trajectory[n + 1, :] = [fill_value for i in x]
             EXIT_CODE = -11
             continue
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -304,18 +304,13 @@ def invert_analytical(
             Sa_surface = Sa[fm.idx_surface, :][:, fm.idx_surface]
             Sa_inv = svd_inv_sqrt(Sa_surface, hash_table, hash_size)[0]
 
-        except np.linalg.LinAlgError:
+        except (np.linalg.LinAlgError, ValueError) as e:
             C_rcond = []
-            trajectory[n + 1, :] = [fill_value for i in x]
-            EXIT_CODE = -15
-            continue
-
-        except ValueError:
-            # On invertible matrix error, save NaN array on step and update exit code
-            C_rcond = []
-            trajectory[n + 1, :] = [fill_value for i in x]
-            EXIT_CODE = -11
-            continue
+            trajectory[n + 1, :] = [fill_value] * len(x)
+            if isinstance(e, np.linalg.LinAlgError):
+                EXIT_CODE = -15
+            elif isinstance(e, ValueError):
+                EXIT_CODE = -11
 
         # Prior mean
         xa_full = fm.xa(x, geom)

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -470,6 +470,10 @@ class Worker(object):
                     logging.error(
                         f"Row, Col: {r, c} - Sa matrix is non-invertible. Statevector is likely NaNs."
                     )
+                if EXIT_CODE == -15:
+                    logging.error(
+                        f"Row, Col: {r, c} - LinalgError. Eigenvalue calculation failed.:"
+                    )
 
                 output_rfl[0, c, :] = states[-1, self.fm.idx_surf_rfl]
                 output_rfl_unc[0, c, :] = unc[self.fm.idx_surf_rfl]

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -472,7 +472,7 @@ class Worker(object):
                     )
                 if EXIT_CODE == -15:
                     logging.error(
-                        f"Row, Col: {r, c} - LinalgError. Eigenvalue calculation failed.:"
+                        f"Row, Col: {r, c} - LinalgError. Eigenvalue calculation failed."
                     )
 
                 output_rfl[0, c, :] = states[-1, self.fm.idx_surf_rfl]


### PR DESCRIPTION
We hit a strange error case within the invert_analytical routine. Certain pixels were failing within the Sa matrix inversion block, which were accurately caught as failed pixels. We looked into why they were failing, and it turned out to be more complicated that we initially thought.

Rather than the matrix containing any NaNs, the matrix was correctly formed, but the scipy.linalg.eigh function failed with error:  `LinAlgError: Internal Error`. There is some similarity and a chance this error follows: https://github.com/scipy/scipy/issues/13220. The `eigh` even succeeds on the transpose of the matrix when the only difference is precision.

For now the work around is to explicitly handle this error within the analytical line.

This PR also includes an addition of a fill value for failed pixels within the analytical line. Rather than returning the result of invert_algebraic, failed pixels will now return fill (-9999 by default).