### PR TITLE
Glint model updates

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -57,6 +57,12 @@ class SurfaceConfig(BaseConfigSection):
         self._surface_T_prior_sigma_degK_type = float
         self.surface_T_prior_sigma_degK = 1.0
 
+        self._sun_glint_prior_sigma_type = float
+        self.sun_glint_prior_sigma = 0.1
+
+        self._sky_glint_prior_sigma_type = float
+        self.sky_glint_prior_sigma = 0.01
+
         self.set_config_options(sub_configdic)
 
     def _check_config_validity(self) -> List[str]:

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -121,6 +121,7 @@ class GlintModelSurface(MultiComponentSurface):
         g_dsf_est = self.init[self.sky_glint_ind]
 
         g_dd_est = glint_est / self.fresnel_rf(geom.observer_zenith)
+        # Updating self.init will set the prior mean (xa) to this value
         self.init[self.sun_glint_ind] = g_dd_est
 
         # SUN_GLINT g_dd

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -82,11 +82,14 @@ class GlintModelSurface(MultiComponentSurface):
         """Given a reflectance estimate and one or more emissive parameters,
         fit a state vector.
         """
-        # Estimate additive glint. Uses multiple options to handle different sensors.
-        # Try SWIR, then NIR
+        # Make sure the glint estimation is not
+        # driving short wavelengths into the negative
+        # causes issues in inversion
         blue_band_1 = np.argmin(np.abs(450 - self.wl))
         blue_band_2 = np.argmin(np.abs(500 - self.wl))
 
+        # Estimate additive glint. Uses multiple options to handle different sensors.
+        # Try SWIR, then NIR
         if np.max(self.wl) >= 2300:
             glint_band_1 = np.argmin(np.abs(2200 - self.wl))
             glint_band_2 = np.argmin(np.abs(2300 - self.wl))

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -32,6 +32,8 @@ class GlintModelSurface(MultiComponentSurface):
     def __init__(self, full_config: Config):
         super().__init__(full_config)
 
+        config = full_config.forward_model.surface
+
         # TODO: Enforce this attribute in the config, not here (this is hidden)
         self.statevec_names.extend(["SUN_GLINT", "SKY_GLINT"])
         self.scale.extend([1.0, 1.0])
@@ -39,10 +41,8 @@ class GlintModelSurface(MultiComponentSurface):
         # Numbers from Marcel Koenig; used for prior mean
         self.init.extend([0.02, 1 / np.pi])
 
-        # Special glint bounds
-        rmin, rmax = -0.05, 2.0
-        self.bounds = [[rmin, rmax] for w in self.wl]
-        self.bounds.extend([[-1, 10], [0, 10]])  # Gege (2021), WASI user manual
+        # Special glint bounds - Gege (2021), WASI user manual
+        self.bounds.extend([[-1, 10], [0, 10]])
         self.n_state = self.n_state + 2
 
         # Useful indexes to track
@@ -54,8 +54,12 @@ class GlintModelSurface(MultiComponentSurface):
         # Change this if you don't want to analytical solve for all the full statevector elements.
         self.analytical_iv_idx = np.arange(len(self.statevec_names))
 
-        self.sun_glint_sigma = (1000000 * np.array(self.scale[self.sun_glint_ind])) ** 2
-        self.sky_glint_sigma = (0.15 * np.array(self.scale[self.sky_glint_ind])) ** 2
+        self.sun_glint_sigma = (
+            config.sun_glint_prior_sigma * np.array(self.scale[self.sun_glint_ind])
+        ) ** 2
+        self.sky_glint_sigma = (
+            config.sky_glint_prior_sigma * np.array(self.scale[self.sky_glint_ind])
+        ) ** 2
 
     def xa(self, x_surface, geom):
         """Mean of prior distribution, calculated at state x."""
@@ -80,17 +84,27 @@ class GlintModelSurface(MultiComponentSurface):
         """
         # Estimate additive glint. Uses multiple options to handle different sensors.
         # Try SWIR, then NIR
-        if np.max(self.wl) >= 2300:
-            glint_band = np.argmin(np.abs(2300 - self.wl))
-        else:
-            glint_band = np.argmin(np.abs(1020 - self.wl))
+        blue_band_1 = np.argmin(np.abs(450 - self.wl))
+        blue_band_2 = np.argmin(np.abs(500 - self.wl))
 
-        glint_est = np.mean(rfl_meas[(glint_band - 2) : glint_band + 2])
+        if np.max(self.wl) >= 2300:
+            glint_band_1 = np.argmin(np.abs(2200 - self.wl))
+            glint_band_2 = np.argmin(np.abs(2300 - self.wl))
+        else:
+            glint_band_1 = np.argmin(np.abs(1000 - self.wl))
+            glint_band_2 = np.argmin(np.abs(1020 - self.wl))
+
+        glint_est = np.min(
+            [
+                np.median(rfl_meas[blue_band_1:blue_band_2]),
+                np.median(rfl_meas[glint_band_1:glint_band_2]),
+            ]
+        )
 
         # hard-coded glint bounds from experience #TODO - get from config
         bounds_glint_est = [
             0,
-            0.2,
+            1.0,
         ]
         glint_est = max(
             bounds_glint_est[0] + eps,
@@ -101,20 +115,16 @@ class GlintModelSurface(MultiComponentSurface):
 
         # Get estimate for g_dd and g_dsf parameters
         # Set sky glint to a static number; use prior mean.
-        g_dsf_est = 1 / np.pi
+        g_dsf_est = self.init[self.sky_glint_ind]
 
-        # Use nadir fresnel coeffs (0.02) and t_down_dir = 0.83, t_down_diff = 0.14 for initialization
-        # Transmission values taken from MODTRAN sim with AERFRAC_2 = 0.5, H2OSTR = 0.5
-        g_dd_est = ((glint_est * 0.97 / 0.02) - 0.14 * g_dsf_est) / 0.83
-        g_dd_est = max(
-            self.bounds[self.sun_glint_ind][0] + eps,
-            min(self.bounds[self.sun_glint_ind][1] - eps, g_dd_est),
-        )
+        g_dd_est = glint_est / self.fresnel_rf(geom.observer_zenith)
+        self.init[self.sun_glint_ind] = g_dd_est
 
         # SUN_GLINT g_dd
         x[self.sun_glint_ind] = g_dd_est
         # SKY_GLINT g_dsf
         x[self.sky_glint_ind] = g_dsf_est
+
         return x
 
     def calc_rfl(self, x_surface, geom):


### PR DESCRIPTION
Three updates included here:

1. Moved sun and sky glint prior sigma into` surface_config.py` 
2. Estimating the glint in `fit_params` from the NIR alone in extremely turbid cases or cases with bottom reflectance could overestimate glint and drive the initial reflectance into the negative/0. This caused issues with the inversion. I added a NIR/SWIR check as well as a check at blue wavelengths to make sure reflectance at short wavelengths isn't negative.
3. I simplified the initial sun glint statevector term. I also dynamically update the prior mean (xa) via `self.init`

Comparison between the two sun glint intensity prior strategies:
<img width="1151" height="652" alt="Screenshot 2025-09-08 at 10 55 42 AM" src="https://github.com/user-attachments/assets/966f2ad1-0323-4c04-b8a6-910566cfb80b" />
