### PR TITLE
Wavelength unit check for liquid water inversion.

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -547,7 +547,7 @@ def invert_liquid_water(
     """
     # make sure that wavelengths are provided in nm
     if wl[0] < 100:
-        wl *= 1000.0
+        wl = units.micron_to_nm(wl)
 
     # params needed for liquid water fitting
     lw_feature_left = np.argmin(abs(l_shoulder - wl))

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -534,7 +534,7 @@ def invert_liquid_water(
 
     Args:
         rfl_meas:            surface reflectance spectrum
-        wl:                  instrument wavelengths, must be same size as rfl_meas
+        wl:                  instrument wavelengths, must be same size as rfl_meas and in units of nm
         l_shoulder:          wavelength of left absorption feature shoulder
         r_shoulder:          wavelength of right absorption feature shoulder
         lw_init:             initial guess for liquid water path length, intercept, and slope
@@ -545,6 +545,9 @@ def invert_liquid_water(
     Returns:
         solution: estimated liquid water path length, intercept, and slope based on a given surface reflectance
     """
+    # check if wavelengths are provided in nm
+    if wl[0] < 100:
+        wl *= 1000.0
 
     # params needed for liquid water fitting
     lw_feature_left = np.argmin(abs(l_shoulder - wl))

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -545,7 +545,7 @@ def invert_liquid_water(
     Returns:
         solution: estimated liquid water path length, intercept, and slope based on a given surface reflectance
     """
-    # check if wavelengths are provided in nm
+    # make sure that wavelengths are provided in nm
     if wl[0] < 100:
         wl *= 1000.0
 

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -28,6 +28,7 @@ from scipy.linalg import inv
 from sklearn.cluster import KMeans
 from spectral.io import envi
 
+from isofit.core import units
 from isofit.core.common import envi_header, expand_path, json_load_ascii, svd_inv
 
 
@@ -106,7 +107,7 @@ def surface_model(
         wl = q[:, 0]
 
     if wl[0] < 100:
-        wl *= 1000.0
+        wl = units.micron_to_nm(wl)
     nchan = len(wl)
 
     # build global reference windows
@@ -173,7 +174,7 @@ def surface_model(
 
             # Maybe convert to nanometers
             if swl[0] < 100:
-                swl = swl * 1000.0
+                swl = units.micron_to_nm(swl)
 
             # Load library and adjust interleave, if needed
             rfl_mm = rfl.open_memmap(interleave="bip", writable=False)


### PR DESCRIPTION
This adds a simple wavelength unit check to `inverse_liquid_water()`. The way the function is set up, wavelengths are required to be in units of nm. Otherwise, EWT results are inaccurate.