### PR TITLE
LUT Compression Options

### DIFF
--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -103,6 +103,14 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         of the keys in radiative_transfer->statevector.  If not specified, uses all keys from
         radiative_transfer->statevector.  Auto-sorted (alphabetically) below."""
 
+        self._lut_compression_type = str
+        self.lut_compression = "zlib"
+        """str: Compression method to use for the LUT NetCDF"""
+
+        self._lut_complevel_type = int
+        self.lut_complevel = None
+        """int: The compression level to use for the chosen method"""
+
         # MODTRAN parameters
         self._aerosol_template_file_type = str
         self.aerosol_template_file = None
@@ -262,6 +270,9 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
                         " must have multipart_transmittance set as True if"
                         " forward_model.topograph_model is set to True"
                     )
+
+        if isinstance(self.lut_complevel, int) and self.lut_complevel < 1:
+            errors.append("The LUT complevel must be and int greater than 0")
 
         return errors
 

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -15,7 +15,7 @@ from netCDF4 import Dataset
 
 from isofit import __version__
 
-Logger = logging.getLogger(__file__)
+Logger = logging.getLogger(__name__)
 
 
 # Statically store expected keys of the LUT file and their fill values
@@ -61,7 +61,8 @@ class Create:
         onedim: dict = {},
         alldim: dict = {},
         zeros: List[str] = [],
-        reduce: bool = ["fwhm"],
+        compression: str = "zlib",
+        complevel: int = None,
     ):
         """
         Prepare a LUT netCDF
@@ -84,9 +85,11 @@ class Create:
             Dictionary of multi-dimensional data. Appends/replaces to the current Create.alldim list.
         zeros : List[str], optional, default=[]
             List of zero values. Appends to the current Create.zeros list.
-        reduce : bool or list, optional, default=['fwhm']
-            Reduces the initialized Dataset by dropping the variables to reduce overall memory usage.
-            If True, drops all variables. If list, drop everything but these.
+        compression : str, default="zlib"
+            Compression method to use to the NetCDF. Check https://unidata.github.io/netcdf4-python/
+            for available options
+        complevel : int, default=None
+            Compression to use. Impact and levels vary per method.
         """
         # Track the ISOFIT version that created this LUT
         attrs["ISOFIT version"] = __version__
@@ -103,6 +106,9 @@ class Create:
         self.consts = {**Keys.consts, **consts}
         self.onedim = {**Keys.onedim, **onedim}
         self.alldim = {**Keys.alldim, **alldim}
+
+        self.compression = compression
+        self.complevel = complevel
 
         # Save ds for backwards compatibility (to work with extractGrid, extractPoints)
         self.initialize()
@@ -122,7 +128,8 @@ class Create:
                 dimensions=dims,
                 fill_value=fill_value,
                 chunksizes=chunksizes,
-                compression="zlib",
+                compression=self.compression,
+                complevel=self.complevel,
             )
             var[:] = vals
 

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -246,6 +246,8 @@ class RadiativeTransferEngine:
                     grid=self.lut_grid,
                     attrs={"RT_mode": self.rt_mode},
                     onedim={"fwhm": fwhm},
+                    compression=engine_config.lut_compression,
+                    complevel=engine_config.lut_complevel,
                 )
 
             # Create and populate a LUT file


### PR DESCRIPTION
Added to the RTE config the ability to set the compression method and level for LUT creation. Right now the default is `zlib` but from some minor tests I've run `zstd` may perform better (complevel 6). Needs more research to find the optimal method combination as there's various trade offs: https://unidata.github.io/netcdf4-python/