### PR TITLE
Added coupled transm to heurstic atmosphere

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -104,7 +104,12 @@ def heuristic_atmosphere(
             rhi = RT.get_shared_rtm_quantities(x_RT_2, geom)
             rhoatm = instrument.sample(x_instrument, RT.wl, rhi["rhoatm"])
             transm = instrument.sample(
-                x_instrument, RT.wl, rhi["transm_down_dir"] + rhi["transm_down_dif"]
+                x_instrument,
+                RT.wl,
+                (
+                    (rhi["transm_down_dir"] + rhi["transm_down_dif"])
+                    * (rhi["transm_up_dir"] + rhi["transm_up_dif"])
+                ),
             )  # REVIEW: This was changed from transm as we're deprecating the key
             sphalb = instrument.sample(x_instrument, RT.wl, rhi["sphalb"])
             solar_irr = instrument.sample(x_instrument, RT.wl, RT.solar_irr)


### PR DESCRIPTION
There is a potential bug in the heursitic_atmosphere function when using the full 4c radiance model.

Currently, the `transm` variable in the function is initialized only with the downwards components:

```python
transm = instrument.sample(
    x_instrument, RT.wl, rhi["transm_down_dir"] + rhi["transm_down_dif"]
) 
```

Regardless if this is the behavior we want, it is inconsistent with the 1c implementation where the populated `transm` LUT variable contains the full coupled transmittance spectrum. To make this consistent:

```python
transm = instrument.sample(
    x_instrument,
    RT.wl,
    (rhi["transm_down_dir"] + rhi["transm_down_dif"]) * (rhi["transm_up_dir"] + rhi["transm_up_dif"])
)
```


First pass tests show that this fixes the initial issue of poor water vapor retrievals with the 4c model:

<img width="988" alt="Screenshot 2025-05-09 at 9 15 02 AM" src="https://github.com/user-attachments/assets/02511102-8d83-4e49-857a-ad31f36c0527" />

