### PR TITLE
Path Keys

### DIFF
--- a/isofit/data/__init__.py
+++ b/isofit/data/__init__.py
@@ -17,11 +17,27 @@ import isofit.data.cli
 
 @click.command(name="path")
 @click.argument("product", type=click.Choice(env._dirs))
-def cli(product):
+@click.option("-k", "--key", help="Append the product's key")
+def cli(product, key=None):
     """\
     Prints the path to a specific product
     """
-    print(env[product])
+    path = env[product]
+    if key:
+        # Check if the given key exists
+        if not (sub := env[key]):
+            # If it doesn't, check if this key is a subkey of the product
+            # eg. product=srtmnet, key=file, actual=srtmnet.file
+            subkey = f"{product}.{key}"
+            if not (sub := env[subkey]):
+                print(
+                    f"The key {key!r} does not exist in the INI nor does the subkey {subkey!r}"
+                )
+                return
+
+        path += f"/{sub}"
+
+    print(path)
 
 
 @click.group("dev", invoke_without_command=True, no_args_is_help=True)

--- a/isofit/data/build_examples.py
+++ b/isofit/data/build_examples.py
@@ -246,12 +246,12 @@ Examples = {
     "AV3Cal": IsofitExample(name="20250308_AV3Cal_wltest", requires=["data"]),
     "ImageCube-small": ApplyOEExample(
         name="image_cube/small",
-        requires=["sixs", "srtmnet", "image_cube"],
+        requires=["sixs", "srtmnet", "imagecube"],
         validate={"size": "small"},
     ),
     "ImageCube-medium": ApplyOEExample(
         name="image_cube/medium",
-        requires=["sixs", "srtmnet", "image_cube"],
+        requires=["sixs", "srtmnet", "imagecube"],
         validate={"size": "medium"},
     ),
 }

--- a/isofit/data/cli/imagecube.py
+++ b/isofit/data/cli/imagecube.py
@@ -87,7 +87,9 @@ def validate(path=None, size="both", debug=print, error=print, **_):
     workflows will never detect updates.
     """
     if size == "both":
-        return validate(path, "small") & validate(path, "medium")
+        small = validate(path, "small", debug=debug, error=error)
+        medium = validate(path, "medium", debug=debug, error=error)
+        return small & medium
 
     if path is None:
         path = env.imagecube


### PR DESCRIPTION
While working on some notebooks, I noticed some inconsistencies and desired functionality in the downloads module. This PR addresses those.

- Renamed `image_cube.py` to `imagecube.py` so that the name is consistent. Some areas of the code expected one to the other, so I've settled it to be the latter
- Added a `--key` option to the `isofit path` command
  - In our docs we use `$(isofit path examples)` to retrieve the user's installed `examples` directory. Given that not everyone uses the default `~/.isofit/`, this command enables us to find it and develop notebooks system agnostic
  - To find a user's sRTMnet, we need the `sRTMnet.file` key from the ini as well, so this option allows us to do `isofit path srtmnet -k file` to get the full path to the user's sRTMnet
- Fixed `image.cube.py:validate` not respecting the debug and warning parameters when checking both small and medium sizes at once