### PR TITLE
Adding uncertainty from unmodeled linearity into the Sb matrix

### DIFF
--- a/isofit/configs/sections/instrument_config.py
+++ b/isofit/configs/sections/instrument_config.py
@@ -42,8 +42,8 @@ class InstrumentUnknowns(BaseConfigSection):
         self._stray_srf_uncertainty_type = float
         self.stray_srf_uncertainty = None
 
-        self._linearity_uncertainty_type = list
-        self.linearity_uncertainty = []
+        self._linearity_file_type = str
+        self.linearity_file = None
 
         self.set_config_options(sub_configdic)
 

--- a/isofit/configs/sections/instrument_config.py
+++ b/isofit/configs/sections/instrument_config.py
@@ -42,6 +42,9 @@ class InstrumentUnknowns(BaseConfigSection):
         self._stray_srf_uncertainty_type = float
         self.stray_srf_uncertainty = None
 
+        self._linearity_uncertainty_type = list
+        self.linearity_uncertainty = []
+
         self.set_config_options(sub_configdic)
 
     def _check_config_validity(self) -> List[str]:

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -87,7 +87,7 @@ class ForwardModel:
             )
 
         # Build combined vectors from surface, RT, and instrument
-        bounds, scale, init, statevec, bvec, bval = ([] for i in range(6))
+        bounds, scale, init, statevec, bvec = ([] for i in range(5))
         for obj_with_statevec in [self.surface, self.RT, self.instrument]:
             bounds.extend([deepcopy(x) for x in obj_with_statevec.bounds])
             scale.extend([deepcopy(x) for x in obj_with_statevec.scale])
@@ -95,7 +95,6 @@ class ForwardModel:
             statevec.extend([deepcopy(x) for x in obj_with_statevec.statevec_names])
 
             bvec.extend([deepcopy(x) for x in obj_with_statevec.bvec])
-            bval.extend([deepcopy(x) for x in obj_with_statevec.bval])
 
         self.bounds = tuple(np.array(bounds).T)
         self.scale = np.array(scale)
@@ -105,8 +104,6 @@ class ForwardModel:
 
         self.bvec = np.array(bvec)
         self.nbvec = len(self.bvec)
-        self.bval = np.array(bval)
-        self.Sb = np.diagflat(np.power(self.bval, 2))
 
         """Set up state vector indices - 
         MUST MATCH ORDER FROM ABOVE ASSIGNMENT
@@ -195,6 +192,15 @@ class ForwardModel:
 
         return block_diag(Sa_surface, Sa_RT, Sa_instrument)
 
+    def Sb(self, x, meas, geom):
+        """Accumulate the uncertainty due to unmodeled variables within
+        respective forward model portions."""
+        Sb_surface = self.surface.Sb()
+        Sb_RT = self.RT.Sb()
+        Sb_instrument = self.instrument.Sb(meas)
+
+        return block_diag(Sb_surface, Sb_RT, Sb_instrument)
+
     def calc_meas(self, x, geom, rfl=[]):
         """Calculate the model observation at instrument wavelengths."""
         # Unpack state vector - Copy to not change x fm-wide
@@ -267,10 +273,11 @@ class ForwardModel:
         else:
             Gamma = 0
 
+        Sb = self.Sb(x, meas, geom)
         Kb = self.Kb(x, geom)
         Sy = self.instrument.Sy(meas, geom)
 
-        return Sy + Kb.dot(self.Sb).dot(Kb.T) + Gamma
+        return Sy + Kb.dot(Sb).dot(Kb.T) + Gamma
 
     def K(self, x, geom):
         """Derivative of observation with respect to state vector. This is

--- a/isofit/core/instrument.py
+++ b/isofit/core/instrument.py
@@ -67,20 +67,22 @@ class Instrument:
         self.statevec_names = config.statevector.get_element_names()
         self.n_state = len(self.statevec_names)
 
-        # config.noise_test = False
+        self.integrations = config.integrations
+
+        # TEMPORARY CODE USED FOR TESTING
+        config.noise_test = False
         if config.noise_test:
             self.model_type = "testing"
 
-            a = 0.0057
+            # a = 0.0057
+            a = 0.007
             b = 0.0
-            c = 0.25
+            c = 0.1
             self.noise_a = np.array([a, b, c])[np.newaxis, :]
 
-            a = 0.2
-            b = 0.3
+            a = 0.3
+            b = 0.2
             self.noise_b = np.array([a, b, c])[np.newaxis, :]
-
-            self.integrations = config.integrations
 
         elif config.SNR is not None:
             self.model_type = "SNR"
@@ -96,8 +98,6 @@ class Instrument:
                 for col in (1, 2, 3)
             ]
             self.noise = np.array([[p_a(w), p_b(w), p_c(w)] for w in self.wl_init])
-
-            self.integrations = config.integrations
 
         elif config.pushbroom_noise_file is not None:
             self.model_type = "pushbroom"
@@ -130,44 +130,30 @@ class Instrument:
         # We track several unretrieved free variables, that are specified
         # in a fixed order (always start with relative radiometric
         # calibration)
-        self.bvec = ["Cal_Relative_%04i" % int(w) for w in self.wl_init] + [
-            "Cal_Spectral",
-            "Cal_Stray_SRF",
-        ]
-        self.bval = np.zeros(self.n_chan + 2)
+        self.unknowns = config.unknowns
+        self.bval = np.zeros(self.n_chan)
+        self.bvec = []
 
-        if config.unknowns is not None:
-            # First we take care of radiometric uncertainties, which add
-            # in quadrature.  We sum their squared values.  Systematic
-            # radiometric uncertainties account for differences in sampling
-            # and radiative transfer that manifest predictably as a function
-            # of wavelength.
-            if config.unknowns.channelized_radiometric_uncertainty_file is not None:
-                f = config.unknowns.channelized_radiometric_uncertainty_file
-                u = np.loadtxt(f, comments="#")
-                if len(u.shape) > 0 and u.shape[1] > 1:
-                    u = u[:, 1]
-                self.bval[: self.n_chan] = self.bval[: self.n_chan] + pow(u, 2)
+        # self.unknowns should always exist via configs
+        if (
+            (self.unknowns.channelized_radiometric_uncertainty_file is not None)
+            or (self.unknowns.uncorrelated_radiometric_uncertainty is not None)
+            or (len(self.unknowns.linearity_uncertainty))
+        ):
+            self.bvec += ["Cal_Relative_%04i" % int(w) for w in self.wl_init]
 
