### PR TITLE
Removed negative rfl block in analytical_line

### DIFF
--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -467,18 +467,6 @@ class Worker(object):
                     output_non_rfl[0, c, :] = states[-1, self.fm.idx_surf_nonrfl]
                     output_non_rfl_unc[0, c, :] = unc[self.fm.idx_surf_nonrfl]
 
-            # What do we want to do with the negative reflectances?
-            # state = output_state[r - start_line, ...]
-            # mask = np.logical_and.reduce(
-            #     [
-            #         state < self.rfl_bounds[0],
-            #         state > self.rfl_bounds[1],
-            #         state != -9999,
-            #         state != -0.01,
-            #     ]
-            # )
-            # state[mask] = 0
-
             logging.info(f"Analytical line writing line {r}")
 
             write_bil_chunk(


### PR DESCRIPTION
Based on conversations, folks are leaning towards keeping negative reflectance values in the analytical line outputs. This introduces a complication that `outside_ret_windows` wavelengths are given a "hidden" fill value of `-0.01`. I looked into specifics on both the generation of the bad band list and the uncertainty of the return within this region.

The bad band list is populated as a list [1 - good band, 0 - bad band]. Does this need to be swapped to be read by envi, wiser, etc? The locations of the bad bands are accurate, as set by the inversion object (an EMIT example):

<img width="1287" alt="Screenshot 2025-05-22 at 10 40 56 AM" src="https://github.com/user-attachments/assets/193cec8d-74e9-4a2f-88ca-4c533ab142d2" />

The returned uncertainty is also very high (at least for this test EMIT example):

The shaded region is the `uncert` output from the analytical_line.
<img width="1356" alt="Screenshot 2025-05-22 at 10 43 26 AM" src="https://github.com/user-attachments/assets/472b1f69-b32b-4194-ae88-e9e30492b11f" />


The bad band list is read correctly by envi in the current form:
<img width="889" alt="Screenshot 2025-05-23 at 2 59 18 PM" src="https://github.com/user-attachments/assets/d6acf53f-54fc-402b-a855-f58de1f44e25" />

The edits proposed here, are only to remove the commented-out code block that previously dealt with negative reflectance values.