### PR TITLE
Fix scipy DeprecationWarning.

### DIFF
--- a/isofit/utils/instrument_model.py
+++ b/isofit/utils/instrument_model.py
@@ -22,7 +22,7 @@ from os.path import abspath, split
 
 import numpy as np
 import scipy
-from scipy.ndimage.filters import gaussian_filter1d
+from scipy.ndimage import gaussian_filter1d
 from spectral.io import envi
 
 from isofit.core.common import envi_header, expand_path, json_load_ascii


### PR DESCRIPTION
This fixes the following DeprecationWarning:

```python
../../../../opt/conda/envs/ci_env/lib/python3.12/site-packages/isofit/utils/instrument_model.py:25
  /opt/conda/envs/ci_env/lib/python3.12/site-packages/isofit/utils/instrument_model.py:25: DeprecationWarning: Please import `gaussian_filter1d` from the `scipy.ndimage` namespace; the `scipy.ndimage.filters` namespace is deprecated and will be removed in SciPy 2.0.0.
    from scipy.ndimage.filters import gaussian_filter1d
```

The module scipy.ndimage.filters is deprecated since scipy version 1.8 (May 2022).
