### PR TITLE
Surface_model auto-build patch

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -268,6 +268,9 @@ def apply_oe(
                 "If num_neighbors has multiple elements, only --analytical_line is valid"
             )
 
+    if os.path.isdir(working_directory) is False:
+        os.mkdir(working_directory)
+
     logging.basicConfig(
         format="%(levelname)s:%(asctime)s || %(filename)s:%(funcName)s() | %(message)s",
         level=logging_level,

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -479,7 +479,7 @@ def check_surface_model(surface_path: str, wl: np.array, paths: Pathnames) -> st
             logging.info(
                 "No surface model provided. Build new one using given config file."
             )
-            surface_model(config_path=surface_path)
+            surface_model(config_path=surface_path, wavelength_path=paths.wavelength_path)
             configdir, _ = os.path.split(os.path.abspath(surface_path))
             config = json_load_ascii(surface_path, shell_replace=True)
             return expand_path(configdir, config["output_model_file"])

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -479,7 +479,9 @@ def check_surface_model(surface_path: str, wl: np.array, paths: Pathnames) -> st
             logging.info(
                 "No surface model provided. Build new one using given config file."
             )
-            surface_model(config_path=surface_path, wavelength_path=paths.wavelength_path)
+            surface_model(
+                config_path=surface_path, wavelength_path=paths.wavelength_path
+            )
             configdir, _ = os.path.split(os.path.abspath(surface_path))
             config = json_load_ascii(surface_path, shell_replace=True)
             return expand_path(configdir, config["output_model_file"])


### PR DESCRIPTION
Presently, the surface_model call from apply_oe will fail if pointing to a directory that doesn't have the wavelength file available (common).  The solution to this is to use the available wavelength_path keyword as a default, which has already been populated by apply_oe.