### PR TITLE
MODTRAN polynomials for upper possible bounds of water vapor and lower possible bounds of AOT

### DIFF
--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -627,8 +627,6 @@ class ModtranRT(RadiativeTransferEngine):
     def modtran_water_upperbound_polynomials(self) -> dict:
         """Polynomials as a function of ground altitude (km) to estimate upperbound of water column vapor (g/cm2).
 
-        NOTE: Any ground altitude greater than 6 km will be set to min g/cm2.
-
         Returns:
             dict: 3rd degree polynomials to estimate upperbound of water column vapor 
         """

--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -623,6 +623,47 @@ class ModtranRT(RadiativeTransferEngine):
                     break
 
         return max_water
+    
+    def modtran_water_upperbound_polynomials(self) -> dict:
+        """Polynomials as a function of ground altitude (km) to estimate upperbound of water column vapor (g/cm2).
+
+        NOTE: Any ground altitude greater than 6 km will be set to min g/cm2.
+
+        Returns:
+            dict: 3rd degree polynomials to estimate upperbound of water column vapor 
+        """
+
+        # Capping polynomial to not allow negative, or increasing trend, at ~7-9km ground altitude.
+        min_value = 0.25
+
+        polynomials = {
+            "ATM_TROPICAL": lambda x: np.maximum(6.74256 + (-2.37052*x) + (0.313829*x**2) + (-0.0159003*x**3),min_value),
+            "ATM_MIDLAT_SUMMER": lambda x: np.maximum(5.350046 + (-1.839548*x) + (2.296582e-01*x**2) + (-1.020594e-02*x**3),min_value),
+            "ATM_MIDLAT_WINTER": lambda x: np.maximum(1.371226 + (-0.442087*x) + (4.485325e-02*x**2) + (-1.130163e-03*x**3),min_value),
+            "ATM_SUBARC_SUMMER": lambda x: np.maximum(3.121272 + (-1.171145*x) + (1.704094e-01*x**2) + (-9.701062e-03*x**3),min_value),
+            "ATM_SUBARC_WINTER": lambda x: np.maximum(0.630406 + (-0.176336*x) + (8.286409e-03*x**2) + (8.138824e-04*x**3),min_value),
+            "ATM_US_STANDARD_1976": lambda x: np.maximum(2.869655 + (-1.227473*x) + (2.039059e-01*x**2) + (-1.274801e-02*x**3),min_value),
+            }
+
+        return polynomials
+
+    def modtran_aot_lowerbound_polynomials(self) -> dict:
+        """Polynomials as a function of ground altitude (km) to estimate lowerbound of AOT at 550nm.
+
+        Returns:
+            dict: 3rd degree polynomials to estimate lowerbound of AOT
+        """
+
+        polynomials = {
+            "ATM_TROPICAL": lambda x: 0.042090 + (-0.003120*x) + (4.462979e-18*x**2) + (-4.260469e-19*x**3),
+            "ATM_MIDLAT_SUMMER": lambda x: 0.042090 + (-0.003120*x) + (4.462979e-18*x**2) + (-4.260469e-19*x**3),
+            "ATM_MIDLAT_WINTER": lambda x: 0.024748 + (-0.001654*x) + (-5.083805e-07*x**2) + (7.252007e-08*x**3),
+            "ATM_SUBARC_SUMMER": lambda x: 0.042090 + (-0.003120*x) + (4.462979e-18*x**2) + (-4.260469e-19*x**3),
+            "ATM_SUBARC_WINTER": lambda x: 0.024748 + (-0.001654*x) + (-5.083805e-07*x**2) + (7.252007e-08*x**3),
+            "ATM_US_STANDARD_1976": lambda x: 0.042090 + (-0.003120*x) + (4.462979e-18*x**2) + (-4.260469e-19*x**3),
+            }
+
+        return polynomials
 
     def required_results_exist(self, filename_base):
         infilename = os.path.join(self.sim_path, "LUT_" + filename_base + ".json")

--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -623,25 +623,58 @@ class ModtranRT(RadiativeTransferEngine):
                     break
 
         return max_water
-    
+
     def modtran_water_upperbound_polynomials(self) -> dict:
         """Polynomials as a function of ground altitude (km) to estimate upperbound of water column vapor (g/cm2).
 
         Returns:
-            dict: 3rd degree polynomials to estimate upperbound of water column vapor 
+            dict: 3rd degree polynomials to estimate upperbound of water column vapor
         """
 