-            # Uncorrelated radiometric uncertainties are consistent and
-            # independent in all channels.
-            if config.unknowns.uncorrelated_radiometric_uncertainty is not None:
-                u = config.unknowns.uncorrelated_radiometric_uncertainty
-                self.bval[: self.n_chan] = self.bval[: self.n_chan] + pow(
-                    np.ones(self.n_chan) * u, 2
-                )
+        # Now handle spectral calibration uncertainties
+        if self.unknowns.wavelength_calibration_uncertainty is not None:
+            self.bvec += ["Cal_Spectral"]
+            self.cal_spectral_idx = len(self.bval)
+            self.bval = np.hstack(
+                [self.bval, self.unknowns.wavelength_calibration_uncertainty]
+            )
 
-            # Radiometric uncertainties combine via Root Sum Square...
-            # Be careful to avoid square roots of zero!
-            small = np.ones(self.n_chan) * eps
-            self.bval[: self.n_chan] = np.maximum(self.bval[: self.n_chan], small)
-            self.bval[: self.n_chan] = np.sqrt(self.bval[: self.n_chan])
-
-            # Now handle spectral calibration uncertainties
-            if config.unknowns.wavelength_calibration_uncertainty is not None:
-                self.bval[-2] = config.unknowns.wavelength_calibration_uncertainty
-            if config.unknowns.stray_srf_uncertainty is not None:
-                self.bval[-1] = config.unknowns.stray_srf_uncertainty
+        if self.unknowns.stray_srf_uncertainty is not None:
+            self.bvec += ["Cal_Stray_SRF"]
+            self.cal_stray_idx = len(self.bval) + 1
+            self.bval = np.hstack([self.bval, self.unknowns.stray_srf_uncertainty])
 
         # Determine whether the calibration is fixed.  If it is fixed,
         # and the wavelengths of radiative transfer modeling and instrument
@@ -193,6 +179,47 @@ class Instrument:
             return np.zeros((0, 0), dtype=float)
         return np.diagflat(np.power(self.prior_sigma, 2))
 
