### PR TITLE
removing pandas from isofit

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -404,26 +404,15 @@ def get_refractive_index(k_wi, a, b, col_wvl, col_k):
         k_wi:    variable
         a:       start line
         b:       end line
-        col_wvl: wavelength column in pandas table
-        col_k:   k column in pandas table
+        col_wvl: wavelength column index
+        col_k:   k column index
 
     Returns:
         wvl_arr: array of wavelengths
         k_arr:   array of imaginary parts of refractive index
     """
-
-    wvl_ = []
-    k_ = []
-
-    for ii in range(a, b):
-        wvl = k_wi.at[ii, col_wvl]
-        k = k_wi.at[ii, col_k]
-        wvl_.append(wvl)
-        k_.append(k)
-
-    wvl_arr = np.asarray(wvl_)
-    k_arr = np.asarray(k_)
-
+    wvl_arr = k_wi[a:b, col_wvl]
+    k_arr = k_wi[a:b, col_k]
     return wvl_arr, k_arr
 
 

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -397,25 +397,6 @@ def get_absorption(wl: np.array, absfile: str) -> (np.array, np.array):
     return water_abscf_intrp, ice_abscf_intrp
 
 
-def get_refractive_index(k_wi, a, b, col_wvl, col_k):
-    """Convert refractive index table entries to numpy array.
-
-    Args:
-        k_wi:    variable
-        a:       start line
-        b:       end line
-        col_wvl: wavelength column index
-        col_k:   k column index
-
-    Returns:
-        wvl_arr: array of wavelengths
-        k_arr:   array of imaginary parts of refractive index
-    """
-    wvl_arr = k_wi[a:b, col_wvl]
-    k_arr = k_wi[a:b, col_k]
-    return wvl_arr, k_arr
-
-
 def recursive_reencode(j, shell_replace: bool = True):
     """Recursively re-encode a mutable object (ascii->str).
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -22,7 +22,6 @@ import os
 from typing import OrderedDict
 
 import numpy as np
-import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.optimize import least_squares, minimize
 from scipy.optimize import minimize_scalar as min1d
