### PR TITLE
sky view factor (math only). hard set to 1.0.

### DIFF
--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -62,6 +62,9 @@ class Geometry:
         self.bg_rfl = bg_rfl
         self.cos_i = None
 
+        # TODO: file IO reads some external sky view image computed outside ISOFIT.
+        self.sky_view_factor = 1.0
+
         # The 'obs' object is observation metadata that follows a historical
         # AVIRIS-NG format.  It arrives to our initializer in the form of
         # a list-like object...

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -397,11 +397,12 @@ class RadiativeTransfer:
                     else r[key]
                 )
 
-        # assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle
+        # Assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle.
+        # Downward diffuse components are scaled by viewable sky fraction (i.e., "ungula" of viewable sky in solid geometry terms).
         L_dir_dir = L_coupled[0] / coszen * cos_i
-        L_dif_dir = L_coupled[1]
+        L_dif_dir = L_coupled[1] * geom.sky_view_factor
         L_dir_dif = L_coupled[2] / coszen * cos_i
-        L_dif_dif = L_coupled[3]
+        L_dif_dif = L_coupled[3] * geom.sky_view_factor
 
         return L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
 


### PR DESCRIPTION
Following our conversation from today, this simply adds in the math component of the sky view factor (introduced as `geom.sky_view_factor`) into the downward diffuse components within **get_L_coupled()**. 

Within class Geometry this is simply defined as 1.0 for now.

This effectively  does not change anything (multiplying difs by 1), but allows the next PR to use/test  external sky view factor .