+    def Sb(self, meas):
+        """Uncertainty due to unmodeled variables."""
+        # First we take care of radiometric uncertainties, which add
+        # in quadrature.  We sum their squared values.  Systematic
+        # radiometric uncertainties account for differences in sampling
+        # and radiative transfer that manifest predictably as a function
+        # of wavelength.
+        if self.unknowns.channelized_radiometric_uncertainty_file is not None:
+            f = self.unknowns.channelized_radiometric_uncertainty_file
+            u = np.loadtxt(f, comments="#")
+            if len(u.shape) > 0 and u.shape[1] > 1:
+                u = u[:, 1]
+            self.bval[: self.n_chan] = self.bval[: self.n_chan] + pow(u, 2)
+
+        # Uncorrelated radiometric uncertainties are consistent and
+        # independent in all channels.
+        if self.unknowns.uncorrelated_radiometric_uncertainty is not None:
+            u = self.unknowns.uncorrelated_radiometric_uncertainty
+            self.bval[: self.n_chan] = self.bval[: self.n_chan] + pow(
+                np.ones(self.n_chan) * u, 2
+            )
+
+        # Unknown linearity uncertainty
+        if len(self.unknowns.linearity_uncertainty):
+            a, b = self.unknowns.linearity_uncertainty
+
+            # Treat it as a parametric noise
+            nedl = a * (1 / np.exp(b * meas))
+            nedl = nedl / np.sqrt(self.integrations)
+
+            # self.bval[: self.n_chan] += np.power(nedl, 2)
+            self.bval[: self.n_chan] += nedl
+
+        # Radiometric uncertainties combine via Root Sum Square...
+        # Be careful to avoid square roots of zero!
+        small = np.ones(self.n_chan) * eps
+        self.bval[: self.n_chan] = np.maximum(self.bval[: self.n_chan], small)
+        self.bval[: self.n_chan] = np.sqrt(self.bval[: self.n_chan])
+
+        return np.diagflat(np.power(self.bval, 2))
+
     def Sy(self, meas, geom):
         """Calculate measuremment error covariance.  Kelvin Man Yiu Leung and
             Jayanth Jagalur Mohan (MIT) developed the noise clipping strategy.
@@ -212,20 +239,22 @@ class Instrument:
             nedl[bad] = minimum_noise
             return np.diagflat(np.power(nedl, 2))
 
-        # 2 This should be the term to use to account for the unaccounted for nonlinearity
+        # TEMPORARY CODE USED FOR TESTING
         elif self.model_type == "testing":
-            noise_plus_meas = self.noise_a[:, 1] + meas
+            # noise_plus_meas = self.noise_a[:, 1] + meas
 
-            nedl_a = np.abs(
-                self.noise_a[:, 0] * np.sqrt(noise_plus_meas) + self.noise_a[:, 2]
-            )
+            # nedl_a = np.abs(
+            #     self.noise_a[:, 0] * np.sqrt(noise_plus_meas) + self.noise_a[:, 2]
+            # )
 
             noise_plus_meas = self.noise_b[:, 1] + meas
-            nedl_b = (
-                self.noise_b[:, 0] * (1 / np.exp(np.sqrt(noise_plus_meas)))
+            nedl = (
+                # self.noise_b[:, 0] * (1 / np.exp(np.sqrt(noise_plus_meas)))
+                self.noise_b[:, 0]
+                * (1 / np.sqrt(noise_plus_meas))
             ) + self.noise_b[:, 2]
 
-            nedl = np.max([nedl_a, nedl_b], axis=0)
+            # nedl = np.max([nedl_a, nedl_b], axis=0)
             nedl = nedl / np.sqrt(self.integrations)
 
             return np.diagflat(np.power(nedl, 2))
@@ -278,19 +307,24 @@ class Instrument:
 
         # Uncertainty due to radiometric calibration
         meas = self.sample(x_instrument, wl_hi, rdn_hi)
-        dmeas_dinstrument = np.hstack((np.diagflat(meas), np.zeros((self.n_chan, 2))))
+        dmeas_dinstrument = np.hstack(
+            (
+                np.diagflat(meas),
+                np.zeros((self.n_chan, len(self.bvec) - len(self.wl_init))),
+            )
+        )
 
         # Uncertainty due to spectral calibration
-        if self.bval[-2] > 1e-6:
-            dmeas_dinstrument[:, -2] = self.sample(
+        if self.unknowns.wavelength_calibration_uncertainty is not None:
+            dmeas_dinstrument[:, self.cal_spectral_idx] = self.sample(
                 x_instrument, wl_hi, np.hstack((np.diff(rdn_hi), np.array([0])))
             )
 
         # Uncertainty due to spectral stray light
-        if self.bval[-1] > 1e-6:
+        if self.unknowns.stray_srf_uncertainty is not None:
             ssrf = spectral_response_function(np.arange(-10, 11), 0, 4)
             blur = convolve(meas, ssrf, mode="same")
-            dmeas_dinstrument[:, -1] = blur - meas
+            dmeas_dinstrument[:, self.cal_stray_idx] = blur - meas
 
         return dmeas_dinstrument
 

--- a/isofit/core/instrument.py
+++ b/isofit/core/instrument.py
@@ -69,6 +69,21 @@ class Instrument:
 
         self.integrations = config.integrations
 
+
+        self.linearity_type = None
+        if config.unknowns.linearity_file is not None:
+            linearity_mat = loadmat(config.unknowns.linearity_file)
+            input_dn = linearity_mat["input_dn"].squeeze()
+            dn_ratio = linearity_mat["dn_ratio"].squeeze()
+            rcc_in = linearity_mat["rcc"].squeeze()
+            rcc_wl = linearity_mat["rcc_wl"].squeeze()
+            rcc_interp = interp1d(rcc_wl, rcc_in, fill_value="extrapolate")
+            self.linearity_rcc = rcc_interp(self.wl_init)
+            self.linearity_interp = interp1d(input_dn, dn_ratio, fill_value="extrapolate")
+            self.linearity_inflation = linearity_mat.get("linearity_inflation", [1.0]).squeeze()
+            self.linearity_type = linearity_mat.get("embedding_location", "Sy")
+
+
         # TEMPORARY CODE USED FOR TESTING
         config.noise_test = False
         if config.noise_test:
@@ -198,23 +213,14 @@ class Instrument:
                     np.ones(self.n_chan) * u, 2
                 )
 
-            # Unknown linearity uncertainty
-            if len(self.unknowns.linearity_uncertainty):
-                a, b, c = self.unknowns.linearity_uncertainty
+            # Impose linearity inside Sb
+            if self.linearity_type == "Sb":
+                # Uncertainty due to imperfect knowledge of linearity correction
+                dn_est = meas / self.linearity_rcc
+                nl_est = self.linearity_interp(dn_est)
 
-                # Treat it as a parametric noise
-                noise_times_meas = np.maximum(b * meas, eps)
+                bval[: self.n_chan] += np.power(meas * (nl_est - 1) * self.linearity_inflation, 2)
 
-                # Testing three forms for the noise
-                # 1 / x
-                # nedl = (1 / (noise_times_meas + a)) + c
-                # Exponential
-                # nedl = a * (1 / np.exp(noise_times_meas)) + c
-                # Linear
-                nedl = np.maximum(0, a - noise_times_meas) + c
-
-                nedl = nedl / np.sqrt(self.integrations)
-                bval[: self.n_chan] += np.power(nedl, 2)
 
         # Radiometric uncertainties combine via Root Sum Square...
         # Be careful to avoid square roots of zero!
@@ -231,6 +237,8 @@ class Instrument:
         Input: meas, the instrument measurement
         Returns: Sy, the measurement error covariance due to instrument noise
         """
+
+        Sy = None
         if self.model_type == "SNR":
             nedl = (1.0 / self.snr) * meas
             minimum_noise = np.sqrt(1e-7)
@@ -241,7 +249,7 @@ class Instrument:
                     " to avoid /0."
                 )
             nedl[bad] = minimum_noise
-            return np.diagflat(np.power(nedl, 2))
+            Sy = np.diagflat(np.power(nedl, 2))
 
         # TEMPORARY CODE USED FOR TESTING
         elif self.model_type == "testing":
@@ -261,7 +269,7 @@ class Instrument:
             # nedl = np.max([nedl_a, nedl_b], axis=0)
             nedl = nedl / np.sqrt(self.integrations)
 
-            return np.diagflat(np.power(nedl, 2))
+            Sy = np.diagflat(np.power(nedl, 2))
 
         elif self.model_type == "parametric":
             noise_plus_meas = self.noise[:, 1] + meas
@@ -275,14 +283,27 @@ class Instrument:
                 self.noise[:, 0] * np.sqrt(noise_plus_meas) + self.noise[:, 2]
             )
             nedl = nedl / np.sqrt(self.integrations)
-            return np.diagflat(np.power(nedl, 2))
+            Sy = np.diagflat(np.power(nedl, 2))
 
         elif self.model_type == "pushbroom":
             C = np.squeeze(self.covs.mean(axis=0))
-            return C / np.sqrt(self.integrations)
+            Sy = C / np.sqrt(self.integrations)
 
         elif self.model_type == "NEDT":
