### PR TITLE
Parallel predict for 6C emulator

### DIFF
--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -135,13 +135,19 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         self.emulator_aux_file = None
         """str: path to emulator auxiliary data - expected npz format"""
 
-        self._predict_parallel_chunks_type = int
-        self.predict_parallel_chunks = 10
-        """int: If emulator predictions are in parallel. How many chunks to run"""
+        self._parallel_layer_read_type = bool
+        self.parallel_layer_read = True
+        """bool: Flag for how to load and run sRTMnet prediction. 
+           If True, will read in the weights/biases per layer per worker.
+           If False, will load entire model into shared memory
+           Model doesn't always fit in shared memory for smaller systems
+        """
 
-        self._model_tmp_store_type = str
-        self.model_tmp_store = "/tmp/ray/session_latest"
-        """str: For 6C emulator, where to store temporary model matrices"""
+        self._predict_parallel_chunks_type = int
+        self.predict_parallel_chunks = 20
+        """int: If emulator predictions are in parallel. How many chunks to run.
+           Keep to a small number for systems with little memory and slow read.
+        """
 
         # 6S parameters - not the corcommemnd
         # TODO: these should come from a template file, as in modtran
@@ -250,8 +256,10 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
                             "The sRTMnet requires an emulator_file to be specified."
                         )
 
