### PR TITLE
Bugfix isoplots version checking

### DIFF
--- a/isofit/data/cli/isoplots.py
+++ b/isofit/data/cli/isoplots.py
@@ -148,7 +148,7 @@ def isUpToDate(path=None, tag="latest", debug=print, error=print, **_):
     current = Version(importlib.metadata.version("isoplots"))
 
     if current < latest:
-        error(f"[x] Latest is {latest}, currently installed is {version}")
+        error(f"[x] Latest is {latest}, currently installed is {current}")
         return False
 
     debug(f"[OK] Path is up to date, current version: {current}")


### PR DESCRIPTION
Rebuilding the cache presently raises an error because one of the variables in the isoplots downloader is misnamed. 