### PR TITLE
sky view factor for ISOFIT

### DIFF
--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -100,6 +100,7 @@ class CLI(click.Group):
         "HRRR_to_modtran": "isofit.utils.add_HRRR_profiles_to_modtran_config",
         "analytical_line": "isofit.utils.analytical_line",
         "apply_oe": "isofit.utils.apply_oe",
+        "skyview": "isofit.utils.skyview",
         "6s_to_srtmnet": "isofit.utils.convert_6s_to_srtmnet",
         "empirical_line": "isofit.utils.empirical_line",
         "ewt": "isofit.utils.ewt_from_reflectance",

--- a/isofit/configs/sections/input_config.py
+++ b/isofit/configs/sections/input_config.py
@@ -95,8 +95,6 @@ class InputConfig(BaseConfigSection):
         Used to modulate incoming diffuse radiance from fraction of viewable sky.
         """
 
-
-
         self.set_config_options(sub_configdic)
 
     def _check_config_validity(self) -> List[str]:

--- a/isofit/configs/sections/input_config.py
+++ b/isofit/configs/sections/input_config.py
@@ -88,6 +88,15 @@ class InputConfig(BaseConfigSection):
         Used to make minor channelized corrections to account for slight systematic errors not captured in calibration.
         """
 
+        self._skyview_factor_file_type = str
+        self.skyview_factor_file = None
+        """
+        str: Input Skyview file.  Can be either a .mat, .txt, or ENVI formatted binary cube.
+        Used to modulate incoming diffuse radiance from fraction of viewable sky.
+        """
+
+
+
         self.set_config_options(sub_configdic)
 
     def _check_config_validity(self) -> List[str]:

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -489,7 +489,7 @@ class IO:
         for source in self.input_datasets:
             if np.allclose(data[source], self.input_datasets[source].flag):
                 return None
-            
+
         # Check if Sky view is used, else it is equal to 1.0.
         if "skyview_factor_file" not in data or data["skyview_factor_file"] is None:
             data["skyview_factor_file"] = 1.0

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -502,7 +502,7 @@ class IO:
             loc=data["loc_file"],
             esd=self.esd,
             bg_rfl=data["background_reflectance_file"],
-            skyview_factor=data["skyview_factor_file"],
+            svf=data["skyview_factor_file"],
         )
 
         self.current_input_data.geom = geom

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -489,6 +489,10 @@ class IO:
         for source in self.input_datasets:
             if np.allclose(data[source], self.input_datasets[source].flag):
                 return None
+            
+        # Check if Sky view is used, else it is equal to 1.0.
+        if "skyview_factor_file" not in data or data["skyview_factor_file"] is None:
+            data["skyview_factor_file"] = 1.0
 
         # We build the geometry object for this spectrum.  For files not
         # specified in the input configuration block, the associated entries
@@ -498,6 +502,7 @@ class IO:
             loc=data["loc_file"],
             esd=self.esd,
             bg_rfl=data["background_reflectance_file"],
+            skyview_factor=data["skyview_factor_file"],
         )
 
         self.current_input_data.geom = geom

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -119,4 +119,8 @@ class Geometry:
         # Local solar zenith angle as a function of surface slope and aspect
         cos_i = self.cos_i if self.cos_i is not None else coszen
 
+        # Ensure coszen and cos_i respect 0-1 bounds.
+        coszen = np.clip(coszen, 0., 1.)
+        cos_i = np.clip(cos_i, 0., 1.)  
+
         return coszen, cos_i

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -38,6 +38,7 @@ class Geometry:
         dt: datetime = None,
         esd: np.array = None,
         bg_rfl: np.array = None,