-                if (os.path.splitext(self.emulator_file)[1] != ".h5") and (
-                    os.path.splitext(self.emulator_file)[1] != ".npz"
+                if (
+                    (os.path.splitext(self.emulator_file)[1] != ".h5")
+                    and (os.path.splitext(self.emulator_file)[1] != ".npz")
+                    and (os.path.splitext(self.emulator_file)[1] != ".6c")
                 ):
                     errors.append(
                         "sRTMnet now requires the emulator_file to be of type .h5 (or .npz for experimental 6c emulator).  "

--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -135,6 +135,14 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         self.emulator_aux_file = None
         """str: path to emulator auxiliary data - expected npz format"""
 
+        self._predict_parallel_chunks_type = int
+        self.predict_parallel_chunks = 10
+        """int: If emulator predictions are in parallel. How many chunks to run"""
+
+        self._model_tmp_store_type = str
+        self.model_tmp_store = "/tmp/ray/session_latest"
+        """str: For 6C emulator, where to store temporary model matrices"""
+
         # 6S parameters - not the corcommemnd
         # TODO: these should come from a template file, as in modtran
         self._day_type = int

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -194,7 +194,7 @@ def apply_oe(
     ray_temp_dir : str, default="/tmp/ray"
         Location of temporary directory for ray parallelization engine
     emulator_base : str, default=None
-        Location of emulator base path. Point this at the model folder (or h5 file) of
+        Location of emulator base path. Point this at the 3C or 6C .h5 files.
         sRTMnet to use the emulator instead of MODTRAN. An additional file with the
         same basename and the extention _aux.npz must accompany
         e.g. /path/to/emulator.h5 /path/to/emulator_aux.npz
@@ -260,13 +260,9 @@ def apply_oe(
         if emulator_base.endswith(".jld2"):
             multipart_transmittance = False
         else:
-            if emulator_base.endswith(".npz"):
-                emulator_aux_file = emulator_base
-            else:
-                emulator_aux_file = os.path.abspath(
-                    os.path.splitext(emulator_base)[0] + "_aux.npz"
-                )
-            aux = np.load(emulator_aux_file)
+            aux = np.load(
+                os.path.abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
+            )
             if (
                 "transm_down_dir"
                 and "transm_down_dif"
@@ -276,6 +272,7 @@ def apply_oe(
                 multipart_transmittance = True
             else:
                 multipart_transmittance = False
+            del aux
     else:
         # This is the MODTRAN case. Do we want to enable the 4c mode by default?
         multipart_transmittance = True

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -259,22 +259,19 @@ def apply_oe(
     if emulator_base is not None:
         if emulator_base.endswith(".jld2"):
             multipart_transmittance = False
+
+        elif emulator_base.endswith(".h5"):
+            multipart_transmittance = False
+
+        elif emulator_base.endswith(".6c"):
+            multipart_transmittance = True
+
         else:
-            aux = np.load(
-                os.path.abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
-            )
-            if (
-                "transm_down_dir"
-                and "transm_down_dif"
-                and "transm_up_dir"
-                and "transm_up_dif" in aux["rt_quantities"]
-            ):
-                multipart_transmittance = True
-            else:
-                multipart_transmittance = False
-            del aux
+            raise ValueError("Invalid emulator_base extension. Use .h5, .6c, or .jld2")
+
     else:
-        # This is the MODTRAN case. Do we want to enable the 4c mode by default?
+        # This is the MODTRAN case.
+        # Do we want to enable the 4c mode by default?
         multipart_transmittance = True
 
     if sensor not in SUPPORTED_SENSORS:

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -721,15 +721,10 @@ def build_presolve_config(
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "emulator_file"
         ] = abspath(emulator_base)
-        if emulator_base.endswith(".npz"):
-            # then aux & emulator are the same
-            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
-                "emulator_aux_file"
-            ] = abspath(emulator_base)
-        else:
-            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
-                "emulator_aux_file"
-            ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
+        radiative_transfer_config["radiative_transfer_engines"]["vswir"][
+            "emulator_aux_file"
+        ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
+
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "earth_sun_distance_file"
         ] = paths.earth_sun_distance_path
@@ -907,15 +902,9 @@ def build_main_config(
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "emulator_file"
         ] = abspath(emulator_base)
-        if emulator_base.endswith(".npz"):
-            # then aux & emulator are the same
-            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
-                "emulator_aux_file"
-            ] = abspath(emulator_base)
-        else:
-            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
-                "emulator_aux_file"
-            ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
+        radiative_transfer_config["radiative_transfer_engines"]["vswir"][
+            "emulator_aux_file"
+        ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "earth_sun_distance_file"
         ] = paths.earth_sun_distance_path

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -19,6 +19,7 @@ import numpy as np
 from scipy.io import loadmat
 from spectral.io import envi
 
+from isofit import __version__
 from isofit.core import isofit, units
 from isofit.core.common import (
     envi_header,
@@ -30,7 +31,6 @@ from isofit.core.multistate import SurfaceMapping
 from isofit.data import env
 from isofit.radiative_transfer.engines.modtran import ModtranRT
 from isofit.utils.surface_model import surface_model
-from isofit import __version__
 
 
 class Pathnames:
@@ -721,6 +721,7 @@ def build_presolve_config(
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "emulator_file"
         ] = abspath(emulator_base)
+
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "emulator_aux_file"
         ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
@@ -902,9 +903,17 @@ def build_main_config(
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "emulator_file"
         ] = abspath(emulator_base)
-        radiative_transfer_config["radiative_transfer_engines"]["vswir"][
-            "emulator_aux_file"
-        ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
+
+        if multipart_transmittance:
+            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
+                "emulator_aux_file"
+            ] = emulator_base
+
+        else:
+            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
+                "emulator_aux_file"
+            ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
+
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "earth_sun_distance_file"
         ] = paths.earth_sun_distance_path


### PR DESCRIPTION
Currently, the prediction step for the emulator is quite slow. I found that batching the full prediction array and then parallelizing the batch predicts improved compute time.

The consideration with a ray-based approach is that the model size can be larger than the default object storage size for ray on smaller systems. For example, [suggested batch prediction strategies with Ray](https://docs.ray.io/en/latest/ray-core/examples/batch_prediction.html) cause spillage on local tests (Mac OS, 64G memory). The object store size is a parameter within the ray config. However it's an OS-specific variable and performance may be different depending on the value relative to Mac vs. Linux for example.

Currently, the config specifies which approach to use. Keeping the model in shared memory vs. reading on a per-layer basis.

A couple of tests included in this draft currently:

Option 1: [follow suggested batch prediciton with ray](https://docs.ray.io/en/latest/ray-core/examples/batch_prediction.html). Full key-model put in memory, and shared in object storage across workers.

```python
                    emulator = tfLikeModel(
                        None,
                        None,
                        weights=aux[f"weights_{key}"],
                        biases=aux[f"biases_{key}"],
                    )

                    ...
                    n_chunks = self.engine_config.predict_parallel_chunks
                    data_chunks = np.array_split(data, n_chunks, axis=0)

                    # Option 1: all in object storage
                    model_ref = ray.put(emulator)
                    result_refs = [
                        ray_predict.remote(model_ref, x) for x in data_chunks
                    ]

                    lp = np.concatenate(ray.get(result_refs), axis=0)

```

Option 2:  Don't keep the model weights/biases in memory. Load in as needed per-batch and per-layer.

```python
                    emulator = tfLikeModel(self.engine_config.emulator_file, key)
                    ...
                    data_chunks = np.array_split(data, n_chunks, axis=0)

                    # Option 2: Read weights per layer - per batch
                    result_refs = [
                        ray_layer_read_predict.remote(emulator, x)
                        for x in data_chunks
                    ]
                    lp = np.concatenate(ray.get(result_refs), axis=0)
                    del result_refs, emulator
```

Considerations include portability across systems, threading and throttling on file reads.  The memory requirements appears dependent on chunk size.  Topic for discussion.


Dependency between batch size and prediction times for `Option 2`:

<img width="681" height="369" alt="image" src="https://github.com/user-attachments/assets/9f2c629a-bac1-490e-bfee-2afa85c4a968" />


Dev-branch vectorized numpy:

~21 Minutes 9 Seconds

```
INFO:2025-09-29,15:42:19 || sRTMnet.py:preSim() | Interpolating simulator quantities to emulator size
INFO:2025-09-29,15:42:24 || sRTMnet.py:preSim() | Loading and predicting with emulator
INFO:2025-09-29,16:03:23 || sRTMnet.py:preSim() | Saving intermediary prediction results to: /Users/bgreenbeProjects/IsofitDev/Predicts/lut_full/sRTMnet.predicts.nc
INFO:2025-09-29,16:03:28 || radiative_transfer_engine.py:runSimulations() | Saving pre-sim data to index zero of all dimensions except wl
INFO:2025-09-29,16:03:28 || radiative_transfer_engine.py:runSimulations() | Running any post-sim functions
```

Sanity check showing that batched predictions in serial is still slower:

~22 minutes 31 seconds

```
INFO:2025-09-30,16:08:12 || sRTMnet.py:preSim() | Interpolating simulator quantities to emulator size
INFO:2025-09-30,16:08:16 || sRTMnet.py:preSim() | Loading and predicting with emulator
INFO:2025-09-30,16:08:16 || sRTMnet.py:preSim() | Loading emulator rhoatm
INFO:2025-09-30,16:08:16 || sRTMnet.py:preSim() | Emulating rhoatm
INFO:2025-09-30,16:11:58 || sRTMnet.py:preSim() | Loading emulator sphalb
INFO:2025-09-30,16:11:58 || sRTMnet.py:preSim() | Emulating sphalb
INFO:2025-09-30,16:15:42 || sRTMnet.py:preSim() | Loading emulator transm_down_dif
INFO:2025-09-30,16:15:42 || sRTMnet.py:preSim() | Emulating transm_down_dif
INFO:2025-09-30,16:19:26 || sRTMnet.py:preSim() | Loading emulator transm_up_dif
INFO:2025-09-30,16:19:26 || sRTMnet.py:preSim() | Emulating transm_up_dif
INFO:2025-09-30,16:23:15 || sRTMnet.py:preSim() | Loading emulator transm_down_dir
INFO:2025-09-30,16:23:15 || sRTMnet.py:preSim() | Emulating transm_down_dir
INFO:2025-09-30,16:27:03 || sRTMnet.py:preSim() | Loading emulator transm_up_dir
INFO:2025-09-30,16:27:03 || sRTMnet.py:preSim() | Emulating transm_up_dir
INFO:2025-09-30,16:30:43 || sRTMnet.py:preSim() | Saving intermediary prediction results to:
```

Figure to show that the solutions are identical between the branches.
<img width="1290" height="354" alt="Screenshot 2025-09-29 at 4 11 13 PM" src="https://github.com/user-attachments/assets/2d33e639-0c5b-4537-ad46-051801e5085f" />


Code block for how I packed the model combined .h5 file:

```python
path = '.../combined_model_random.npz'
outfile = '.../model_101025_26_combined.6c'
aux = np.load(path, allow_pickle=True)
keys = [
    'weights_rhoatm',
    'biases_rhoatm',
    'weights_sphalb',
    'biases_sphalb',
    'weights_transm_down_dif',
    'biases_transm_down_dif',
    'weights_transm_up_dif',
    'biases_transm_up_dif',
    'weights_transm_down_dir',
    'biases_transm_down_dir',
    'weights_transm_up_dir',
    'biases_transm_up_dir',
]
files = [
    'lut_names',
    'feature_point_names',
    'rt_quantities',
    'solar_irr',
    'emulator_wavelengths',
    'simulator_wavelengths',
]
dict_files = [
    'response_scaler',
    'response_offset'
]
with h5py.File(outfile, 'w') as f:
    for key in keys:
        print(key)
        group = f.create_group(key)
        for i, ar in enumerate(aux[key]):
            group.create_dataset(f"layer_{i}", data=ar)

    for fname in files:
        print(fname)
        if (
            (aux[fname].dtype != np.dtype('float64')) 
        ):
            f.create_dataset(fname, data=aux[fname].astype(object))
        else:
            f.create_dataset(fname, data=aux[fname])

    for fname in dict_files:
        print(fname)
        group = f.create_group(fname)
        for i, ar in aux[fname].item().items():
            group.create_dataset(i, data=ar)
```


