### PR TITLE
AOD lower bounds from polynomial

### DIFF
--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -38,7 +38,7 @@ class Geometry:
         dt: datetime = None,
         esd: np.array = None,
         bg_rfl: np.array = None,
-        svf: float = None,
+        svf: float = 1,
     ):
         # Set some benign defaults...
         self.observer_zenith = (

--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -625,7 +625,8 @@ class ModtranRT(RadiativeTransferEngine):
 
         return max_water
 
-    def modtran_water_upperbound_polynomials(self) -> dict:
+    @staticmethod
+    def modtran_water_upperbound_polynomials() -> dict:
         """Polynomials as a function of ground altitude (km) to estimate upperbound of water column vapor (g/cm2).
 
         Returns:
@@ -679,7 +680,8 @@ class ModtranRT(RadiativeTransferEngine):
 
         return polynomials
 
-    def modtran_aot_lowerbound_polynomials(self) -> dict:
+    @staticmethod
+    def modtran_aot_lowerbound_polynomials() -> dict:
         """Polynomials as a function of ground altitude (km) to estimate lowerbound of AOT at 550nm.
 
         Returns:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -332,7 +332,9 @@ def apply_oe(
                 raise ValueError(err_str)
     logging.info("...Data file checks complete")
 
-    lut_params = tmpl.LUTConfig(lut_config_file, emulator_base, no_min_lut_spacing)
+    lut_params = tmpl.LUTConfig(
+        lut_config_file, emulator_base, no_min_lut_spacing, atmosphere_type
+    )
 
     logging.info("Setting up files and directories....")
     paths = tmpl.Pathnames(

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -8,7 +8,7 @@ import logging
 import os
 import subprocess
 from datetime import datetime
-from os.path import abspath, exists, join, split, dirname
+from os.path import abspath, dirname, exists, join, split
 from shutil import copyfile
 from sys import platform
 from typing import List
@@ -26,6 +26,7 @@ from isofit.core.common import (
     resample_spectrum,
 )
 from isofit.data import env
+from isofit.radiative_transfer.engines.modtran import ModtranRT
 from isofit.utils import surface_model
 
 
@@ -328,6 +329,7 @@ class LUTConfig:
         lut_config_file: str = None,
         emulator: str = None,
         no_min_lut_spacing: bool = False,
+        atmosphere_type="ATM_MIDLAT_SUMMER",
     ):
         if lut_config_file is not None:
             with open(lut_config_file, "r") as f:
@@ -379,10 +381,22 @@ class LUTConfig:
         self.aerosol_2_spacing_min = 0
 
         # Units of AOD
-        self.aerosol_0_range = [0.001, 1]
-        self.aerosol_1_range = [0.001, 1]
-        self.aerosol_2_range = [0.001, 1]
-        self.aot_550_range = [0.001, 1]
+        self.aerosol_0_range = [
+            ModtranRT.modtran_aot_lowerbound_polynomials()[atmosphere_type](0),
+            1,
+        ]
+        self.aerosol_1_range = [
+            ModtranRT.modtran_aot_lowerbound_polynomials()[atmosphere_type](0),
+            1,
+        ]
+        self.aerosol_2_range = [
+            ModtranRT.modtran_aot_lowerbound_polynomials()[atmosphere_type](0),
+            1,
+        ]
+        self.aot_550_range = [
+            ModtranRT.modtran_aot_lowerbound_polynomials()[atmosphere_type](0),
+            1,
+        ]
 
         self.aot_550_spacing = 0
         self.aot_550_spacing_min = 0


### PR DESCRIPTION
For discussion. 

We currently hit a Modtran warning that our default minimum LUT bound 0.001 is lower than the Modtran minimum ~0.04. This also resolves the warning and potentially issues with hitting atmospheres outside of emulator training.

LUTs look better with the 6C emulator:
<img width="2826" height="1038" alt="image" src="https://github.com/user-attachments/assets/dde90855-8a19-4369-86c0-2ba214f3b8c5" />