@@ -561,9 +560,22 @@ def invert_liquid_water(
     # load imaginary part of liquid water refractive index and calculate wavelength dependent absorption coefficient
     path_k = env.path("data", "iop", "k_liquid_water_ice.csv")
 
-    k_wi = pd.read_csv(path_k)
+    # Create dict with table entries (to remove pandas dependency).
+    # NOTE: these values are hardcoded based on k_liquid_water_ice.csv.
+    refractive_index_dict = {
+        "T = 22°C": (0, 1, 0, 551),
+        "T = -8°C": (2, 3, 218, 551),
+        "T = -25°C": (4, 5, 404, 551),
+        "T = -7°C": (6, 7, 0, 135),
+        "T = 25°C (H)": (8, 9, 0, 23),
+        "T = 20°C": (10, 11, 0, 982),
+        "T = 25°C (S)": (12, 13, 0, 221),
+    }
+    col_wvl, col_k, a, b = refractive_index_dict["T = 20°C"]
+
+    k_wi = np.genfromtxt(path_k, delimiter=",", skip_header=1)
     wl_water, k_water = get_refractive_index(
-        k_wi=k_wi, a=0, b=982, col_wvl="wvl_6", col_k="T = 20°C"
+        k_wi=k_wi, a=a, b=b, col_wvl=col_wvl, col_k=col_k
     )
     kw = np.interp(x=wl_sel, xp=wl_water, fp=k_water)
     abs_co_w = 4 * np.pi * kw / wl_sel

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -559,25 +559,9 @@ def invert_liquid_water(
 
     # load imaginary part of liquid water refractive index and calculate wavelength dependent absorption coefficient
     path_k = env.path("data", "iop", "k_liquid_water_ice.csv")
-
-    # Create dict with table entries (to remove pandas dependency).
-    # NOTE: these values are hardcoded based on k_liquid_water_ice.csv.
-    refractive_index_dict = {
-        "T = 22°C": (0, 1, 0, 551),
-        "T = -8°C": (2, 3, 218, 551),
-        "T = -25°C": (4, 5, 404, 551),
-        "T = -7°C": (6, 7, 0, 135),
-        "T = 25°C (H)": (8, 9, 0, 23),
-        "T = 20°C": (10, 11, 0, 982),
-        "T = 25°C (S)": (12, 13, 0, 221),
-    }
-    col_wvl, col_k, a, b = refractive_index_dict["T = 20°C"]
-
-    k_wi = np.genfromtxt(path_k, delimiter=",", skip_header=1)
-    wl_water, k_water = get_refractive_index(
-        k_wi=k_wi, a=a, b=b, col_wvl=col_wvl, col_k=col_k
-    )
-    kw = np.interp(x=wl_sel, xp=wl_water, fp=k_water)
+    k_wi = np.genfromtxt(path_k, delimiter=",", names=True, encoding="utf-8-sig")
+    k_wi_idx = ~np.isnan(k_wi["wl_20c"]) & ~np.isnan(k_wi["k_20c"])
+    kw = np.interp(x=wl_sel, xp=k_wi["wl_20c"][k_wi_idx], fp=k_wi["k_20c"][k_wi_idx])
     abs_co_w = 4 * np.pi * kw / wl_sel
 
     rfl_meas_sel = rfl_meas[lw_feature_left : lw_feature_right + 1]

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -30,7 +30,6 @@ from isofit.core import units
 from isofit.core.common import (
     emissive_radiance,
     eps,
-    get_refractive_index,
     svd_inv_sqrt,
 )
 from isofit.data import env

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -558,6 +558,7 @@ def invert_liquid_water(
         lw_bounds[0][1] = ewt_detection_limit
 
     # load imaginary part of liquid water refractive index and calculate wavelength dependent absorption coefficient
+    # options are: 'k_22c', 'k_minus8c', 'k_minus25c', 'k_minus7c', 'k_25c_H', 'k_20c', 'k_25c_S
     path_k = env.path("data", "iop", "k_liquid_water_ice.csv")
     k_wi = np.genfromtxt(path_k, delimiter=",", names=True, encoding="utf-8-sig")
     k_wi_idx = ~np.isnan(k_wi["wl_20c"]) & ~np.isnan(k_wi["k_20c"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   "h5py",
   "netCDF4",
   "numpy >= 1.20",
-  "pandas >= 0.24.0",
   "pyyaml >= 5.3.2",
   "ray >= 1.2.0",
   "scikit-image >= 0.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
   "scikit-learn >= 0.19.1",
   "scipy >= 1.3.0",
   "spectral >= 0.19",
-  "utm",
   "xarray",
   "xxhash >= 1.2.0",
 ]

--- a/recipe/docs.yml
+++ b/recipe/docs.yml
@@ -11,7 +11,6 @@ dependencies:
   - h5py
   - netCDF4<1.7.1
   - numpy>=1.20.0,<2.0.0
-  - pandas>=0.24
   - pre-commit
   - pytest>=3.5.1
   - python-xxhash<3

--- a/recipe/docs.yml
+++ b/recipe/docs.yml
@@ -19,7 +19,6 @@ dependencies:
   - scikit-learn>=0.19.1
   - scipy>=1.3.0
   - spectral>=0.19
-  - utm
   - xarray<2024.1.1
   - myst-parser
   - sphinx-autoapi

--- a/recipe/isofit.yml
+++ b/recipe/isofit.yml
@@ -19,7 +19,6 @@ dependencies:
   - scikit-learn>=0.19.1
   - scipy>=1.3.0
   - spectral>=0.19
-  - utm
   - xarray
 
   - pip:

--- a/recipe/isofit.yml
+++ b/recipe/isofit.yml
@@ -11,7 +11,6 @@ dependencies:
   - h5py
   - netCDF4
   - numpy>=1.20.0
-  - pandas>=0.24
   - pre-commit
   - pytest>=3.5.1
   - python-xxhash<3


### PR DESCRIPTION
This would resolve #745 . The only use of pandas is for reading a refractive index file in inverse_simple. In this, I just made a simple dictionary that replicates this read without needing pandas installed. 

<img width="1874" height="877" alt="Screenshot 2025-09-11 at 13 09 37" src="https://github.com/user-attachments/assets/39949ea8-8f9d-4a3c-8bd3-6da2edf3d38c" />





.. There is still pandas in `.imgspec/` but I am not sure if this is active / a part of isofit?