+        svf: float = None,
     ):
         # Set some benign defaults...
         self.observer_zenith = (
@@ -63,9 +64,7 @@ class Geometry:
 
         self.bg_rfl = bg_rfl
         self.cos_i = None
-
-        # TODO: file IO reads some external sky view image computed outside ISOFIT.
-        self.sky_view_factor = 1.0
+        self.sky_view_factor = svf
 
         # The 'obs' object is observation metadata that follows a historical
         # AVIRIS-NG format.  It arrives to our initializer in the form of

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -120,7 +120,7 @@ class Geometry:
         cos_i = self.cos_i if self.cos_i is not None else coszen
 
         # Ensure coszen and cos_i respect 0-1 bounds.
-        coszen = np.clip(coszen, 0., 1.)
-        cos_i = np.clip(cos_i, 0., 1.)  
+        coszen = np.clip(coszen, 0.0, 1.0)
+        cos_i = np.clip(cos_i, 0.0, 1.0)
 
         return coszen, cos_i

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -320,6 +320,9 @@ class RadiativeTransfer:
                     L_down_dif = units.transm_to_rdn(
                         r["transm_down_dif"], coszen, self.solar_irr
                     )
+                
+                # Apply sky view factor to downward diffuse for 1C case.
+                L_down_dif *= geom.sky_view_factor
 
                 L_down = L_down_dir + L_down_dif
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -320,7 +320,7 @@ class RadiativeTransfer:
                     L_down_dif = units.transm_to_rdn(
                         r["transm_down_dif"], coszen, self.solar_irr
                     )
-                
+
                 # Apply sky view factor to downward diffuse for 1C case.
                 L_down_dif *= geom.sky_view_factor
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -589,6 +589,7 @@ def apply_oe(
             (paths.radiance_working_path, paths.rdn_subs_path),
             (paths.obs_working_path, paths.obs_subs_path),
             (paths.loc_working_path, paths.loc_subs_path),
+            (paths.svf_working_path, paths.svf_subs_path),
         ]:
             if not exists(outp):
                 logging.info("Extracting " + outp)

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -803,6 +803,7 @@ def apply_oe(
                 working_directory,
                 output_rfl_file=paths.rfl_working_path,
                 output_unc_file=paths.uncert_working_path,
+                skyview_factor_file=paths.svf_working_path,
                 loglevel=logging_level,
                 logfile=log_file,
                 n_atm_neighbors=nneighbors,

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -849,7 +849,7 @@ def apply_oe(
 @click.option("--config_only", is_flag=True, default=False)
 @click.option("--interpolate_bad_rdn", is_flag=True, default=False)
 @click.option("--interpolate_inplace", is_flag=True, default=False)
-@click.option("--skyview_factor", is_flag=True, default=None)
+@click.option("--skyview_factor", type=str, default=None)
 @click.option(
     "--debug-args",
     help="Prints the arguments list without executing the command",

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -300,12 +300,14 @@ def apply_oe(
                     f" match input_radiance size: {rdn_size}"
                 )
                 raise ValueError(err_str)
-    
+
     # Check if user passed a path to sky view factor image file, else it is None.
     if skyview_factor:
         # check file exists first..
         if not exists(skyview_factor):
-            raise ValueError(f'Input skyview: {skyview_factor} file was not found system.')
+            raise ValueError(
+                f"Input skyview: {skyview_factor} file was not found system."
+            )
         else:
             # load in and ensure same shape as image file.
             svf_dataset = envi.open(envi_header(skyview_factor), skyview_factor)
@@ -337,7 +339,7 @@ def apply_oe(
         channelized_uncertainty_path,
         ray_temp_dir,
         interpolate_inplace,
-        skyview_factor
+        skyview_factor,
     )
     paths.make_directories()
     paths.stage_files()

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -591,7 +591,7 @@ def apply_oe(
             (paths.loc_working_path, paths.loc_subs_path),
             (paths.svf_working_path, paths.svf_subs_path),
         ]:
-            if not exists(outp):
+            if not exists(outp) and inp is not None:
                 logging.info("Extracting " + outp)
                 extractions(
                     inputfile=inp,
@@ -603,6 +603,8 @@ def apply_oe(
                     loglevel=logging_level,
                     logfile=log_file,
                 )
+            else:
+                logging.info(f"Skipping {inp}, because is not a path.")
 
     if presolve:
         # write modtran presolve template

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -315,7 +315,7 @@ def apply_oe(
             del svf_dataset
             if not (svf_size[0] == rdn_size[0] and svf_size[1] == rdn_size[1]):
                 err_str = (
-                    f"Input file: {skyview_factor} size is {input_size}, which does not"
+                    f"Input file: {skyview_factor} size is {svf_size}, which does not"
                     f" match input_radiance size: {rdn_size}"
                 )
                 raise ValueError(err_str)

--- a/isofit/utils/skyview.py
+++ b/isofit/utils/skyview.py
@@ -97,7 +97,7 @@ def skyview(
 
     # Load DEM data (assuming hdr).
     dem = envi.open(envi_header(dem_prj_path))
-    dem_data = dem.open_memmap(writeable=False)
+    dem_data = dem.open_memmap(writeable=False).copy()
     if dem_data.ndim == 3 and dem_data.shape[2] == 1:
         dem_data = dem_data[:, :, 0]
     dem_metadata = dem.metadata.copy()
@@ -110,6 +110,10 @@ def skyview(
             "byte order": 0,
         }
     )
+
+    # Handle potential no data in dem_data.
+    dem_data[dem_data>8900] = np.nan 
+    dem_data[dem_data>-1360] = np.nan 
 
     # prep the data for correct format for computation
     angles, aspect, cos_slope, sin_slope, tan_slope = viewf2022_prep(

--- a/isofit/utils/skyview.py
+++ b/isofit/utils/skyview.py
@@ -193,7 +193,6 @@ def viewf2022_prep(dem, spacing, nangles=72, sin_slope=None, aspect=None):
     # -180 is North
     angles = np.linspace(-180, 180, num=nangles, endpoint=False)
 
-
     return angles, aspect, cos_slope, sin_slope, tan_slope
 
 

--- a/isofit/utils/skyview.py
+++ b/isofit/utils/skyview.py
@@ -1,0 +1,660 @@
+#! /usr/bin/env python3
+#
+#  Copyright 2019 California Institute of Technology
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ISOFIT: Imaging Spectrometer Optimal FITting
+# Author: David R Thompson, david.r.thompson@jpl.nasa.gov
+#
+
+
+import logging
+from os.path import abspath, join
+
+import click
+import numpy as np
+import ray
+from spectral.io import envi
+
+from isofit.core.common import envi_header
+
+
+def skyview(
+    dem_prj_path,
+    dem_prj_resolution,
+    working_directory,
+    n_angles=72,
+    logging_level="INFO",
+    log_file=None,
+    n_cores=1,
+    ray_address: str = None,
+    ray_redis_password: str = None,
+    ray_temp_dir=None,
+    ray_ip_head=None,
+):
+    """\
+    Applies sky view factor calculation for a given UTM projected DEM or DSM. Much of this code was borrowed from ARS Topo-Calc.
+    The key thing here was to create a python-only, rasterio-free port of this that could be used within ISOFIT. We also included 
+    improvements that are current in Jeff Dozier's horizon method in Matlab (https://github.com/DozierJeff/Topographic-Horizons).
+
+    Also, following suggestions from Dozier (2021), multiprocessing is leveraged here w.r.t. to n_angles rotating the image. As default,
+    sky view is computed with n angles = 72 which in most cases is of sufficient accuracy to resolve but more angles may be used.
+
+    \b
+    Parameters
+    ----------
+    dem_prj_path : str
+        Path to the projected DEM or DSM file in UTM coordinates.
+    dem_prj_resolution : float
+        Spatial resolution of the projected DEM in coordinate units (GSD in meters).
+    working_directory : str
+        Directory path for temporary files and outputs during processing; similar to apply_oe.
+    n_angles : int, optional
+        Number of angles used in horizon calculations (default is 72).
+    logging_level : str, optional
+        Logging verbosity level (default is "INFO"); similar to apply_oe.
+    log_file : str or None, optional
+        File path to write logs; similar to apply_oe.
+    n_cores : int, optional
+        Number of CPU cores to use for parallel processing (default is 1).
+    """
+
+    # Match data directory from template construction and set svf path.
+    data_directory = abspath(join(working_directory, "data/"))
+    svf_hdr_path = join(data_directory, "sky_view_factor.hdr")
+
+    # Set up logging
+    logging.basicConfig(
+        format="%(levelname)s:%(message)s", level=logging_level, filename=log_file
+    )
+
+    # Start up a ray instance for parallel work
+    rayargs = {
+        "ignore_reinit_error": True,
+        "local_mode": n_cores == 1,
+        "address": ray_address,
+        "include_dashboard": False,
+        "_temp_dir": ray_temp_dir,
+        "_redis_password": ray_redis_password,
+    }
+
+    # We can only set the num_cpus if running on a single-node
+    if ray_ip_head is None and ray_redis_password is None:
+        rayargs["num_cpus"] = n_cores
+
+    ray.init(**rayargs)
+
+    # Load DEM data (assuming hdr).
+    dem = envi.open(envi_header(dem_prj_path))
+    dem_data = dem.open_memmap(writeable=False)
+    if dem_data.ndim == 3 and dem_data.shape[2] == 1:
+        dem_data = dem_data[:, :, 0]
+    dem_metadata = dem.metadata.copy()
+    dem_metadata.update(
+        {
+            "description": "Sky View Factor",
+            "bands": 1,
+            "interleave": "bsq",
+            "data type": 4,
+            "byte order": 0,
+        }
+    )
+
+    # prep the data for correct format for computation
+    angles, aspect, cos_slope, sin_slope, tan_slope = viewf2022_prep(
+        dem=dem_data,
+        spacing=dem_prj_resolution,
+        nangles=n_angles,
+        sin_slope=None,
+        aspect=None,
+    )
+
+    # Run n-angles in parallel (n=72 by default)
+    futures = [
+        viewf2022_i.remote(
+            a, dem_data, dem_prj_resolution, aspect, cos_slope, sin_slope, tan_slope
+        )
+        for a in angles
+    ]
+    results = ray.get(futures)
+
+    # and so now, we have a list object of 72, 2-d arrays
+    # and  can complete integration for svf
+    svf = sum(results) / len(angles)
+    # tcf = (1 + cos_slope)/2 - svf
+
+    # Save the SVF result using spectral.envi
+    envi.save_image(
+        svf_hdr_path,
+        svf.astype(np.float32),
+        dtype=np.float32,
+        interleave="bsq",
+        metadata=dem_metadata,
+        force=True,
+    )
+
+
+def viewf2022_prep(dem, spacing, nangles=72, sin_slope=None, aspect=None):
+    """
+    Preps computations for multipool
+
+    Args:
+        dem: numpy array for the DEM
+        spacing: grid spacing of the DEM
+        nangles: number of angles to estimate the horizon, defaults
+                to 72 angles
+        sin_slope: optional, will calculate if not provided
+                    sin(slope) with range from 0 to 1
+        aspect: optional, will calculate if not provided
+                Aspect as radians from south (aspect 0 is toward
+                the south) with range from -pi to pi, with negative
+                values to the west and positive values to the east.
+
+    Returns:
+        angles, aspect, cos_slope, sin_slope, tan_slope
+
+    """
+
+    if dem.ndim != 2:
+        raise ValueError("viewf input of dem is not a 2D array")
+
+    if nangles < 16:
+        raise ValueError("viewf number of angles should be 16 or greater")
+
+    if sin_slope is not None:
+        if np.max(sin_slope) > 1:
+            raise ValueError("slope must be sin(slope) with range from 0 to 1")
+
+    # calculate the gradient if not provided
+    # The slope is returned as radians so convert to sin(S)
+    if sin_slope is None:
+        slope, aspect = gradient_d8(dem, dx=spacing, dy=spacing, aspect_rad=True)
+        sin_slope = np.sin(slope)
+        cos_slope = np.cos(slope)
+        tan_slope = np.tan(slope)
+
+    # -180 is North
+    angles = np.linspace(-180, 180, num=nangles, endpoint=False)
+
+    # trig
+    cos_slope = np.sqrt(1 - sin_slope**2)
+
+    return angles, aspect, cos_slope, sin_slope, tan_slope
+
+
+@ray.remote
+def viewf2022_i(angle, dem, spacing, aspect, cos_slope, sin_slope, tan_slope):
+    """
+    See above, but this is running each horizon angle in parallel (n=72 , or user input)
+
+    This returns the i-th svf array, used in the integral
+
+    """
+
+    # horizon angles
+    hcos = horizon(angle, dem, spacing)
+    azimuth = np.radians(angle)
+    h = np.arccos(hcos)
+
+    # cosines of difference between horizon aspect and slope aspect
+    cos_aspect = np.cos(aspect - azimuth)
+
+    # check for slope being obscured
+    # EQ 3 in Dozier et al. 2022
+    #     H(t) = min(H(t), acos(sqrt(1-1./(1+tand(slopeDegrees)^2*cos(azmRadian(t)-aspectRadian).^2))));
+    t = cos_aspect < 0
+    h[t] = np.fmin(
+        h[t], np.arccos(np.sqrt(1 - 1 / (1 + cos_aspect[t] ** 2 * tan_slope[t] ** 2)))
+    )
+
+    # integral in Dozier.
+    # qIntegrand = (cosd(slopeDegrees)*sin(H).^2 + sind(slopeDegrees)*cos(aspectRadian-azmRadian).*(H-cos(H).*sin(H)))/2
+    svf = cos_slope * np.sin(h) ** 2 + sin_slope * cos_aspect * (
+        h - np.sin(h) * np.cos(h)
+    )
+
+    svf[svf < 0] = 0
+
+    return svf
+
+
+def gradient_d8(dem, dx, dy, aspect_rad=False):
+    """
+    Calculate the slope and aspect for provided dem,
+    using a 3x3 cell around the center
+
+    Given a center cell e and it's neighbors:
+
+    | a | b | c |
+    | d | e | f |
+    | g | h | i |
+
+    The rate of change in the x direction is
+
+    [dz/dx] = ((c + 2f + i) - (a + 2d + g) / (8 * dx)
+
+    The rate of change in the y direction is
+
+    [dz/dy] = ((g + 2h + i) - (a + 2b + c)) / (8 * dy)
+
+    The slope is calculated
+
+    slope_radians = arctan ( sqrt ([dz/dx]^2 + [dz/dy]^2) )
+
+    Args:
+        dem: array of elevation values
+        dx: cell size along the x axis
+        dy: cell size along the y axis
+        aspect_rad: turn the aspect from degrees to IPW radians
+
+    Returns:
+        slope in radians
+        aspect in degrees or IPW radians
+    """
+
+    # Pad the dem
+    dem_pad = np.pad(dem, pad_width=1, mode="edge")
+
+    # top
+    dem_pad[0, :] = dem_pad[1, :] + (dem_pad[1, :] - dem_pad[2, :])
+
+    # bottom
+    dem_pad[-1, :] = dem_pad[-2, :] + (dem_pad[-2, :] - dem_pad[-3, :])
+
+    # left
+    dem_pad[:, 0] = dem_pad[:, 1] + (dem_pad[:, 1] - dem_pad[:, 2])
+
+    # right
+    dem_pad[:, -1] = dem_pad[:, -2] - (dem_pad[:, -3] - dem_pad[:, -2])
+
+    # finite difference in the y direction
+    dz_dy = (
+        (dem_pad[2:, :-2] + 2 * dem_pad[2:, 1:-1] + dem_pad[2:, 2:])
+        - (dem_pad[:-2, :-2] + 2 * dem_pad[:-2, 1:-1] + dem_pad[:-2, 2:])
+    ) / (8 * dy)
+
+    # finite difference in the x direction
+    dz_dx = (
+        (dem_pad[:-2, 2:] + 2 * dem_pad[1:-1, 2:] + dem_pad[2:, 2:])
+        - (dem_pad[:-2, :-2] + 2 * dem_pad[1:-1, :-2] + dem_pad[2:, :-2])
+    ) / (8 * dx)
+
+    slope = calc_slope(dz_dx, dz_dy)
+    a = aspect(dz_dx, dz_dy)
+
+    if aspect_rad:
+        a = aspect_to_ipw_radians(a)
+
+    return slope, a
+
+
+def calc_slope(dz_dx, dz_dy):
+    """Calculate the slope given the finite differences
+
+    Arguments:
+        dz_dx: finite difference in the x direction
+        dz_dy: finite difference in the y direction
+
+    Returns:
+        slope numpy array
+    """
+
+    return np.arctan(np.sqrt(dz_dx**2 + dz_dy**2))
+
+
+def aspect(dz_dx, dz_dy):
+    """
+    Calculate the aspect from the finite difference.
+    Aspect is degrees clockwise from North (0/360 degrees)
+
+    See below for a referance to how ArcGIS calculates slope
+    http://help.arcgis.com/en/arcgisdesktop/10.0/help/index.html#/How_Aspect_works/00q900000023000000/
+
+    Args:
+        dz_dx: finite difference in the x direction
+        dz_dy: finite difference in the y direction
+
+    Returns
+        aspect in degrees clockwise from North
+    """
+
+    # return in degrees
+    a = 180 * np.arctan2(dz_dy, -dz_dx) / np.pi
+
+    aout = 90 - a
+    aout[a < 0] = 90 - a[a < 0]
+    aout[a > 90] = 360 - a[a > 90] + 90
+
+    # if dz_dy and dz_dx are zero, then handle the
+    # special case. Follow the IPW convetion and set
+    # the aspect to south or 180 degrees
+    idx = (dz_dy == 0) & (dz_dx == 0)
+    aout[idx] = 180
+
+    return aout
+
+
+def aspect_to_ipw_radians(a):
+    """
+    IPW defines aspect differently than most GIS programs
+    so convert an aspect in degrees from due North (0/360)
+    to the IPW definition.
+
+    Aspect is radians from south (aspect 0 is toward
+    the south) with range from -pi to pi, with negative
+    values to the west and positive values to the east
+
+    Args:
+        a: aspect in degrees from due North
+
+    Returns
+        a: aspect in radians from due South
+    """
+
+    arad = np.pi - a * np.pi / 180
+
+    return arad
+
+
+def horizon(azimuth, dem, spacing):
+    """Calculate horizon angles for one direction. Horizon angles
+    are based on Dozier and Frew 1990 and are adapted from the
+    IPW C code.
+
+    The coordinate system for the azimuth is 0 degrees is South,
+    with positive angles through East and negative values
+    through West. Azimuth values must be on the -180 -> 0 -> 180
+    range.
+
+    Arguments:
+        azimuth {float} -- find horizon's along this direction
+        dem {np.array2d} -- numpy array of dem elevations
+        spacing {float} -- grid spacing
+
+    Returns:
+        hcos {np.array} -- cosines of angles to the horizon
+    """
+
+    if dem.ndim != 2:
+        raise ValueError("horizon input of dem is not a 2D array")
+
+    if azimuth > 180 or azimuth < -180:
+        raise ValueError("azimuth must be between -180 and 180 degrees")
+
+    if azimuth == 90:
+        # East
+        hcos = hor2d(dem, spacing, fwd=True)
+
+    elif azimuth == -90:
+        # West
+        hcos = hor2d(dem, spacing, fwd=False)
+
+    elif azimuth == 0:
+        # South
+        hcos = hor2d(dem.transpose(), spacing, fwd=True)
+        hcos = hcos.transpose()
+
+    elif np.abs(azimuth) == 180:
+        # South
+        hcos = hor2d(dem.transpose(), spacing, fwd=False)
+        hcos = hcos.transpose()
+
+    elif azimuth >= -45 and azimuth <= 45:
+        # South west through south east
+        t, spacing = skew_transpose(dem, spacing, azimuth)
+        h = hor2d(t, spacing, fwd=True)
+        hcos = skew(h.transpose(), azimuth, fwd=False)
+
+    elif azimuth <= -135 and azimuth > -180:
+        # North west
+        a = azimuth + 180
+        t, spacing = skew_transpose(dem, spacing, a)
+        h = hor2d(t, spacing, fwd=False)
+        hcos = skew(h.transpose(), a, fwd=False)
+
+    elif azimuth >= 135 and azimuth < 180:
+        # North East
+        a = azimuth - 180
+        t, spacing = skew_transpose(dem, spacing, a)
+        h = hor2d(t, spacing, fwd=False)
+        hcos = skew(h.transpose(), a, fwd=False)
+
+    elif azimuth > 45 and azimuth < 135:
+        # South east through north east
+        a = 90 - azimuth
+        t, spacing = transpose_skew(dem, spacing, a)
+        h = hor2d(t, spacing, fwd=True)
+        hcos = skew(h.transpose(), a, fwd=False).transpose()
+
+    elif azimuth < -45 and azimuth > -135:
+        # South west through north west
+        a = -90 - azimuth
+        t, spacing = transpose_skew(dem, spacing, a)
+        h = hor2d(t, spacing, fwd=False)
+        hcos = skew(h.transpose(), a, fwd=False).transpose()
+
+    else:
+        ValueError("azimuth not valid")
+
+    # sanity check
+    assert hcos.shape == dem.shape
+
+    return hcos
+
+
+def hor1(z, fwd=True):
+    n = len(z)
+    h = np.empty(n, dtype=int)
+    if fwd:
+        h[-1] = n - 1
+        iterator = range(n - 2, -1, -1)
+        step = 1
+    else:
+        h[0] = 0
+        iterator = range(1, n)
+        step = -1
+
+    for i in iterator:
+        zi = z[i]
+        max_slope = 0.0
+        max_point = i
+        k_range = range(i + step, n if fwd else -1, step)
+        for k in k_range:
+            if z[k] > zi:
+                dist = abs(k - i)
+                slope_ik = (z[k] - zi) / dist
+                if slope_ik > max_slope:
+                    max_slope = slope_ik
+                    max_point = k
+        h[i] = max_point
+    return h
+
+
+def horval(z, delta, h):
+    j = h
+    d = j - np.arange(len(z))
+    diff = z[j] - z
+    dist = np.abs(d) * delta
+    hcos = np.where(d == 0, 0, diff / np.hypot(diff, dist))
+    return hcos
+
+
+def hor2d(z, delta, fwd=True):
+    if z.ndim != 2:
+        raise ValueError("Input must be 2D array")
+    nrows, ncols = z.shape
+    hcos = np.empty_like(z)
+    for i in range(nrows):
+        zbuf = z[i, :]
+        hbuf = hor1(zbuf, fwd=fwd)
+        obuf = horval(zbuf, delta, hbuf)
+        hcos[i, :] = obuf
+    return hcos
+
+
+
+def adjust_spacing(spacing, skew_angle):
+    """Adjust the grid spacing if a skew angle is present
+
+    Arguments:
+        spacing {float} -- grid spacing
+        skew_angle {float} -- angle to adjust the spacing for [degrees]
+    """
+
+    if skew_angle > 45 or skew_angle < 0:
+        raise ValueError("skew angle must be between 0 and 45 degrees")
+
+    return spacing / np.cos(skew_angle * np.arctan(1.0) / 45)
+
+
+def skew(arr, angle, fwd=True, fill_min=True):
+    """
+    Skew the origin of successive lines by a specified angle
+    A skew with angle of 30 degrees causes the following transformation:
+
+        +-----------+       +---------------+
+        |           |       |000/          /|
+        |   input   |       |00/  output  /0|
+        |   image   |       |0/   image  /00|
+        |           |       |/          /000|
+        +-----------+       +---------------+
+
+    Calling skew with fwd=False will return the output image
+    back to the input image.
+
+    Skew angle must be between -45 and 45 degrees
+
+    Args:
+        arr: array to skew
+        angle: angle between -45 and 45 to skew by
+        fwd: add skew to image if True, unskew image if False
+        fill_min: While IPW skew says it fills with zeros, the output
+            image is filled with the minimum value
+
+    Returns:
+        skewed array
+
+    """
+
+    if angle == 0:
+        return arr
+
+    if angle > 45 or angle < -45:
+        raise ValueError("skew angle must be between -45 and 45 degrees")
+
+    nlines, nsamps = arr.shape
+
+    if angle >= 0.0:
+        negflag = False
+    else:
+        negflag = True
+        angle = -angle
+
+    slope = np.tan(angle * np.pi / 180.0)
+    max_skew = int((nlines - 1) * slope + 0.5)
+
+    o_nsamps = nsamps
+    if fwd:
+        o_nsamps += max_skew
+    else:
+        o_nsamps -= max_skew
+
+    b = np.zeros((nlines, o_nsamps))
+    if fill_min:
+        b += np.min(arr)
+
+    for line in range(nlines):
+        o = line if negflag else nlines - line - 1
+        offset = int(o * slope + 0.5)
+
+        if fwd:
+            b[line, offset : offset + nsamps] = arr[line, :]
+        else:
+            b[line, :] = arr[line, offset : offset + o_nsamps]
+
+    return b
+
+
+def skew_transpose(dem, spacing, angle):
+    """Skew and transpose the dem for the given angle.
+    Also calculate the new spacing given the skew.
+
+    Arguments:
+        dem {array} -- numpy array of dem elevations
+        spacing {float} -- grid spacing
+        angle {float} -- skew angle
+
+    Returns:
+        t -- skew and transpose array
+        spacing -- new spacing adjusted for angle
+    """
+
+    spacing = adjust_spacing(spacing, np.abs(angle))
+    t = skew(dem, angle, fill_min=True).transpose()
+
+    return t, spacing
+
+
+def transpose_skew(dem, spacing, angle):
+    """Transpose, skew then transpose a dem for the
+    given angle. Also calculate the new spacing
+
+    Arguments:
+        dem {array} -- numpy array of dem elevations
+        spacing {float} -- grid spacing
+        angle {float} -- skew angle
+
+    Returns:
+        t -- skew and transpose array
+        spacing -- new spacing adjusted for angle
+    """
+
+    t = skew(dem.transpose(), angle, fill_min=True).transpose()
+    spacing = adjust_spacing(spacing, np.abs(angle))
+
+    return t, spacing
+
+# Input arguments
+@click.command(name="skyview", help=skyview.__doc__, no_args_is_help=True)
+@click.argument("dem_prj_path", type=str)
+@click.argument("dem_prj_resolution", type=float)
+@click.argument("working_directory", type=str)
+@click.option("--n_angles", type=int, default=72)
+@click.option("--logging_level", default="INFO")
+@click.option("--log_file", type=str, default=None)
+@click.option("--n_cores", type=int, default=1)
+@click.option("--ray_address", type=str, default=None)
+@click.option("--ray_redis_password", type=str, default=None)
+@click.option("--ray_temp_dir", type=str, default="/tmp/ray")
+@click.option("--ray_ip_head", type=str, default=None)
+@click.option(
+    "--debug_args",
+    help="Print the arguments and exit",
+    is_flag=True,
+)
+def cli(debug_args, **kwargs):
+    if debug_args:
+        print("Arguments to be passed:")
+        for key, value in kwargs.items():
+            print(f"  {key} = {value!r}")
+    else:
+        skyview(**kwargs)
+
+    print("Done")
+
+
+if __name__ == "__main__":
+    raise NotImplementedError(
+        "skyview.py can no longer be called this way.  Run as:\n isofit skyview [ARGS]"
+    )

--- a/isofit/utils/skyview.py
+++ b/isofit/utils/skyview.py
@@ -113,7 +113,7 @@ def skyview(
 
     # Handle potential no data in dem_data.
     dem_data[dem_data>8900] = np.nan 
-    dem_data[dem_data>-1360] = np.nan 
+    dem_data[dem_data<-1360] = np.nan 
 
     # prep the data for correct format for computation
     angles, aspect, cos_slope, sin_slope, tan_slope = viewf2022_prep(

--- a/isofit/utils/skyview.py
+++ b/isofit/utils/skyview.py
@@ -20,7 +20,7 @@
 
 
 import logging
-from os.path import abspath, join
+from os.path import join
 
 import click
 import numpy as np
@@ -33,7 +33,7 @@ from isofit.core.common import envi_header
 def skyview(
     dem_prj_path,
     dem_prj_resolution,
-    working_directory,
+    output_directory,
     n_angles=72,
     logging_level="INFO",
     log_file=None,
@@ -70,9 +70,8 @@ def skyview(
         Number of CPU cores to use for parallel processing (default is 1).
     """
 
-    # Match data directory from template construction and set svf path.
-    data_directory = abspath(join(working_directory, "data/"))
-    svf_hdr_path = join(data_directory, "sky_view_factor.hdr")
+    # Construct svf output path.
+    svf_hdr_path = join(output_directory, "sky_view_factor.hdr")
 
     # Set up logging
     logging.basicConfig(
@@ -112,8 +111,8 @@ def skyview(
     )
 
     # Handle potential no data in dem_data.
-    dem_data[dem_data>8900] = np.nan 
-    dem_data[dem_data<-1360] = np.nan 
+    dem_data[dem_data > 8900] = np.nan
+    dem_data[dem_data < -1360] = np.nan
 
     # prep the data for correct format for computation
     angles, aspect, cos_slope, sin_slope, tan_slope = viewf2022_prep(
@@ -507,7 +506,6 @@ def hor2d(z, delta, fwd=True):
     return hcos
 
 
-
 def adjust_spacing(spacing, skew_angle):
     """Adjust the grid spacing if a skew angle is present
 
@@ -628,6 +626,7 @@ def transpose_skew(dem, spacing, angle):
     spacing = adjust_spacing(spacing, np.abs(angle))
 
     return t, spacing
+
 
 # Input arguments
 @click.command(name="skyview", help=skyview.__doc__, no_args_is_help=True)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -162,12 +162,12 @@ class Pathnames:
 
         if skyview_factor:
             self.svf_working_path = abspath(skyview_factor)
-            self.svf_subs_path = join(
-                dirname(self.svf_working_path), self.fid + "_subs_svf"
-            )
         else:
             self.svf_working_path = None
-            self.svf_subs_path = None
+
+        self.svf_subs_path = abspath(
+            join(self.input_data_directory, self.fid + "_subs_svf")
+        )
 
         self.rdn_subs_path = abspath(
             join(self.input_data_directory, self.fid + "_subs_rdn")

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -50,7 +50,7 @@ class Pathnames:
         channelized_uncertainty_path,
         ray_temp_dir,
         interpolate_inplace,
-        skyview_factor
+        skyview_factor,
     ):
         # Determine FID based on sensor name
         if sensor == "ang":
@@ -163,7 +163,7 @@ class Pathnames:
         if skyview_factor:
             self.svf_working_path = abspath(skyview_factor)
         else:
-            self.svf_working_path = None         
+            self.svf_working_path = None
 
         self.rdn_subs_path = abspath(
             join(self.input_data_directory, self.fid + "_subs_rdn")
@@ -1028,11 +1028,9 @@ def build_main_config(
         isofit_config_modtran["input"][
             "radiometry_correction_file"
         ] = paths.rdn_factors_path
-    
+
     if paths.svf_working_path:
-        isofit_config_modtran["input"][
-            "skyview_factor_file"
-        ] = paths.svf_working_path
+        isofit_config_modtran["input"]["skyview_factor_file"] = paths.svf_working_path
 
     # write main config file
     with open(paths.isofit_full_config_path, "w") as fout:

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -50,6 +50,7 @@ class Pathnames:
         channelized_uncertainty_path,
         ray_temp_dir,
         interpolate_inplace,
+        skyview_factor
     ):
         # Determine FID based on sensor name
         if sensor == "ang":
@@ -158,6 +159,11 @@ class Pathnames:
         self.model_discrepancy_working_path = abspath(
             join(self.data_directory, "model_discrepancy.mat")
         )
+
+        if skyview_factor:
+            self.svf_working_path = abspath(skyview_factor)
+        else:
+            self.svf_working_path = None         
 
         self.rdn_subs_path = abspath(
             join(self.input_data_directory, self.fid + "_subs_rdn")
@@ -1022,6 +1028,11 @@ def build_main_config(
         isofit_config_modtran["input"][
             "radiometry_correction_file"
         ] = paths.rdn_factors_path
+    
+    if paths.svf_working_path:
+        isofit_config_modtran["input"][
+            "skyview_factor_file"
+        ] = paths.svf_working_path
 
     # write main config file
     with open(paths.isofit_full_config_path, "w") as fout:

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -975,6 +975,10 @@ def build_main_config(
         ] = paths.radiance_working_path
         isofit_config_modtran["input"]["loc_file"] = paths.loc_working_path
         isofit_config_modtran["input"]["obs_file"] = paths.obs_working_path
+        if paths.svf_working_path:
+            isofit_config_modtran["input"][
+                "skyview_factor_file"
+            ] = paths.svf_working_path
         isofit_config_modtran["output"][
             "posterior_uncertainty_file"
         ] = paths.uncert_working_path
@@ -1028,9 +1032,6 @@ def build_main_config(
         isofit_config_modtran["input"][
             "radiometry_correction_file"
         ] = paths.rdn_factors_path
-
-    if paths.svf_working_path:
-        isofit_config_modtran["input"]["skyview_factor_file"] = paths.svf_working_path
 
     # write main config file
     with open(paths.isofit_full_config_path, "w") as fout:

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -8,7 +8,7 @@ import logging
 import os
 import subprocess
 from datetime import datetime
-from os.path import abspath, exists, join, split
+from os.path import abspath, exists, join, split, dirname
 from shutil import copyfile
 from sys import platform
 from typing import List
@@ -162,8 +162,12 @@ class Pathnames:
 
         if skyview_factor:
             self.svf_working_path = abspath(skyview_factor)
+            self.svf_subs_path = join(
+                dirname(self.svf_working_path), self.fid + "_subs_svf"
+            )
         else:
             self.svf_working_path = None
+            self.svf_subs_path = None
 
         self.rdn_subs_path = abspath(
             join(self.input_data_directory, self.fid + "_subs_rdn")
@@ -959,6 +963,8 @@ def build_main_config(
         isofit_config_modtran["input"]["measured_radiance_file"] = paths.rdn_subs_path
         isofit_config_modtran["input"]["loc_file"] = paths.loc_subs_path
         isofit_config_modtran["input"]["obs_file"] = paths.obs_subs_path
+        if paths.svf_working_path:
+            isofit_config_modtran["input"]["skyview_factor_file"] = paths.svf_subs_path
         isofit_config_modtran["output"]["estimated_state_file"] = paths.state_subs_path
         isofit_config_modtran["output"][
             "posterior_uncertainty_file"


### PR DESCRIPTION
Changes
- Standalone skyview.py utility that can be used prior to apply_oe. Recommended for DEM larger than image. 
- Sky view flag in apply_oe (tested for 4C, 1C, and analytical line). ENVI skyview file input must be same dimensions as radiance data (i.e., clipped to radiance data by user prior to apply_oe). 
- physical bounds [0,1] introduced for cos_i and coszen in Geometry class.