### PR TITLE
CLI Docs Update

### DIFF
--- a/docs/source/custom/data.rst
+++ b/docs/source/custom/data.rst
@@ -69,20 +69,24 @@ Notice the default location for all paths is ``~/.isofit/``. These can be modifi
     $ isofit --help
     Usage: isofit [OPTIONS] COMMAND [ARGS]...
 
-      This houses the subcommands of ISOFIT
+      ISOFIT contains a set of routines and utilities for fitting surface,
+      atmosphere and instrument models to imaging spectrometer data.
+
+      Repository: https://github.com/isofit/isofit
+      Documentation: https://isofit.readthedocs.io/en/latest
+      Report an issue: https://github.com/isofit/isofit/issues
 
     Options:
-      -v, --version           Print the current version
       -i, --ini TEXT          Override path to an isofit.ini file
       -b, --base TEXT         Override the base directory for all products
       -s, --section TEXT      Switches which section of the ini to use
-      -d, --data TEXT         Override path to data directory
-      -e, --examples TEXT     Override path to examples directory
-      -c, --imagecube TEXT    Override path to imagecube data directory
-      -em, --srtmnet TEXT     Override path to sRTMnet installation
-      -6s, --sixs TEXT        Override path to SixS installation
+      -p, --path TEXT...      Override paths with the format `-p [key] [value]`
+      -k, --keys TEXT...      Override keys with the format `-k [key] [value]`
       --save / -S, --no-save  Save the ini file
-      --help                  Show this message and exit.
+      --preview               Prints the environment that will be used. This
+                              disables saving
+      --version               Print the installed ISOFIT version
+      --help                  Show this message and exit
 
 Using a data override flag (``--path [name] [path]``) will update the the INI with the provided path:
 
@@ -177,16 +181,18 @@ Additionally, download paths may be temporarily overridden and not saved to the 
     Downloads the extra ISOFIT data files from the repository
     https://github.com/isofit/isofit-data.
 
-    Run ``isofit download paths`` to see default path locations.
+    Run `isofit download paths` to see default path locations.
     There are two ways to specify output directory:
-      - ``isofit --data /path/data download data``: Override the ini file. This will save the provided path for future reference.
-      - ``isofit download data --output /path/data``: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
+      - `isofit --data /path/data download data`: Override the ini file. This will save the provided path for future reference.
+      - `isofit download data --path /path/data`: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
     It is recommended to use the first style so the download path is remembered in the future.
 
     Options:
-    -o, --output TEXT  Root directory to download data files to, ie. [path]/data
-    -t, --tag TEXT     Release tag to pull  [default: latest]
-    --help             Show this message and exit.
+    -p, --path TEXT  Root directory to download data files to, ie. [path]/data
+    -t, --tag TEXT   Release tag to pull  [default: latest]
+    --overwrite      Overwrite any existing installation
+    -c, --check      Only check for updates
+    --help           Show this message and exit.
 
 Some subcommands have additional flags to further tweak the download, such as ``data`` and ``examples`` having a ``--tag`` to download specific tag releases, or ``sRTMnet`` having ``--version`` for different model versions, but it is recommended to use the default to pull the most up-to-date download for each.
 

--- a/docs/source/custom/installation.rst
+++ b/docs/source/custom/installation.rst
@@ -220,7 +220,7 @@ The following procedure walks through the steps required to install sRTMnet manu
    You will likely need to set the path to 6S and sRTMnet for the ISOFIT ini file as well as rebuild the examples.
    To do this, execute::
 
-      $ isofit --sixs /path/to/sixs/ --srtmnet /path/to/sRTMnet/ build
+      $ isofit --path sixs /path/to/sixs/ --path srtmnet /path/to/sRTMnet/ build
 
 #. Run one of the following examples:
 

--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -73,15 +73,15 @@ class SixSRT(RadiativeTransferEngine):
             Logger.debug(f"Setting SIXS_DIR={env.sixs}")
             os.environ["SIXS_DIR"] = env.sixs
         elif (current := os.path.abspath(current)) != env.sixs:
-            Logger.error(
-                "WARNING: The environment variable $SIXS_DIR does not match the ISOFIT ini"
+            Logger.warning(
+                "The environment variable $SIXS_DIR does not match the ISOFIT ini. It is recommended to make these match, though not required. The ENV path will be the one used."
             )
-            Logger.error(f"ENV: {current}")
-            Logger.error(f"INI: {env.sixs}")
-            Logger.error(
-                "This may cause issues, please either set the env to the ini, or override the ini to the env using:"
+            Logger.warning(f"ENV: {current}")
+            Logger.warning(f"INI: {env.sixs}")
+            Logger.warning(
+                "Please either set the ENV to that INI value, or update the INI with the ENV via:"
             )
-            Logger.error("  isofit --sixs $SIXS_DIR ...")
+            Logger.warning("  isofit --path sixs $SIXS_DIR")
 
         self.modtran_emulation = modtran_emulation
 


### PR DESCRIPTION
- Updated docs for the newer ini path overrides syntax
- Added further clarity to the sixs warning when the `$SIXS_DIR` does not match the loaded INI

Closes #677 