### PR TITLE
Added edge handling in LUT interp with pre-built LUT

### DIFF
--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -271,9 +271,13 @@ def findSlice(dim, val):
 
     # Subselect the two points encompassing this interp point
     b = np.searchsorted(dim * orientation, val * orientation)
-    a = b - 1
 
-    return slice(a, b + 1)
+    # Handle edge cases when val equals first or last lut dim value
+    if val == dim[0] or val == dim[-1]:
+        return slice(b, b + 1)
+
+    else:
+        return slice(b - 1, b + 1)
 
 
 def optimizedInterp(ds, strat):
@@ -306,10 +310,8 @@ def optimizedInterp(ds, strat):
         else:
             sel = findSlice(dim, val)
 
-        Logger.debug(f"- Subselecting {key}[{sel.start}:{sel.stop}]")
         ds = ds.isel({key: sel})
 
-    Logger.debug("Calling .interp")
     return ds.interp(**strat)
 
 

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -273,8 +273,8 @@ def findSlice(dim, val):
     b = np.searchsorted(dim * orientation, val * orientation)
 
     # Handle edge cases when val equals first or last lut dim value
-    if val == dim[0] or val == dim[-1]:
-        return slice(b, b + 1)
+    if val <= dim[0]:
+        return slice(b, b + 2)
 
     else:
         return slice(b - 1, b + 1)
@@ -297,6 +297,20 @@ def optimizedInterp(ds, strat):
     """
     for key, val in strat.items():
         dim = ds[key]
+
+        if val <= dim[0]:
+            Logger.warning(
+                f"Scene value for key: {key} of {round(val, 2)} "
+                f"is less or equal to minimum LUT value {np.round(dim[0].data, 2)}. "
+                "Solutions will use value interpolated to minimum LUT value"
+            )
+
+        elif val >= dim[-1]:
+            Logger.warning(
+                f"Scene value for key: {key} of {round(val, 2)} "
+                f"is greater or equal to maximum LUT value {np.round(dim[-1].data, 2)}. "
+                "Solutions will use value interpolated to maximum LUT value"
+            )
 
         if isinstance(val, list):
             a = findSlice(dim, val[0])

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -310,8 +310,10 @@ def optimizedInterp(ds, strat):
         else:
             sel = findSlice(dim, val)
 
+        Logger.debug(f"- Subselecting {key}[{sel.start}:{sel.stop}]")
         ds = ds.isel({key: sel})
 
+    Logger.debug("Calling .interp")
     return ds.interp(**strat)
 
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -144,7 +144,8 @@ class RadiativeTransferEngine:
             self.lut_grid = lut_grid or luts.extractGrid(self.lut)
             self.points = luts.extractPoints(self.lut)
             self.lut_names = list(self.lut_grid.keys())
-            Logger.info(f"LUT grid loaded from file: {self.lut_grid}")
+            Logger.info(f"LUT grid loaded from file")
+            Logger.debug(f"{self.lut_grid}")
 
             # remove 'point' if added to lut_names after subsetting
             if "point" in self.lut_names:


### PR DESCRIPTION
 Isofit errors out when using a pre-built lut grid, and the interpolated value (as noted in the "interp" key) is at, or smaller than the smallest value in the lut dimension for that key. See example for "surface_elevation_km" below:

```
                 "lut_names": {
                        "AERFRAC_2": {
                            "gte": 0.001,
                            "lte": 1.0
                        },
                        "H2OSTR": {
                            "gte": 0.05,
                            "lte": 5.0
                        },
                        "observer_zenith": {
                            "gte": 2.2024,
                            "lte": 18.9262
                        },
                        "relative_azimuth": {
                            "gte": 0.0002,
                            "lte": 86.0982
                        },
                        "surface_elevation_km": {
                            "interp": 0.0
                        }
                    },
```

As noted in #697, we may not want to support run cases when the scene-value is lower than the LUT value, but at the bare minimum we have to support cases when the scene-value is _at_ the LUT grid minimum, which currently fails.

The root of the issue is with how we slice the LUT dimension. For example, when the interpolated value (`val`) is equal to the smallest value in the lut grid (`dim[0]`):
``` 
b = np.searchsorted(dim * orientation, val * orientation)
```
returns 0 and
```
slice(b - 1, b + 1)
```
returns a slice, which always indexes to an empty list. 

Interestingly, the inverse is not true. If the interpolated value is greater than the largest value in the lut grid (`val > dim[-1]`):
``` 
b = np.searchsorted(dim * orientation, val * orientation)
```
returns len(dim) and
```
slice(b - 1, b + 1)
```
returns a slice for the last LUT dim value. It looks like we actually currently allow for scene-values for LUT elements to be greater than the maximum value within the LUT grid.


The proposed changes are to:

1. Handle the specific cases directly when the interpolated values are at the minimum and maximum LUT grid dimension values.
2. To be discussed, but we could raise exceptions when the interpolation is trying to resolve values outside of the LUT grid dimension values. Not sure how necessary this is given that it should be an edge case, and in test cases when using pre-built LUTs it may be advantageous to run outside the bounds.