### PR TITLE
Emulator CO2

### DIFF
--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -39,7 +39,7 @@ SIXS_TEMPLATE = """\
 0 (User defined)
 {solzen} {solaz} {viewzen} {viewaz} {month} {day}
 8  (User defined H2O, O3)
-{H2OSTR}, {O3}
+{H2OSTR}, {O3}, {CO2}
 {aermodel}
 0
 {AOT550}
@@ -207,6 +207,7 @@ class SixSRT(RadiativeTransferEngine):
             "AOT550": 0.01,
             "H2OSTR": 0,
             "O3": 0.30,
+            "CO2": 420, # ppm
             "day": self.engine_config.day,
             "month": self.engine_config.month,
             "elev": self.engine_config.elev,

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -80,6 +80,7 @@ def apply_oe(
     config_only=False,
     interpolate_bad_rdn=False,
     interpolate_inplace=False,
+    retrieve_co2=False,
 ):
     """\
     Applies OE over a flightline using a radiative transfer engine. This executes
@@ -205,6 +206,8 @@ def apply_oe(
         Flag to tell interpolation to work on the file in place, or generate a
         new interpolated rdn file. The location of the new file will be in the
         "input" directory within the working directory.
+    retrieve_co2 : bool, default=False
+        Flag to retrieve CO2 in the state vector. Only available with emulator at the moment.
 
     \b
     References
@@ -722,6 +725,7 @@ def apply_oe(
             prebuilt_lut_path=prebuilt_lut,
             inversion_windows=INVERSION_WINDOWS,
             multipart_transmittance=multipart_transmittance,
+            retrieve_co2=retrieve_co2,
         )
 
         if config_only:
@@ -825,6 +829,7 @@ def apply_oe(
 @click.option("--config_only", is_flag=True, default=False)
 @click.option("--interpolate_bad_rdn", is_flag=True, default=False)
 @click.option("--interpolate_inplace", is_flag=True, default=False)
+@click.option("--retrieve_co2", is_flag=True, default=False)
 @click.option(
     "--debug-args",
     help="Prints the arguments list without executing the command",

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -377,6 +377,11 @@ class LUTConfig:
         self.aot_550_spacing = 0
         self.aot_550_spacing_min = 0
 
+        # CO2 ppm
+        self.co2_range = [380, 440]
+        self.co2_spacing = 60
+        self.co2_spacing_min = 60
+
         self.no_min_lut_spacing = no_min_lut_spacing
 
         # overwrite anything that comes in from the config file
@@ -703,6 +708,7 @@ def build_main_config(
     inversion_windows=[[350.0, 1360.0], [1410, 1800.0], [1970.0, 2500.0]],
     prebuilt_lut_path: str = None,
     multipart_transmittance: bool = False,
+    retrieve_co2: bool = False,
 ) -> None:
     """Write an isofit config file for the main solve, using the specified pathnames and all given info
 
@@ -730,6 +736,7 @@ def build_main_config(
         pressure_elevation:                   if true, retrieve pressure elevation
         debug:                                if true, run ISOFIT in debug mode
         multipart_transmittance:              flag to indicate whether a 4-component transmittance model is to be used
+        retrieve_co2:                         flag to include CO2 in lut and retrieval
     """
 
     # Determine number of spectra included in each retrieval.  If we are
@@ -830,6 +837,8 @@ def build_main_config(
             radiative_transfer_config["lut_grid"][
                 "relative_azimuth"
             ] = relative_azimuth_lut_grid.tolist()
+        if retrieve_co2 and lut_params.co2_range is not None:
+            radiative_transfer_config["lut_grid"]["CO2"] = lut_params.co2_range
         radiative_transfer_config["lut_grid"].update(aerosol_lut_grid)
 
     rtc_ln = {}
@@ -885,6 +894,10 @@ def build_main_config(
             radiative_transfer_config["radiative_transfer_engines"]["vswir"][
                 "lut_names"
             ][key] = get_lut_subset(aerosol_lut_grid[key])
+        if retrieve_co2:
+            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
+                "lut_names"
+            ]["CO2"] = get_lut_subset(lut_params.co2_range)
 
         rm_keys = []
         for key, item in radiative_transfer_config["radiative_transfer_engines"][
@@ -918,6 +931,15 @@ def build_main_config(
             "prior_sigma": 1000.0,
             "prior_mean": (elevation_lut_grid[0] + elevation_lut_grid[-1]) / 2.0,
         }
+    if retrieve_co2:
+        radiative_transfer_config["statevector"]["CO2"] = {
+            "bounds": [lut_params.co2_range[0], lut_params.co2_range[-1]],
+            "scale": 10,
+            "init": 420.0,
+            "prior_sigma": 100.0,
+            "prior_mean": 420.0,
+        }
+
     radiative_transfer_config["statevector"].update(aerosol_state_vector)
 
     # MODTRAN should know about our whole LUT grid and all of our statevectors, so copy them in


### PR DESCRIPTION
This PR adds in CO2 to the statevector, with special 'retrieve_co2' flag optional in apply OE.  The default behavior opens up a LUT (configurable like all other apply_oe LUT config parameters) that has CO2 ranging from 380-440.  The goal is just to span the range of reasonable values.  Test retrievals show that it works well...values center around 420 (within a few ppm), and the SWIR-1 residuals vanish, with the SWIR-2 residuals look better - notably this is with the 1c model as is. With #704 , the residuals diminish further.

![Screenshot 2025-06-05 at 9 49 22 PM](https://github.com/user-attachments/assets/7921c632-ffcc-4e81-b464-c57713ba7665)
