### PR TITLE
Fixed Docker Syntax Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . ISOFIT/
 RUN pip install -e "ISOFIT[docker]" jupyterlab &&\
     python -m ipykernel install --user --name isofit &&\
     isofit -b . download all &&\
-    isofit build
+    isofit build &&\
     echo "alias launch=\"micromamba activate base && jupyter-lab --ip 0.0.0.0 --no-browser --allow-root --NotebookApp.token='' --NotebookApp.password=''\"" >> ~/.bashrc
 
 # Jupyter needs this to access the terminal


### PR DESCRIPTION
Super simple syntax error, a missing `&&\` which made Docker think the `echo` line was a docker command instead of a bash one