### PR TITLE
Configs to Dict Recursively

### DIFF
--- a/isofit/configs/base_config.py
+++ b/isofit/configs/base_config.py
@@ -95,7 +95,7 @@ class BaseConfigSection(object):
 
         return errors
 
-    def get_config_options_as_dict(self) -> Dict[str, Dict[str, any]]:
+    def _get_config_options_as_dict(self) -> Dict[str, Dict[str, any]]:
         config_options = OrderedDict()
         for key in self._get_nontype_attributes():
             value = getattr(self, key)
@@ -105,6 +105,16 @@ class BaseConfigSection(object):
                 )  # Lists look nicer in config files and seem friendlier
             config_options[key] = value
         return config_options
+
+    def get_config_options_as_dict(self):
+        data = {}
+        for key, val in self.__dict__.items():
+            if not key.startswith("_"):
+                if issubclass(type(val), BaseConfigSection):
+                    data[key] = val.get_config_options_as_dict()
+                else:
+                    data[key] = val
+        return data
 
     def _check_config_validity(self) -> List[str]:
         return list()

--- a/isofit/configs/base_config.py
+++ b/isofit/configs/base_config.py
@@ -95,7 +95,7 @@ class BaseConfigSection(object):
 
         return errors
 
-    def _get_config_options_as_dict(self) -> Dict[str, Dict[str, any]]:
+    def get_config_options_as_dict(self) -> Dict[str, Dict[str, any]]:
         config_options = OrderedDict()
         for key in self._get_nontype_attributes():
             value = getattr(self, key)
@@ -106,12 +106,12 @@ class BaseConfigSection(object):
             config_options[key] = value
         return config_options
 
-    def get_config_options_as_dict(self):
+    def get_config_as_dict(self):
         data = {}
         for key, val in self.__dict__.items():
             if not key.startswith("_"):
                 if issubclass(type(val), BaseConfigSection):
-                    data[key] = val.get_config_options_as_dict()
+                    data[key] = val.get_config_as_dict()
                 else:
                     data[key] = val
         return data

--- a/isofit/configs/configs.py
+++ b/isofit/configs/configs.py
@@ -119,8 +119,8 @@ class Config(BaseConfigSection):
 
 def get_config_differences(config_a: Config, config_b: Config) -> Dict:
     differing_items = dict()
-    dict_a = config_a.get_config_options_as_dict()
-    dict_b = config_b.get_config_options_as_dict()
+    dict_a = config_a.get_config_as_dict()
+    dict_b = config_b.get_config_as_dict()
     all_sections = set(list(dict_a.keys()) + list(dict_b.keys()))
     for section in all_sections:
         section_a = dict_a.get(section, dict())

--- a/isofit/configs/configs.py
+++ b/isofit/configs/configs.py
@@ -74,30 +74,18 @@ class Config(BaseConfigSection):
 
         self._forward_model_type = ForwardModelConfig
         self.forward_model = ForwardModelConfig({})
-        """ForwardModelConfig: forward_model config. Holds information about surface models, 
+        """ForwardModelConfig: forward_model config. Holds information about surface models,
         radiative transfer models, and the instrument.
         """
 
         self._implementation_type = ImplementationConfig
         self.implementation = ImplementationConfig({})
-        """ImplementationConfig: holds information regarding how isofit is to be run, including relevant sub-configs 
+        """ImplementationConfig: holds information regarding how isofit is to be run, including relevant sub-configs
         (e.g. inversion information).
         """
 
         # Load sub-classes and attributes
         self.set_config_options(configdict)
-
-    def get_config_as_dict(self) -> dict:
-        """Get configuration options as a nested dictionary with delineated sections.
-
-        Returns:
-            Configuration options as a nested dictionary with delineated sections.
-        """
-        config = OrderedDict()
-        for config_section in self._get_nontype_attributes():
-            populated_section = getattr(self, config_section)
-            config[config_section] = populated_section.get_config_options_as_dict()
-        return config
 
     def get_config_errors(self):
         """
@@ -131,8 +119,8 @@ class Config(BaseConfigSection):
 
 def get_config_differences(config_a: Config, config_b: Config) -> Dict:
     differing_items = dict()
-    dict_a = config_a.get_config_as_dict()
-    dict_b = config_b.get_config_as_dict()
+    dict_a = config_a.get_config_options_as_dict()
+    dict_b = config_b.get_config_options_as_dict()
     all_sections = set(list(dict_a.keys()) + list(dict_b.keys()))
     for section in all_sections:
         section_a = dict_a.get(section, dict())


### PR DESCRIPTION
Fixes the function to convert a config object to a dictionary by implementing recursion. The `get_config_differences` now works with it as before. There's probably more to do here to clean it up and make it more useful but.. out of scope. 