-            return np.diagflat(np.power(self.noise_NESR, 2))
+            Sy = np.diagflat(np.power(self.noise_NESR, 2))
+
+
+        if self.linearity_type:
+            # Uncertainty due to imperfect knowledge of linearity correction
+            dn_est = meas / self.linearity_rcc
+            nl_est = self.linearity_interp(dn_est)
+
+            nl_drdn = np.abs(meas * (nl_est - 1) * self.linearity_inflation)
+
+            np.fill_diagonal(Sy, Sy.diagonal() + nl_drdn)
+
+
+        return Sy
 
     def dmeas_dinstrument(self, x_instrument, wl_hi, rdn_hi):
         """Jacobian of measurement with respect to the instrument

--- a/isofit/core/instrument.py
+++ b/isofit/core/instrument.py
@@ -84,22 +84,7 @@ class Instrument:
             self.linearity_type = linearity_mat.get("embedding_location", "Sy")
 
 
-        # TEMPORARY CODE USED FOR TESTING
-        config.noise_test = False
-        if config.noise_test:
-            self.model_type = "testing"
-
-            # a = 0.0057
-            a = 0.007
-            b = 0.0
-            c = 0.1
-            self.noise_a = np.array([a, b, c])[np.newaxis, :]
-
-            a = 0.3
-            b = 0.2
-            self.noise_b = np.array([a, b, c])[np.newaxis, :]
-
-        elif config.SNR is not None:
+        if config.SNR is not None:
             self.model_type = "SNR"
             self.snr = config.SNR
 

--- a/isofit/core/instrument.py
+++ b/isofit/core/instrument.py
@@ -200,13 +200,20 @@ class Instrument:
 
             # Unknown linearity uncertainty
             if len(self.unknowns.linearity_uncertainty):
-                a, b = self.unknowns.linearity_uncertainty
+                a, b, c = self.unknowns.linearity_uncertainty
 
                 # Treat it as a parametric noise
                 noise_times_meas = np.maximum(b * meas, eps)
-                nedl = a * (1 / np.exp(noise_times_meas))
-                nedl = nedl / np.sqrt(self.integrations)
 
+                # Testing three forms for the noise
+                # 1 / x
+                # nedl = (1 / (noise_times_meas + a)) + c
+                # Exponential
+                # nedl = a * (1 / np.exp(noise_times_meas)) + c
+                # Linear
+                nedl = np.maximum(0, a - noise_times_meas) + c
+
+                nedl = nedl / np.sqrt(self.integrations)
                 bval[: self.n_chan] += np.power(nedl, 2)
 
         # Radiometric uncertainties combine via Root Sum Square...

--- a/isofit/core/instrument.py
+++ b/isofit/core/instrument.py
@@ -209,8 +209,7 @@ class Instrument:
             nedl = a * (1 / np.exp(b * meas))
             nedl = nedl / np.sqrt(self.integrations)
 
-            # self.bval[: self.n_chan] += np.power(nedl, 2)
-            self.bval[: self.n_chan] += nedl
+            self.bval[: self.n_chan] += np.power(nedl, 2)
 
         # Radiometric uncertainties combine via Root Sum Square...
         # Be careful to avoid square roots of zero!

--- a/isofit/core/instrument.py
+++ b/isofit/core/instrument.py
@@ -132,28 +132,23 @@ class Instrument:
         # calibration)
         self.unknowns = config.unknowns
         self.bval = np.zeros(self.n_chan)
-        self.bvec = []
+        self.bvec = ["Cal_Relative_%04i" % int(w) for w in self.wl_init]
 
         # self.unknowns should always exist via configs
-        if (
-            (self.unknowns.channelized_radiometric_uncertainty_file is not None)
-            or (self.unknowns.uncorrelated_radiometric_uncertainty is not None)
-            or (len(self.unknowns.linearity_uncertainty))
-        ):
-            self.bvec += ["Cal_Relative_%04i" % int(w) for w in self.wl_init]
+        # but may not exist for manual configs
+        if self.unknowns:
+            # Now handle spectral calibration uncertainties
+            if self.unknowns.wavelength_calibration_uncertainty is not None:
+                self.bvec += ["Cal_Spectral"]
+                self.cal_spectral_idx = len(self.bval)
+                self.bval = np.hstack(
+                    [self.bval, self.unknowns.wavelength_calibration_uncertainty]
+                )
 
-        # Now handle spectral calibration uncertainties
-        if self.unknowns.wavelength_calibration_uncertainty is not None:
-            self.bvec += ["Cal_Spectral"]
-            self.cal_spectral_idx = len(self.bval)
-            self.bval = np.hstack(
-                [self.bval, self.unknowns.wavelength_calibration_uncertainty]
-            )
-
-        if self.unknowns.stray_srf_uncertainty is not None:
-            self.bvec += ["Cal_Stray_SRF"]
-            self.cal_stray_idx = len(self.bval) + 1
-            self.bval = np.hstack([self.bval, self.unknowns.stray_srf_uncertainty])
+            if self.unknowns.stray_srf_uncertainty is not None:
+                self.bvec += ["Cal_Stray_SRF"]
+                self.cal_stray_idx = len(self.bval) + 1
+                self.bval = np.hstack([self.bval, self.unknowns.stray_srf_uncertainty])
 
         # Determine whether the calibration is fixed.  If it is fixed,
         # and the wavelengths of radiative transfer modeling and instrument
@@ -187,29 +182,32 @@ class Instrument:
         # radiometric uncertainties account for differences in sampling
         # and radiative transfer that manifest predictably as a function
         # of wavelength.
-        if self.unknowns.channelized_radiometric_uncertainty_file is not None:
-            f = self.unknowns.channelized_radiometric_uncertainty_file
-            u = np.loadtxt(f, comments="#")
-            if len(u.shape) > 0 and u.shape[1] > 1:
-                u = u[:, 1]
-            bval[: self.n_chan] = bval[: self.n_chan] + pow(u, 2)
+        if self.unknowns:
+            if self.unknowns.channelized_radiometric_uncertainty_file is not None:
+                f = self.unknowns.channelized_radiometric_uncertainty_file
+                u = np.loadtxt(f, comments="#")
+                if len(u.shape) > 0 and u.shape[1] > 1:
+                    u = u[:, 1]
+                bval[: self.n_chan] = bval[: self.n_chan] + pow(u, 2)
 
-        # Uncorrelated radiometric uncertainties are consistent and
-        # independent in all channels.
-        if self.unknowns.uncorrelated_radiometric_uncertainty is not None:
-            u = self.unknowns.uncorrelated_radiometric_uncertainty
-            bval[: self.n_chan] = bval[: self.n_chan] + pow(np.ones(self.n_chan) * u, 2)
+            # Uncorrelated radiometric uncertainties are consistent and
+            # independent in all channels.
+            if self.unknowns.uncorrelated_radiometric_uncertainty:
+                u = self.unknowns.uncorrelated_radiometric_uncertainty
+                bval[: self.n_chan] = bval[: self.n_chan] + pow(
+                    np.ones(self.n_chan) * u, 2
+                )
 
-        # Unknown linearity uncertainty
-        if len(self.unknowns.linearity_uncertainty):
-            a, b = self.unknowns.linearity_uncertainty
+            # Unknown linearity uncertainty
+            if len(self.unknowns.linearity_uncertainty):
+                a, b = self.unknowns.linearity_uncertainty
 
-            # Treat it as a parametric noise
-            noise_times_meas = np.maximum(b * meas, eps)
-            nedl = a * (1 / np.exp(noise_times_meas))
-            nedl = nedl / np.sqrt(self.integrations)
+                # Treat it as a parametric noise
+                noise_times_meas = np.maximum(b * meas, eps)
+                nedl = a * (1 / np.exp(noise_times_meas))
+                nedl = nedl / np.sqrt(self.integrations)
 
-            bval[: self.n_chan] += np.power(nedl, 2)
+                bval[: self.n_chan] += np.power(nedl, 2)
 
         # Radiometric uncertainties combine via Root Sum Square...
         # Be careful to avoid square roots of zero!
@@ -314,16 +312,17 @@ class Instrument:
         )
 
         # Uncertainty due to spectral calibration
-        if self.unknowns.wavelength_calibration_uncertainty is not None:
-            dmeas_dinstrument[:, self.cal_spectral_idx] = self.sample(
-                x_instrument, wl_hi, np.hstack((np.diff(rdn_hi), np.array([0])))
-            )
+        if self.unknowns:
+            if self.unknowns.wavelength_calibration_uncertainty is not None:
+                dmeas_dinstrument[:, self.cal_spectral_idx] = self.sample(
+                    x_instrument, wl_hi, np.hstack((np.diff(rdn_hi), np.array([0])))
+                )
 
-        # Uncertainty due to spectral stray light
-        if self.unknowns.stray_srf_uncertainty is not None:
-            ssrf = spectral_response_function(np.arange(-10, 11), 0, 4)
-            blur = convolve(meas, ssrf, mode="same")
-            dmeas_dinstrument[:, self.cal_stray_idx] = blur - meas
+            # Uncertainty due to spectral stray light
+            if self.unknowns.stray_srf_uncertainty is not None:
+                ssrf = spectral_response_function(np.arange(-10, 11), 0, 4)
+                blur = convolve(meas, ssrf, mode="same")
+                dmeas_dinstrument[:, self.cal_stray_idx] = blur - meas
 
         return dmeas_dinstrument
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -146,6 +146,10 @@ class RadiativeTransfer:
         """Pull the priors from each of the individual RTs."""
         return np.diagflat(np.power(np.array(self.prior_sigma), 2))
 
+    def Sb(self):
+        """Uncertainty due to unmodeled variables."""
+        return np.diagflat(np.power(self.bval, 2))
+
     def get_shared_rtm_quantities(self, x_RT, geom):
         """Return only the set of RTM quantities (transup, sphalb, etc.) that are contained
         in all RT engines.

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -86,6 +86,10 @@ class Surface:
 
         return np.zeros((0, 0), dtype=float)
 
