### PR TITLE
LUT Status Attribute

### DIFF
--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -516,6 +516,8 @@ class RadiativeTransferEngine:
                     Logger.warning("Not all points were flushed, doing so now")
                     self.lut.flush()
 
+                self.lut.finalize()
+
             del lut_names, makeSim, readSim, lut_path, buffer_time
         else:
             Logger.debug("makeSim is disabled for this engine")

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -516,8 +516,6 @@ class RadiativeTransferEngine:
                     Logger.warning("Not all points were flushed, doing so now")
                     self.lut.flush()
 
-                self.lut.finalize()
-
             del lut_names, makeSim, readSim, lut_path, buffer_time
         else:
             Logger.debug("makeSim is disabled for this engine")
@@ -533,6 +531,8 @@ class RadiativeTransferEngine:
 
             point = {key: 0 for key in self.lut_names}
             self.lut.writePoint(point, data=post)
+
+        self.lut.finalize()
 
         # Reload the LUT now that it's populated
         Logger.debug("Reloading LUT")

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -251,6 +251,9 @@ class RadiativeTransferEngine:
             # Create and populate a LUT file
             self.runSimulations()
 
+        # Write the NetCDF information to the log file so devs have that info during debugging
+        Logger.debug(f"LUT information:\n{self.lut.info()}")
+
         # Limit the wavelength per the config, does not affect data on disk
         if engine_config.wavelength_range is not None:
             Logger.info(


### PR DESCRIPTION
- Added a simple `ISOFIT status` attribute to the LUT on creation to track whether it finished being created correctly
  - May help debug cases where isofit crashed during lut creation but followup runs attempted to use the prebuilt lut
- Added `Create.getAttr` function to access attributes in the netcdf
- Added RTE dumping the LUT info to debug logs after loading it
  - Should help debug external LUTs by having that information always available instead of requesting users to provide it