### PR TITLE
Added AVIRIS-5 support

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -333,6 +333,9 @@ def apply_oe(
         # parse flightline ID (AVIRIS-3 assumptions)
         dt = datetime.strptime(paths.fid[3:], "%Y%m%dt%H%M%S")
         INVERSION_WINDOWS = [[380.0, 1350.0], [1435, 1800.0], [1970.0, 2500.0]]
+    elif sensor == "av5":
+        # parse flightline ID (AVIRIS-5 assumptions)
+        dt = datetime.strptime(paths.fid[3:], "%Y%m%dt%H%M%S")
     elif sensor == "avcl":
         # parse flightline ID (AVIRIS-Classic assumptions)
         dt = datetime.strptime("20{}t000000".format(paths.fid[1:7]), "%Y%m%dt%H%M%S")

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -56,6 +56,8 @@ class Pathnames:
             self.fid = split(input_radiance)[-1][:18]
         elif sensor == "av3":
             self.fid = split(input_radiance)[-1][:18]
+        elif sensor == "av5":
+            self.fid = split(input_radiance)[-1][:18]
         elif sensor == "avcl":
             self.fid = split(input_radiance)[-1][:16]
         elif sensor == "emit":


### PR DESCRIPTION
This PR adds support for AVIRIS-5 data. Unlike AVIRIS-3, it does not include default `INVERSION WINDOWS,` as these can be set in the `apply_oe` call. We may want to consider adding defaults in the future.

Note: There is some code redundancy in `template_construction.py` in the code block that sets the fid. For example, AVIRIS-NG, AVIRIS-3, AVIRIS-5, and PRISM all use the same filename template but have separate conditional statements. A similar issue exists in `apply_oe`.