### PR TITLE
SRTM radiance based convolution

### DIFF
--- a/isofit/radiative_transfer/engines/sRTMnet.py
+++ b/isofit/radiative_transfer/engines/sRTMnet.py
@@ -222,7 +222,10 @@ class SimulatedModtranRT(RadiativeTransferEngine):
         data = luts.load(self.predict_path, mode="r").sel(point=tuple(point)).load()
         return {
             key: resample_spectrum(
-                values.data * self.emulator_sol_irr, self.emu_wl, self.wl, self.fwhm
+                values.data * (1.0 if key == "sphalb" else self.emulator_sol_irr),
+                self.emu_wl,
+                self.wl,
+                self.fwhm,
             )
             for key, values in data.items()
             if values.data.dtype != "int64"

--- a/isofit/radiative_transfer/engines/sRTMnet.py
+++ b/isofit/radiative_transfer/engines/sRTMnet.py
@@ -237,6 +237,7 @@ class SimulatedModtranRT(RadiativeTransferEngine):
         """
         # Update engine to run in RDN mode
         self.rt_mode = "rdn"
+        #self.lut["RT_mode"] = "rdn"
 
     def get_L_atm(self, x_RT, geom):
         r = self.get(x_RT, geom)

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -535,6 +535,7 @@ class RadiativeTransferEngine:
 
         # Reload the LUT now that it's populated
         self.lut = luts.load(self.lut_path)
+        self.lut["RT_mode"] = "rdn" # this is bad - DON"T LET THIS INTO THE MAIN REPO.  Stopgap only
 
     def summarize(self, x_RT, *_):
         """


### PR DESCRIPTION
Currently includes sloppy key setting that must be address before this PR is accepted.  Works for superpixels, currently fails in the analytical line.