-        # Capping polynomial to not allow negative, or increasing trend, at ~7-9km ground altitude.
+        # Capping polynomial to not allow negative, or increasing trend, at very high ground altitudes (>6km).
         min_value = 0.25
 
         polynomials = {
-            "ATM_TROPICAL": lambda x: np.maximum(6.74256 + (-2.37052*x) + (0.313829*x**2) + (-0.0159003*x**3),min_value),
-            "ATM_MIDLAT_SUMMER": lambda x: np.maximum(5.350046 + (-1.839548*x) + (2.296582e-01*x**2) + (-1.020594e-02*x**3),min_value),
-            "ATM_MIDLAT_WINTER": lambda x: np.maximum(1.371226 + (-0.442087*x) + (4.485325e-02*x**2) + (-1.130163e-03*x**3),min_value),
-            "ATM_SUBARC_SUMMER": lambda x: np.maximum(3.121272 + (-1.171145*x) + (1.704094e-01*x**2) + (-9.701062e-03*x**3),min_value),
-            "ATM_SUBARC_WINTER": lambda x: np.maximum(0.630406 + (-0.176336*x) + (8.286409e-03*x**2) + (8.138824e-04*x**3),min_value),
-            "ATM_US_STANDARD_1976": lambda x: np.maximum(2.869655 + (-1.227473*x) + (2.039059e-01*x**2) + (-1.274801e-02*x**3),min_value),
-            }
+            "ATM_TROPICAL": lambda x: np.maximum(
+                6.74256 + (-2.37052 * x) + (0.313829 * x**2) + (-0.0159003 * x**3),
+                min_value,
+            ),
+            "ATM_MIDLAT_SUMMER": lambda x: np.maximum(
+                5.350046
+                + (-1.839548 * x)
+                + (2.296582e-01 * x**2)
+                + (-1.020594e-02 * x**3),
+                min_value,
+            ),
+            "ATM_MIDLAT_WINTER": lambda x: np.maximum(
+                1.371226
+                + (-0.442087 * x)
+                + (4.485325e-02 * x**2)
+                + (-1.130163e-03 * x**3),
+                min_value,
+            ),
+            "ATM_SUBARC_SUMMER": lambda x: np.maximum(
+                3.121272
+                + (-1.171145 * x)
+                + (1.704094e-01 * x**2)
+                + (-9.701062e-03 * x**3),
+                min_value,
+            ),
+            "ATM_SUBARC_WINTER": lambda x: np.maximum(
+                0.630406
+                + (-0.176336 * x)
+                + (8.286409e-03 * x**2)
+                + (8.138824e-04 * x**3),
+                min_value,
+            ),
+            "ATM_US_STANDARD_1976": lambda x: np.maximum(
+                2.869655
+                + (-1.227473 * x)
+                + (2.039059e-01 * x**2)
+                + (-1.274801e-02 * x**3),
+                min_value,
+            ),
+        }
 
         return polynomials
 
@@ -653,13 +686,31 @@ class ModtranRT(RadiativeTransferEngine):
         """
 
         polynomials = {
-            "ATM_TROPICAL": lambda x: 0.042090 + (-0.003120*x) + (4.462979e-18*x**2) + (-4.260469e-19*x**3),
-            "ATM_MIDLAT_SUMMER": lambda x: 0.042090 + (-0.003120*x) + (4.462979e-18*x**2) + (-4.260469e-19*x**3),
-            "ATM_MIDLAT_WINTER": lambda x: 0.024748 + (-0.001654*x) + (-5.083805e-07*x**2) + (7.252007e-08*x**3),
-            "ATM_SUBARC_SUMMER": lambda x: 0.042090 + (-0.003120*x) + (4.462979e-18*x**2) + (-4.260469e-19*x**3),
-            "ATM_SUBARC_WINTER": lambda x: 0.024748 + (-0.001654*x) + (-5.083805e-07*x**2) + (7.252007e-08*x**3),
-            "ATM_US_STANDARD_1976": lambda x: 0.042090 + (-0.003120*x) + (4.462979e-18*x**2) + (-4.260469e-19*x**3),
-            }
+            "ATM_TROPICAL": lambda x: 0.042090
+            + (-0.003120 * x)
+            + (4.462979e-18 * x**2)
+            + (-4.260469e-19 * x**3),
+            "ATM_MIDLAT_SUMMER": lambda x: 0.042090
+            + (-0.003120 * x)
+            + (4.462979e-18 * x**2)
+            + (-4.260469e-19 * x**3),
+            "ATM_MIDLAT_WINTER": lambda x: 0.024748
+            + (-0.001654 * x)
+            + (-5.083805e-07 * x**2)
+            + (7.252007e-08 * x**3),
+            "ATM_SUBARC_SUMMER": lambda x: 0.042090
+            + (-0.003120 * x)
+            + (4.462979e-18 * x**2)
+            + (-4.260469e-19 * x**3),
+            "ATM_SUBARC_WINTER": lambda x: 0.024748
+            + (-0.001654 * x)
+            + (-5.083805e-07 * x**2)
+            + (7.252007e-08 * x**3),
+            "ATM_US_STANDARD_1976": lambda x: 0.042090
+            + (-0.003120 * x)
+            + (4.462979e-18 * x**2)
+            + (-4.260469e-19 * x**3),
+        }
 
         return polynomials
 


### PR DESCRIPTION
MODTRAN will write to tp6 log file the theoretical maximum water column vapor and minimum AOT for a given altitude if the user provides one that is out of range for building a LUT. A lot of times this is unavoidable for scenes with wide range of ground altitude. Further, it is non-trivial to implement a rectilinear grid that is based on these theoretical max and mins that are altitude dependent.

Where this impacts ISOFIT the most is during **_Inversion()_** , which uses bounds that were declared during initialization. However, for some altitudes there may not actually be any change in the MODTRAN output, thereby creating a condition where any change in the cost surface (Jacobian) will be virtually nonexistent . This can occur especially for too coarse of water vapor resolution and large changes in altitude, where perhaps there is only 1 or 2 modtran simulations of measurable  change.

A possible solution is to have a series of polynomials that we reverse-engineer out of MODTRAN to inform these bound during run time of OE. Potentially this information could be carried in the geom object, which could then reset the AOT and H2O bounds right before the main inversion. There are a lot of assumptions we have to think about though including,

- How to determine atm type from user?
- Assuming these bounds are only a function of ground altitude and atm type?
- RH cannot exceed 100% (a mode that can be enabled on MODTRAN)
- Potentially others?

<img width="488" alt="image" src="https://github.com/user-attachments/assets/0559efb2-7937-436c-b2da-b82c21cfce77" />


