### PR TITLE
Leveraging initial superpixel solve to inform background reflectance terms

### DIFF
--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -184,10 +184,10 @@ class RadiativeTransfer:
         Physics-based forward model to calculate at-sensor radiance.
         Includes topography, background reflectance, and glint.
         """
-        # Adjacency effects
-        # ToDo: we need to think about if we want to obtain the background reflectance from the Geometry object
-        #  or from the surface model, i.e., the same way as we do with the target pixel reflectance
-
+        # Adjacency effects (dir_dif) and spherical albedo interactions (dif_dif)
+        # taken from geom object, the scale of which is determined from number of segmentations.
+        # TODO: what scale are we currently assuming in the default no. of segmentations for an EMIT scene for example?
+        # Also, do we want dir-dif and dif-dif scales to be the same?
         rho_dir_dif = (
             geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_dir_dir
         )

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -106,7 +106,6 @@ def analytical_line(
 
     # Set up input file paths
     subs_state_file = config.output.estimated_state_file
-    subs_rfl_file = config.output.estimated_reflectance_file
     subs_loc_file = config.input.loc_file
 
     # Rename files
@@ -312,7 +311,6 @@ def analytical_line(
             obs_file,
             atm_file,
             subs_state_file,
-            subs_rfl_file,
             lbl_file,
             rfl_output,
             unc_output,
@@ -375,7 +373,6 @@ class Worker(object):
         obs_file: str,
         atm_file: str,
         subs_state_file: str,
-        subs_rfl_file: str,
         lbl_file: str,
         rfl_output: str,
         unc_output: str,
@@ -431,9 +428,6 @@ class Worker(object):
         self.subs_state = envi.open(envi_header(subs_state_file)).open_memmap(
             interleave="bip"
         )
-        self.subs_rfl = envi.open(envi_header(subs_rfl_file)).open_memmap(
-            interleave="bip"
-        )
         self.lbl = envi.open(envi_header(lbl_file)).open_memmap(interleave="bip")
 
         # Open skyview file for ALAlg, or create an array of 1s.
@@ -460,7 +454,6 @@ class Worker(object):
 
         # Can't see any reason to leave these as optional
         self.subs_state_file = subs_state_file
-        self.subs_rfl_file = subs_rfl_file
         self.lbl_file = lbl_file
 
         # If I only want to use some of the atm_interp bands
@@ -535,7 +528,7 @@ class Worker(object):
             
             iv_idx = self.fm.surface.analytical_iv_idx
             sub_state = self.subs_state[int(self.lbl[r, c, 0]), 0, iv_idx]
-            bg_rfl = self.subs_rfl[int(self.lbl[r, c, 0]), 0, iv_idx]
+            bg_rfl = sub_state[self.n_rfl_bands]
 
             geom = Geometry(
                 obs=self.obs[r, c, :],


### PR DESCRIPTION
We currently have the capability in our RT to pull background reflectances if superpixel mode is enabled from  `Geometry()`. These reflectances are dif-dif and dir-dif (diagram courtesy of Nimrod).

We currently set these background terms to None, which will auto-assign it to be the target pixel terms (dif-dir, dir-dir). This is probably fine for a majority of scenes. Some exceptions though would be aquatic and snow environments, where high contrasts between surfaces become more common. Cloud cover is another instance where this high contrast can occur over normal-ish scenes. 

Since we essentially do solve the scene twice, because of superpixel solve, we do have access to coarse spatial resolution reflectance without changing too much in the code. There are quite a few questions that would arise though including, but not limited to,

- Adjacency effects are typically averaged over a ~1 km area (see VIIRS and EnMap ATBD). With our current default segmentation in ApplyOE, what kind of scale are these superpixels computed at say for an EMIT scene? We are limited by not knowing pixel resolution, but it seems like maybe we could enforce some sort of scale parameter?

- This only works if superpixel is selected, and I don't think there is really an easy way to bring this into just the pixel-by-pixel solve?

- Would we want to smooth out the bg_ rfl in the same way we do to the atm?



<img width="1217" height="517" alt="Screenshot 2025-09-25 at 17 33 20" src="https://github.com/user-attachments/assets/1c304c49-3ded-4226-b9aa-a9befe69e885" />
