### PR TITLE
update lower bound

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -604,7 +604,7 @@ def apply_oe(
             paths.h2o_subs_path
         ):
             # Write the presolve connfiguration file
-            h2o_grid = np.linspace(0.01, max_water - 0.01, 10).round(2)
+            h2o_grid = np.linspace(0.2, max_water - 0.01, 10).round(2)
             logging.info(f"Pre-solve H2O grid: {h2o_grid}")
             logging.info("Writing H2O pre-solve configuration file.")
             tmpl.build_presolve_config(


### PR DESCRIPTION
Replaces #703 for clean merge.  From previous:

changes h2o grid lower bound in presolve to 0.2, which is already lower than we ever observe in practice. Below this, many RTMs start to fall apart. The full inversion grid is already bounded, but this bad low end causes some errant retrievals in the presolve.

@unbohn - when checks clear this is ready for review / merge.