+    def Sb(self):
+        """Uncertainty due to unmodeled variables."""
+        return np.diagflat(np.power(self.bval, 2))
+
     def fit_params(self, rfl_meas, geom, *args):
         """Given a directional reflectance estimate and one or more emissive
         parameters, fit a state vector."""

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -78,6 +78,10 @@ class Surface:
 
         return np.zeros((0, 0), dtype=float)
 
+    def Sb(self):
+        """Uncertainty due to unmodeled variables."""
+        return np.diagflat(np.power(self.bval, 2))
+
     def fit_params(self, rfl_meas, geom, *args):
         """Given a directional reflectance estimate and one or more emissive
         parameters, fit a state vector."""

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -97,6 +97,10 @@ class LUTSurface(Surface):
 
         return Cov
 
+    def Sb(self):
+        """Uncertainty due to unmodeled variables."""
+        return np.diagflat(np.power(self.bval, 2))
+
     def fit_params(self, rfl_meas, geom, *args):
         """Given a reflectance estimate, fit a state vector."""
 

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -100,6 +100,10 @@ class LUTSurface(Surface):
 
         return Cov
 
+    def Sb(self):
+        """Uncertainty due to unmodeled variables."""
+        return np.diagflat(np.power(self.bval, 2))
+
     def fit_params(self, rfl_meas, geom, *args):
         """Given a reflectance estimate, fit a state vector."""
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -774,7 +774,7 @@ def apply_oe(
 @click.option("--atmosphere_type", default="ATM_MIDLAT_SUMMER")
 @click.option("--channelized_uncertainty_path")
 @click.option(
-    "--linearity_uncertainty_coeffs", "-lcf", type=float, nargs=2, default=[0, 0]
+    "--linearity_uncertainty_coeffs", "-lcf", type=float, multiple=True, default=[]
 )
 @click.option("--model_discrepancy_path")
 @click.option("--lut_config_file")

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -82,6 +82,7 @@ def apply_oe(
     rdn_factors_path=None,
     atmosphere_type="ATM_MIDLAT_SUMMER",
     channelized_uncertainty_path=None,
+    linearity_uncertainty_coeffs=[],
     model_discrepancy_path=None,
     lut_config_file=None,
     multiple_restarts=False,
@@ -155,6 +156,8 @@ def apply_oe(
         radiative transfer models.
     channelized_uncertainty_path : str, default=None
         Path to a channelized uncertainty file
+    linearity_uncertainty_coeffs:  str, default=[]
+        Coefficients for parametric model for uncertainty in measurement linearity
     model_discrepancy_path : str, default=None
         Modifies S_eps in the OE formalism as the Gamma additive term, as:
         S_eps = Sy + Kb.dot(self.Sb).dot(Kb.T) + Gamma
@@ -672,6 +675,7 @@ def apply_oe(
                 surface_category=surface_category,
                 emulator_base=emulator_base,
                 uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
+                linearity_uncertainty_coeffs=linearity_uncertainty_coeffs,
                 prebuilt_lut_path=prebuilt_lut,
                 inversion_windows=INVERSION_WINDOWS,
                 multipart_transmittance=multipart_transmittance,
@@ -779,6 +783,7 @@ def apply_oe(
             surface_category=surface_category,
             emulator_base=emulator_base,
             uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
+            linearity_uncertainty_coeffs=linearity_uncertainty_coeffs,
             multiple_restarts=multiple_restarts,
             segmentation_size=segmentation_size,
             pressure_elevation=pressure_elevation,
@@ -875,6 +880,9 @@ def apply_oe(
 @click.option("--rdn_factors_path")
 @click.option("--atmosphere_type", default="ATM_MIDLAT_SUMMER")
 @click.option("--channelized_uncertainty_path")
+@click.option(
+    "--linearity_uncertainty_coeffs", "-lcf", type=float, nargs=2, default=[0, 0]
+)
 @click.option("--model_discrepancy_path")
 @click.option("--lut_config_file")
 @click.option("--multiple_restarts", is_flag=True, default=False)

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -72,6 +72,7 @@ def apply_oe(
     rdn_factors_path=None,
     atmosphere_type="ATM_MIDLAT_SUMMER",
     channelized_uncertainty_path=None,
+    linearity_uncertainty_coeffs=[],
     model_discrepancy_path=None,
     lut_config_file=None,
     multiple_restarts=False,
@@ -144,6 +145,8 @@ def apply_oe(
         radiative transfer models.
     channelized_uncertainty_path : str, default=None
         Path to a channelized uncertainty file
+    linearity_uncertainty_coeffs:  str, default=[]
+        Coefficients for parametric model for uncertainty in measurement linearity
     model_discrepancy_path : str, default=None
         Modifies S_eps in the OE formalism as the Gamma additive term, as:
         S_eps = Sy + Kb.dot(self.Sb).dot(Kb.T) + Gamma
@@ -578,6 +581,7 @@ def apply_oe(
                 surface_category=surface_category,
                 emulator_base=emulator_base,
                 uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
+                linearity_uncertainty_coeffs=linearity_uncertainty_coeffs,
                 prebuilt_lut_path=prebuilt_lut,
                 inversion_windows=INVERSION_WINDOWS,
                 multipart_transmittance=multipart_transmittance,
@@ -679,6 +683,7 @@ def apply_oe(
             surface_category=surface_category,
             emulator_base=emulator_base,
             uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
+            linearity_uncertainty_coeffs=linearity_uncertainty_coeffs,
             multiple_restarts=multiple_restarts,
             segmentation_size=segmentation_size,
             pressure_elevation=pressure_elevation,
@@ -768,6 +773,9 @@ def apply_oe(
 @click.option("--rdn_factors_path")
 @click.option("--atmosphere_type", default="ATM_MIDLAT_SUMMER")
 @click.option("--channelized_uncertainty_path")
+@click.option(
+    "--linearity_uncertainty_coeffs", "-lcf", type=float, nargs=2, default=[0, 0]
+)
 @click.option("--model_discrepancy_path")
 @click.option("--lut_config_file")
 @click.option("--multiple_restarts", is_flag=True, default=False)

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -881,7 +881,7 @@ def apply_oe(
 @click.option("--atmosphere_type", default="ATM_MIDLAT_SUMMER")
 @click.option("--channelized_uncertainty_path")
 @click.option(
-    "--linearity_uncertainty_coeffs", "-lcf", type=float, nargs=2, default=[0, 0]
+    "--linearity_uncertainty_coeffs", "-lcf", type=float, multiple=True, default=[]
 )
 @click.option("--model_discrepancy_path")
 @click.option("--lut_config_file")

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -72,7 +72,7 @@ def apply_oe(
     rdn_factors_path=None,
     atmosphere_type="ATM_MIDLAT_SUMMER",
     channelized_uncertainty_path=None,
-    linearity_uncertainty_coeffs=[],
+    linearity_file=None,
     model_discrepancy_path=None,
     lut_config_file=None,
     multiple_restarts=False,
@@ -145,8 +145,8 @@ def apply_oe(
         radiative transfer models.
     channelized_uncertainty_path : str, default=None
         Path to a channelized uncertainty file
-    linearity_uncertainty_coeffs:  str, default=[]
-        Coefficients for parametric model for uncertainty in measurement linearity
+    linearity_file:  str, default=None
+        Path to a linearity .mat file to augment S matrix with linearity uncertainty
     model_discrepancy_path : str, default=None
         Modifies S_eps in the OE formalism as the Gamma additive term, as:
         S_eps = Sy + Kb.dot(self.Sb).dot(Kb.T) + Gamma
@@ -581,7 +581,7 @@ def apply_oe(
                 surface_category=surface_category,
                 emulator_base=emulator_base,
                 uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
-                linearity_uncertainty_coeffs=linearity_uncertainty_coeffs,
+                linearity_file=linearity_file,
                 prebuilt_lut_path=prebuilt_lut,
                 inversion_windows=INVERSION_WINDOWS,
                 multipart_transmittance=multipart_transmittance,
@@ -683,7 +683,7 @@ def apply_oe(
             surface_category=surface_category,
             emulator_base=emulator_base,
             uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
-            linearity_uncertainty_coeffs=linearity_uncertainty_coeffs,
+            linearity_file=linearity_file,
             multiple_restarts=multiple_restarts,
             segmentation_size=segmentation_size,
             pressure_elevation=pressure_elevation,
@@ -773,9 +773,7 @@ def apply_oe(
 @click.option("--rdn_factors_path")
 @click.option("--atmosphere_type", default="ATM_MIDLAT_SUMMER")
 @click.option("--channelized_uncertainty_path")
-@click.option(
-    "--linearity_uncertainty_coeffs", "-lcf", type=float, multiple=True, default=[]
-)
+@click.option("--linearity_file", "-lf", type=str, default=None)
 @click.option("--model_discrepancy_path")
 @click.option("--lut_config_file")
 @click.option("--multiple_restarts", is_flag=True, default=False)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -641,6 +641,7 @@ def build_presolve_config(
     surface_category="multicomponent_surface",
     emulator_base: str = None,
     uncorrelated_radiometric_uncertainty: float = 0.0,
+    linearity_uncertainty_coeffs: list = [],
     segmentation_size: int = 400,
     debug: bool = False,
     inversion_windows=[[350.0, 1360.0], [1410, 1800.0], [1970.0, 2500.0]],
@@ -657,6 +658,7 @@ def build_presolve_config(
         surface_category: type of surface to use
         emulator_base: the basename of the emulator, if used
         uncorrelated_radiometric_uncertainty: uncorrelated radiometric uncertainty parameter for isofit
+        linearity_uncertainty_coeffs:         Coefficients for parametric model for uncertainty in measurement linearity
         segmentation_size: image segmentation size if empirical line is used
         debug: flag to enable debug_mode in the config.implementation
         prebuilt_lut_path: lut path to use; if none, presolve config will create a new file
@@ -754,7 +756,8 @@ def build_presolve_config(
                 "wavelength_file": paths.wavelength_path,
                 "integrations": spectra_per_inversion,
                 "unknowns": {
-                    "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty
+                    "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty,
+                    "linearity_uncertainty": linearity_uncertainty_coeffs,
                 },
             },
             "surface": make_surface_config(
@@ -830,6 +833,7 @@ def build_main_config(
     surface_category="multicomponent_surface",
     emulator_base: str = None,
     uncorrelated_radiometric_uncertainty: float = 0.0,
+    linearity_uncertainty_coeffs: list = [],
     multiple_restarts: bool = False,
     segmentation_size=400,
     pressure_elevation: bool = False,
@@ -860,6 +864,7 @@ def build_main_config(
         surface_category:                     type of surface to use
         emulator_base:                        the basename of the emulator, if used
         uncorrelated_radiometric_uncertainty: uncorrelated radiometric uncertainty parameter for isofit
+        linearity_uncertainty_coeffs:         Coefficients for parametric model for uncertainty in measurement linearity
         multiple_restarts:                    if true, use multiple restarts
         segmentation_size:                    image segmentation size if empirical line is used
         pressure_elevation:                   if true, retrieve pressure elevation
@@ -1072,7 +1077,8 @@ def build_main_config(
                 "wavelength_file": paths.wavelength_path,
                 "integrations": spectra_per_inversion,
                 "unknowns": {
-                    "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty
+                    "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty,
+                    "linearity_uncertainty": linearity_uncertainty_coeffs,
                 },
             },
             "surface": make_surface_config(
@@ -1163,6 +1169,7 @@ def build_main_config(
         isofit_config_modtran["forward_model"]["instrument"][
             "parametric_noise_file"
         ] = paths.noise_path
+
     else:
         isofit_config_modtran["forward_model"]["instrument"]["SNR"] = 500
 

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -529,7 +529,7 @@ def build_presolve_config(
     surface_category="multicomponent_surface",
     emulator_base: str = None,
     uncorrelated_radiometric_uncertainty: float = 0.0,
-    linearity_uncertainty_coeffs: list = [],
+    linearity_file: str = None,
     segmentation_size: int = 400,
     debug: bool = False,
     inversion_windows=[[350.0, 1360.0], [1410, 1800.0], [1970.0, 2500.0]],
@@ -546,7 +546,7 @@ def build_presolve_config(
         surface_category: type of surface to use
         emulator_base: the basename of the emulator, if used
         uncorrelated_radiometric_uncertainty: uncorrelated radiometric uncertainty parameter for isofit
-        linearity_uncertainty_coeffs:         Coefficients for parametric model for uncertainty in measurement linearity
+        linearity_file: Path to a linearity .mat file to augment S matrix with linearity uncertainty
         segmentation_size: image segmentation size if empirical line is used
         debug: flag to enable debug_mode in the config.implementation
         prebuilt_lut_path: lut path to use; if none, presolve config will create a new file
@@ -645,7 +645,7 @@ def build_presolve_config(
                 "integrations": spectra_per_inversion,
                 "unknowns": {
                     "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty,
-                    "linearity_uncertainty": linearity_uncertainty_coeffs,
+                    "linearity_file": linearity_file,
                 },
             },
             "surface": {
@@ -722,7 +722,7 @@ def build_main_config(
     surface_category="multicomponent_surface",
     emulator_base: str = None,
     uncorrelated_radiometric_uncertainty: float = 0.0,
-    linearity_uncertainty_coeffs: list = [],
+    linearity_file: str = None,
     multiple_restarts: bool = False,
     segmentation_size=400,
     pressure_elevation: bool = False,
@@ -752,7 +752,7 @@ def build_main_config(
         surface_category:                     type of surface to use
         emulator_base:                        the basename of the emulator, if used
         uncorrelated_radiometric_uncertainty: uncorrelated radiometric uncertainty parameter for isofit
-        linearity_uncertainty_coeffs:         Coefficients for parametric model for uncertainty in measurement linearity
+        linearity_file:                       Path to a linearity .mat file to augment S matrix with linearity uncertainty
         multiple_restarts:                    if true, use multiple restarts
         segmentation_size:                    image segmentation size if empirical line is used
         pressure_elevation:                   if true, retrieve pressure elevation
@@ -961,7 +961,7 @@ def build_main_config(
                 "integrations": spectra_per_inversion,
                 "unknowns": {
                     "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty,
-                    "linearity_uncertainty": linearity_uncertainty_coeffs,
+                    "linearity_file": linearity_file,
                 },
             },
             "surface": {

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -529,6 +529,7 @@ def build_presolve_config(
     surface_category="multicomponent_surface",
     emulator_base: str = None,
     uncorrelated_radiometric_uncertainty: float = 0.0,
+    linearity_uncertainty_coeffs: list = [],
     segmentation_size: int = 400,
     debug: bool = False,
     inversion_windows=[[350.0, 1360.0], [1410, 1800.0], [1970.0, 2500.0]],
@@ -545,6 +546,7 @@ def build_presolve_config(
         surface_category: type of surface to use
         emulator_base: the basename of the emulator, if used
         uncorrelated_radiometric_uncertainty: uncorrelated radiometric uncertainty parameter for isofit
+        linearity_uncertainty_coeffs:         Coefficients for parametric model for uncertainty in measurement linearity
         segmentation_size: image segmentation size if empirical line is used
         debug: flag to enable debug_mode in the config.implementation
         prebuilt_lut_path: lut path to use; if none, presolve config will create a new file
@@ -642,7 +644,8 @@ def build_presolve_config(
                 "wavelength_file": paths.wavelength_path,
                 "integrations": spectra_per_inversion,
                 "unknowns": {
-                    "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty
+                    "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty,
+                    "linearity_uncertainty": linearity_uncertainty_coeffs,
                 },
             },
             "surface": {
@@ -719,6 +722,7 @@ def build_main_config(
     surface_category="multicomponent_surface",
     emulator_base: str = None,
     uncorrelated_radiometric_uncertainty: float = 0.0,
+    linearity_uncertainty_coeffs: list = [],
     multiple_restarts: bool = False,
     segmentation_size=400,
     pressure_elevation: bool = False,
@@ -748,6 +752,7 @@ def build_main_config(
         surface_category:                     type of surface to use
         emulator_base:                        the basename of the emulator, if used
         uncorrelated_radiometric_uncertainty: uncorrelated radiometric uncertainty parameter for isofit
+        linearity_uncertainty_coeffs:         Coefficients for parametric model for uncertainty in measurement linearity
         multiple_restarts:                    if true, use multiple restarts
         segmentation_size:                    image segmentation size if empirical line is used
         pressure_elevation:                   if true, retrieve pressure elevation
@@ -955,7 +960,8 @@ def build_main_config(
                 "wavelength_file": paths.wavelength_path,
                 "integrations": spectra_per_inversion,
                 "unknowns": {
-                    "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty
+                    "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty,
+                    "linearity_uncertainty": linearity_uncertainty_coeffs,
                 },
             },
             "surface": {
@@ -1042,6 +1048,7 @@ def build_main_config(
         isofit_config_modtran["forward_model"]["instrument"][
             "parametric_noise_file"
         ] = paths.noise_path
+
     else:
         isofit_config_modtran["forward_model"]["instrument"]["SNR"] = 500
 


### PR DESCRIPTION
Following conversations, this supports one possible implementation of adding uncertainty from the effects of unconstrained non-linearity into the Seps matrix. 

Here, I've chosen to add it into the Sb matrix (rather than the Sy matrix) because of how rigid the Sb and Sy matrices are respectively. The Sy matrix returns exclusive models. That is, the different model types are run exclusively (SNR vs parametric vs pushbroom). The code could become messy if we wanted to add a parametric linearity model. We would have to either make the function more modular or add a named model that combined the measurement noise model + linearity model for example. Doable, but I felt that the Sb matrix made a bit more sense.

The Sb matrix construction is already fairly modular. The `bval` vector is constructed based on a sequence of config flags that are not mutually exclusive, at least within the code. The flexibility of the `bval` vector construction meant that the parametric linearity model could be applied to the `bval` vector agnostic of the other radiometric uncertainty terms, and therefore incorporated into the configs easily and unobtrusively. Th Sb matrix also has the advantage of being the preferred location for unknown radiometric effects.

To support this, the Sb matrix construction is achieved analogously to the Sa matrix construction. ForwardModel calls `fm.Sb`, which calls `fm.surface.Sb`, `fm.RT.Sb`, and `fm.instrument.Sb` respectively. The necessary `bval` and `bvec` initialization still occurs within the forward component init calls. The potential benefit here is that it should be fairly easy to add other Sb terms, especially as we think about Sb terms for surface/geometric effects.

The specific parametric model I implemented for unmodeled linearity is:

$y=a\cdot\left(\frac{1}{e^{bx}}\right)$

where _a_ is the scale and _b_ is the decay rate.
<img width="453" height="281" alt="Screenshot 2025-09-02 at 3 58 49 PM" src="https://github.com/user-attachments/assets/6f55c83a-2dd9-4cbe-b359-8ea70a793eeb" />

The uncertainty matrices for `a = .1` and `b = 10` look like (water pixel):
<img width="1231" height="1000" alt="image" src="https://github.com/user-attachments/assets/7c160c51-adb4-4ac9-b56d-07490940483a" />

An OE inversion for a water pixel:
<img width="1289" height="790" alt="image" src="https://github.com/user-attachments/assets/d738507c-057e-45d2-870e-260fa5870bd4" />

An OE inversion for a vegetation pixel:
<img width="1289" height="790" alt="image" src="https://github.com/user-attachments/assets/2e5d1c11-848d-4af3-8233-893fa07abb11" />


