### PR TITLE
More descriptions on ISOFIT run to envi file

### DIFF
--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -87,11 +87,6 @@ class ImplementationConfig(BaseConfigSection):
         """bool: A flag to run the code in debug mode, which circumvents ray.
         """
 
-        self._segmentation_size_type = int
-        self.segmentation_size = 40
-        """int: If superpixels are enabled (analytical_line or empirical_line), sets the number of spectra per superpixel.
-        """
-
         self._isofit_version_type = str
         self.isofit_version = __version__
         """str: ISOFIT version used."""

--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -86,6 +86,11 @@ class ImplementationConfig(BaseConfigSection):
         """bool: A flag to run the code in debug mode, which circumvents ray.
         """
 
+        self._segmentation_size_type = int
+        self.segmentation_size = 40
+        """int: If superpixels are enabled (analytical_line or empirical_line), sets the number of spectra per superpixel.
+        """
+
         self.set_config_options(sub_configdic)
 
     def _check_config_validity(self) -> List[str]:

--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Type
 
 from isofit.configs.base_config import BaseConfigSection
 from isofit.configs.sections.inversion_config import InversionConfig
+from isofit import __version__
 
 
 class ImplementationConfig(BaseConfigSection):
@@ -90,6 +91,10 @@ class ImplementationConfig(BaseConfigSection):
         self.segmentation_size = 40
         """int: If superpixels are enabled (analytical_line or empirical_line), sets the number of spectra per superpixel.
         """
+
+        self._isofit_version_type = str
+        self.isofit_version = __version__
+        """str: ISOFIT version used."""
 
         self.set_config_options(sub_configdic)
 

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -247,7 +247,7 @@ class SpectrumFile:
                     "bbl": bad_bands,
                     "band names": band_names,
                     "wavelength": self.wl,
-                    "ISOFIT version": isofit_version,
+                    "isofit version": isofit_version,
                     "engine": engine,
                 }
 

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -86,7 +86,6 @@ class SpectrumFile:
         ztitles="{Wavelength (nm), Magnitude}",
         map_info="{}",
         engine=None,
-        segmentation_size=None,
         isofit_version=None,
     ):
         """."""
@@ -250,7 +249,6 @@ class SpectrumFile:
                     "wavelength": self.wl,
                     "ISOFIT version": isofit_version,
                     "engine": engine,
-                    "segmentation_size": segmentation_size,
                 }
 
                 for k, v in meta.items():
@@ -377,8 +375,6 @@ class IO:
                 0
             ].engine_name
         )
-        self.segmentation_size = config.implementation.segmentation_size
-        self.isofit_version = config.implementation.isofit_version
 
         # Use the pre-defined full statevec
         if len(full_statevec):
@@ -451,8 +447,7 @@ class IO:
                 zrange=zrange,
                 ztitles=ztitle,
                 engine=self.engine_name,
-                segmentation_size=self.segmentation_size,
-                isofit_version=self.isofit_version,
+                isofit_version=config.implementation.isofit_version,
             )
 
         # Do we apply a radiance correction?
@@ -820,9 +815,6 @@ class IO:
             ].engine_name
         )
 
-        segmentation_size = config.implementation.segmentation_size
-        isofit_version = config.implementation.isofit_version
-
         for element, element_header, element_name in zip(
             *config.output.get_output_files()
         ):
@@ -854,8 +846,7 @@ class IO:
                 zrange=zrange,
                 ztitles=ztitle,
                 engine=engine_name,
-                segmentation_size=segmentation_size,
-                isofit_version=isofit_version,
+                isofit_version=config.implementation.isofit_version,
             )
 
     @staticmethod

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -42,7 +42,6 @@ from isofit.core.geometry import Geometry
 from isofit.core.multistate import match_statevector
 from isofit.data import env
 from isofit.inversion.inverse_simple import invert_algebraic
-from isofit import __version__
 
 ### Variables ###
 Logger = logging.getLogger(__file__)
@@ -87,7 +86,8 @@ class SpectrumFile:
         ztitles="{Wavelength (nm), Magnitude}",
         map_info="{}",
         engine=None,
-        segmentation_size=1,
+        segmentation_size=None,
+        isofit_version=None,
     ):
         """."""
 
@@ -248,7 +248,7 @@ class SpectrumFile:
                     "bbl": bad_bands,
                     "band names": band_names,
                     "wavelength": self.wl,
-                    "ISOFIT version": __version__,
+                    "ISOFIT version": isofit_version,
                     "engine": engine,
                     "segmentation_size": segmentation_size,
                 }
@@ -378,6 +378,7 @@ class IO:
             ].engine_name
         )
         self.segmentation_size = config.implementation.segmentation_size
+        self.isofit_version = config.implementation.isofit_version
 
         # Use the pre-defined full statevec
         if len(full_statevec):
@@ -451,6 +452,7 @@ class IO:
                 ztitles=ztitle,
                 engine=self.engine_name,
                 segmentation_size=self.segmentation_size,
+                isofit_version=self.isofit_version,
             )
 
         # Do we apply a radiance correction?
@@ -819,6 +821,7 @@ class IO:
         )
 
         segmentation_size = config.implementation.segmentation_size
+        isofit_version = config.implementation.isofit_version
 
         for element, element_header, element_name in zip(
             *config.output.get_output_files()
@@ -852,6 +855,7 @@ class IO:
                 ztitles=ztitle,
                 engine=engine_name,
                 segmentation_size=segmentation_size,
+                isofit_version=isofit_version,
             )
 
     @staticmethod

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -42,6 +42,7 @@ from isofit.core.geometry import Geometry
 from isofit.core.multistate import match_statevector
 from isofit.data import env
 from isofit.inversion.inverse_simple import invert_algebraic
+from isofit import __version__
 
 ### Variables ###
 Logger = logging.getLogger(__file__)
@@ -85,6 +86,8 @@ class SpectrumFile:
         flag=-9999.0,
         ztitles="{Wavelength (nm), Magnitude}",
         map_info="{}",
+        engine=None,
+        segmentation_size=1,
     ):
         """."""
 
@@ -245,6 +248,9 @@ class SpectrumFile:
                     "bbl": bad_bands,
                     "band names": band_names,
                     "wavelength": self.wl,
+                    "ISOFIT version": __version__,
+                    "engine": engine,
+                    "segmentation_size": segmentation_size,
                 }
 
                 for k, v in meta.items():
@@ -366,6 +372,12 @@ class IO:
         self.n_rows = 1
         self.n_cols = 1
         self.bbl = "{" + ",".join([str(1) for n in range(len(self.meas_wl))]) + "}"
+        self.engine_name = (
+            config.forward_model.radiative_transfer.radiative_transfer_engines[
+                0
+            ].engine_name
+        )
+        self.segmentation_size = config.implementation.segmentation_size
 
         # Use the pre-defined full statevec
         if len(full_statevec):
@@ -437,6 +449,8 @@ class IO:
                 map_info=self.map_info,
                 zrange=zrange,
                 ztitles=ztitle,
+                engine=self.engine_name,
+                segmentation_size=self.segmentation_size,
             )
 
         # Do we apply a radiance correction?
@@ -798,6 +812,13 @@ class IO:
         )
         wl_names = [("Channel %i" % i) for i in range(len(wl_init))]
         bbl = "{" + ",".join([str(1) for n in range(len(wl_init))]) + "}"
+        engine_name = (
+            config.forward_model.radiative_transfer.radiative_transfer_engines[
+                0
+            ].engine_name
+        )
+
+        segmentation_size = config.implementation.segmentation_size
 
         for element, element_header, element_name in zip(
             *config.output.get_output_files()
@@ -829,6 +850,8 @@ class IO:
                 map_info="{}",
                 zrange=zrange,
                 ztitles=ztitle,
+                engine=engine_name,
+                segmentation_size=segmentation_size,
             )
 
     @staticmethod

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -243,13 +243,14 @@ class SpectrumFile:
                     "sensor type": "unknown",
                     "interleave": interleave,
                     "data type": typemap[dtype],
-                    "wavelength units": "nm",
+                    "wavelength units": "Nanometers",
                     "z plot range": zrange,
                     "z plot titles": ztitles,
                     "fwhm": fwhm,
                     "bbl": bad_bands,
-                    "band names": band_names,
+                    "band_names": band_names,
                     "wavelength": self.wl,
+                    "data ignore value": self.flag,
                 }
 
                 for k, v in meta.items():

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -85,7 +85,7 @@ class SpectrumFile:
         flag=-9999.0,
         ztitles="{Wavelength (nm), Magnitude}",
         map_info="{}",
-        engine=None,
+        engine_name=None,
         isofit_version=None,
     ):
         """."""
@@ -230,6 +230,9 @@ class SpectrumFile:
                 # from scratch.  Hopefully the caller has supplied the
                 # necessary metadata details.
                 meta = {
+                    "description": (
+                        f"L2A per-pixel surface retrieval (engine={engine_name}, isofit_version={isofit_version})"
+                    ),
                     "lines": n_rows,
                     "samples": n_cols,
                     "bands": n_bands,
@@ -247,8 +250,6 @@ class SpectrumFile:
                     "bbl": bad_bands,
                     "band names": band_names,
                     "wavelength": self.wl,
-                    "isofit_version": isofit_version,
-                    "engine": engine,
                 }
 
                 for k, v in meta.items():
@@ -446,7 +447,7 @@ class IO:
                 map_info=self.map_info,
                 zrange=zrange,
                 ztitles=ztitle,
-                engine=self.engine_name,
+                engine_name=self.engine_name,
                 isofit_version=config.implementation.isofit_version,
             )
 
@@ -845,7 +846,7 @@ class IO:
                 map_info="{}",
                 zrange=zrange,
                 ztitles=ztitle,
-                engine=engine_name,
+                engine_name=engine_name,
                 isofit_version=config.implementation.isofit_version,
             )
 

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -248,7 +248,7 @@ class SpectrumFile:
                     "z plot titles": ztitles,
                     "fwhm": fwhm,
                     "bbl": bad_bands,
-                    "band_names": band_names,
+                    "band names": band_names,
                     "wavelength": self.wl,
                     "data ignore value": self.flag,
                 }

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -247,7 +247,7 @@ class SpectrumFile:
                     "bbl": bad_bands,
                     "band names": band_names,
                     "wavelength": self.wl,
-                    "isofit version": isofit_version,
+                    "isofit_version": isofit_version,
                     "engine": engine,
                 }
 

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -180,6 +180,13 @@ def analytical_line(
         "file type": "ENVI Standard",
         "byte order": 0,
         "no data value": -9999,
+        "map info": {rdn_meta["map_info"]},
+        "wavelength units": "Nanometers",
+        "wavelength": wl_init,
+        "fwhm": fwhm_init,
+        "lines": rdn_meta["lines"],
+        "samples": rdn_meta["samples"],
+        "interleave": "bil",
     }
     bbl = "{" + ",".join([f"{x}" for x in outside_ret_windows]) + "}"
     num_bands = len(full_idx_surf_rfl)
@@ -192,16 +199,9 @@ def analytical_line(
         output_metadata,
         analytical_rfl_path,
         (rdns[0], num_bands, rdns[1]),
-        map_info=rdn_meta["map_info"],
-        lines=rdn_meta["lines"],
-        samples=rdn_meta["samples"],
         bands=f"{num_bands}",
         bbl=bbl,
-        interleave="bil",
         band_names=band_names,
-        wavelength=wl_init,
-        wavelength_unts="Nanometers",
-        fwhm=fwhm_init,
         description=(
             f"L2A Analytical per-pixel surface retrieval (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
         ),
@@ -212,18 +212,9 @@ def analytical_line(
         output_metadata,
         analytical_rfl_unc_path,
         (rdns[0], num_bands, rdns[1]),
-        map_info=rdn_meta["map_info"],
-        lines=rdn_meta["lines"],
-        samples=rdn_meta["samples"],
         bands=f"{num_bands}",
         bbl=bbl,
-        interleave="bil",
         band_names=band_names,
-        wavelength=wl_init,
-        wavelength_unts="Nanometers",
-        fwhm=fwhm_init,
-        isofit_version=config.implementation.isofit_version,
-        engine_name=engine_name,
         description=(
             f"L2A Analytical per-pixel surface retrieval uncertainty (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
         ),
@@ -239,14 +230,8 @@ def analytical_line(
             output_metadata,
             analytical_non_rfl_surf_file,
             (rdns[0], n_non_rfl_bands, rdns[1]),
-            map_info=rdn_meta["map_info"],
-            lines=rdn_meta["lines"],
-            samples=rdn_meta["samples"],
             bands=f"{n_non_rfl_bands}",
-            interleave="bil",
             band_names=non_rfl_band_names,
-            isofit_version=config.implementation.isofit_version,
-            engine_name=engine_name,
             description=(
                 f"L2A Analytical per-pixel non_rfl surface retrieval  (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
             ),
@@ -256,14 +241,8 @@ def analytical_line(
             output_metadata,
             analytical_non_rfl_surf_unc_file,
             (rdns[0], n_non_rfl_bands, rdns[1]),
-            map_info=rdn_meta["map_info"],
-            lines=rdn_meta["lines"],
-            samples=rdn_meta["samples"],
             bands=f"{n_non_rfl_bands}",
-            interleave="bil",
             band_names=non_rfl_band_names,
-            isofit_version=config.implementation.isofit_version,
-            engine_name=engine_name,
             description=(
                 f"L2A Analytical per-pixel non_rfl surface retrieval uncertainty  (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
             ),

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -180,7 +180,7 @@ def analytical_line(
         "file type": "ENVI Standard",
         "byte order": 0,
         "no data value": -9999,
-        "map info": {rdn_meta["map_info"]},
+        "map info": "{" + ", ".join(map(str, rdn_meta["map info"])) + "}",
         "wavelength units": "Nanometers",
         "wavelength": wl_init,
         "fwhm": fwhm_init,
@@ -188,9 +188,11 @@ def analytical_line(
         "samples": rdn_meta["samples"],
         "interleave": "bil",
     }
+    output_metadata["band names"] = [
+        full_statevector[i] for i in range(len(full_idx_surf_rfl))
+    ]
     bbl = "{" + ",".join([f"{x}" for x in outside_ret_windows]) + "}"
     num_bands = len(full_idx_surf_rfl)
-    band_names = [full_statevector[i] for i in range(len(full_idx_surf_rfl))]
     engine_name = config.forward_model.radiative_transfer.radiative_transfer_engines[
         0
     ].engine_name
@@ -201,20 +203,21 @@ def analytical_line(
         (rdns[0], num_bands, rdns[1]),
         bands=f"{num_bands}",
         bbl=bbl,
-        band_names=band_names,
         description=(
             f"L2A Analytical per-pixel surface retrieval (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
         ),
     )
 
     # Construct surf rfl uncertainty output
+    output_metadata["band names"] = [
+        full_statevector[i] for i in range(len(full_idx_surf_rfl))
+    ]
     unc_output = initialize_output(
         output_metadata,
         analytical_rfl_unc_path,
         (rdns[0], num_bands, rdns[1]),
         bands=f"{num_bands}",
         bbl=bbl,
-        band_names=band_names,
         description=(
             f"L2A Analytical per-pixel surface retrieval uncertainty (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
         ),
@@ -223,7 +226,7 @@ def analytical_line(
     # If there are more idx in surface than rfl, there are non_rfl surface states
     if len(full_idx_surface) > len(full_idx_surf_rfl):
         n_non_rfl_bands = len(full_idx_surface) - len(full_idx_surf_rfl)
-        non_rfl_band_names = [
+        output_metadata["band names"] = [
             full_statevector[len(full_idx_surf_rfl) + i] for i in range(n_non_rfl_bands)
         ]
         non_rfl_output = initialize_output(
@@ -231,7 +234,6 @@ def analytical_line(
             analytical_non_rfl_surf_file,
             (rdns[0], n_non_rfl_bands, rdns[1]),
             bands=f"{n_non_rfl_bands}",
-            band_names=non_rfl_band_names,
             description=(
                 f"L2A Analytical per-pixel non_rfl surface retrieval  (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
             ),
@@ -242,7 +244,6 @@ def analytical_line(
             analytical_non_rfl_surf_unc_file,
             (rdns[0], n_non_rfl_bands, rdns[1]),
             bands=f"{n_non_rfl_bands}",
-            band_names=non_rfl_band_names,
             description=(
                 f"L2A Analytical per-pixel non_rfl surface retrieval uncertainty  (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
             ),

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -80,6 +80,7 @@ def analytical_line(
     loglevel: str = "INFO",
     logfile: str = None,
     initializer: str = "algebraic",
+    segmentation_size: int = 40,
 ) -> None:
     """
     TODO: Description
@@ -183,6 +184,9 @@ def analytical_line(
     bbl = "{" + ",".join([f"{x}" for x in outside_ret_windows]) + "}"
     num_bands = len(full_idx_surf_rfl)
     band_names = [full_statevector[i] for i in range(len(full_idx_surf_rfl))]
+    engine_name = config.forward_model.radiative_transfer.radiative_transfer_engines[
+        0
+    ].engine_name
     rfl_output = initialize_output(
         {
             "data type": 4,
@@ -200,7 +204,11 @@ def analytical_line(
         wavelength=wl_init,
         wavelength_unts="Nanometers",
         fwhm=fwhm_init,
-        description=("L2A Analytyical per-pixel surface retrieval"),
+        isofit_version=config.implementation.isofit_version,
+        engine_name=engine_name,
+        description=(
+            f"L2A Analytical per-pixel surface retrieval (segmentation_size={segmentation_size})"
+        ),
     )
 
     # Construct surf rfl uncertainty output
@@ -221,7 +229,11 @@ def analytical_line(
         wavelength=wl_init,
         wavelength_unts="Nanometers",
         fwhm=fwhm_init,
-        description=("L2A Analytyical per-pixel surface retrieval uncertainty"),
+        isofit_version=config.implementation.isofit_version,
+        engine_name=engine_name,
+        description=(
+            f"L2A Analytical per-pixel surface retrieval uncertainty (segmentation_size={segmentation_size})"
+        ),
     )
 
     # If there are more idx in surface than rfl, there are non_rfl surface states
@@ -243,7 +255,11 @@ def analytical_line(
             bands=f"{n_non_rfl_bands}",
             interleave="bil",
             band_names=non_rfl_band_names,
-            description=("L2A Analytyical per-pixel non_rfl surface retrieval"),
+            isofit_version=config.implementation.isofit_version,
+            engine_name=engine_name,
+            description=(
+                f"L2A Analytical per-pixel non_rfl surface retrieval  (segmentation_size={segmentation_size})"
+            ),
         )
 
         non_rfl_unc_output = initialize_output(
@@ -259,8 +275,10 @@ def analytical_line(
             bands=f"{n_non_rfl_bands}",
             interleave="bil",
             band_names=non_rfl_band_names,
+            isofit_version=config.implementation.isofit_version,
+            engine_name=engine_name,
             description=(
-                "L2A Analytyical per-pixel non_rfl surface retrieval uncertainty"
+                f"L2A Analytical per-pixel non_rfl surface retrieval uncertainty  (segmentation_size={segmentation_size})"
             ),
         )
     else:

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -205,7 +205,7 @@ def analytical_line(
         wavelength_unts="Nanometers",
         fwhm=fwhm_init,
         isofit_version=config.implementation.isofit_version,
-        engine_name=engine_name,
+        engine=engine_name,
         description=(
             f"L2A Analytical per-pixel surface retrieval (segmentation_size={segmentation_size})"
         ),

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -180,7 +180,6 @@ def analytical_line(
         "file type": "ENVI Standard",
         "byte order": 0,
         "no data value": -9999,
-        "map info": "{" + ", ".join(map(str, rdn_meta["map info"])) + "}",
         "wavelength units": "Nanometers",
         "wavelength": wl_init,
         "fwhm": fwhm_init,
@@ -188,6 +187,11 @@ def analytical_line(
         "samples": rdn_meta["samples"],
         "interleave": "bil",
     }
+    if "map info" in rdn_meta:
+        output_metadata["map info"] = (
+            "{" + ", ".join(map(str, rdn_meta["map info"])) + "}"
+        )
+
     output_metadata["band names"] = [
         full_statevector[i] for i in range(len(full_idx_surf_rfl))
     ]

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -174,13 +174,13 @@ def analytical_line(
     rdn_meta = rdn_ds.metadata
     del rdn_ds
 
-    output_metadata = {
-        "lines": rdn_meta["lines"],
-        "samples": rdn_meta["samples"],
-        "bands": rdn_meta["bands"],
-    }
-
     # Construct surf rfl output
+    output_metadata = {
+        "data type": 4,
+        "file type": "ENVI Standard",
+        "byte order": 0,
+        "no data value": -9999,
+    }
     bbl = "{" + ",".join([f"{x}" for x in outside_ret_windows]) + "}"
     num_bands = len(full_idx_surf_rfl)
     band_names = [full_statevector[i] for i in range(len(full_idx_surf_rfl))]
@@ -189,13 +189,10 @@ def analytical_line(
     ].engine_name
     isofit_version = config.implementation.isofit_version
     rfl_output = initialize_output(
-        {
-            "data type": 4,
-            "file type": "ENVI Standard",
-            "byte order": 0,
-        },
+        output_metadata,
         analytical_rfl_path,
         (rdns[0], num_bands, rdns[1]),
+        map_info=rdn_meta["map_info"],
         lines=rdn_meta["lines"],
         samples=rdn_meta["samples"],
         bands=f"{num_bands}",
@@ -212,13 +209,10 @@ def analytical_line(
 
     # Construct surf rfl uncertainty output
     unc_output = initialize_output(
-        {
-            "data type": 4,
-            "file type": "ENVI Standard",
-            "byte order": 0,
-        },
+        output_metadata,
         analytical_rfl_unc_path,
         (rdns[0], num_bands, rdns[1]),
+        map_info=rdn_meta["map_info"],
         lines=rdn_meta["lines"],
         samples=rdn_meta["samples"],
         bands=f"{num_bands}",
@@ -242,13 +236,10 @@ def analytical_line(
             full_statevector[len(full_idx_surf_rfl) + i] for i in range(n_non_rfl_bands)
         ]
         non_rfl_output = initialize_output(
-            {
-                "data type": 4,
-                "file type": "ENVI Standard",
-                "byte order": 0,
-            },
+            output_metadata,
             analytical_non_rfl_surf_file,
             (rdns[0], n_non_rfl_bands, rdns[1]),
+            map_info=rdn_meta["map_info"],
             lines=rdn_meta["lines"],
             samples=rdn_meta["samples"],
             bands=f"{n_non_rfl_bands}",
@@ -262,13 +253,10 @@ def analytical_line(
         )
 
         non_rfl_unc_output = initialize_output(
-            {
-                "data type": 4,
-                "file type": "ENVI Standard",
-                "byte order": 0,
-            },
+            output_metadata,
             analytical_non_rfl_surf_unc_file,
             (rdns[0], n_non_rfl_bands, rdns[1]),
+            map_info=rdn_meta["map_info"],
             lines=rdn_meta["lines"],
             samples=rdn_meta["samples"],
             bands=f"{n_non_rfl_bands}",

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -187,6 +187,7 @@ def analytical_line(
     engine_name = config.forward_model.radiative_transfer.radiative_transfer_engines[
         0
     ].engine_name
+    isofit_version = config.implementation.isofit_version
     rfl_output = initialize_output(
         {
             "data type": 4,
@@ -204,10 +205,8 @@ def analytical_line(
         wavelength=wl_init,
         wavelength_unts="Nanometers",
         fwhm=fwhm_init,
-        isofit_version=config.implementation.isofit_version,
-        engine=engine_name,
         description=(
-            f"L2A Analytical per-pixel surface retrieval (segmentation_size={segmentation_size})"
+            f"L2A Analytical per-pixel surface retrieval (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
         ),
     )
 
@@ -232,7 +231,7 @@ def analytical_line(
         isofit_version=config.implementation.isofit_version,
         engine_name=engine_name,
         description=(
-            f"L2A Analytical per-pixel surface retrieval uncertainty (segmentation_size={segmentation_size})"
+            f"L2A Analytical per-pixel surface retrieval uncertainty (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
         ),
     )
 
@@ -258,7 +257,7 @@ def analytical_line(
             isofit_version=config.implementation.isofit_version,
             engine_name=engine_name,
             description=(
-                f"L2A Analytical per-pixel non_rfl surface retrieval  (segmentation_size={segmentation_size})"
+                f"L2A Analytical per-pixel non_rfl surface retrieval  (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
             ),
         )
 
@@ -278,7 +277,7 @@ def analytical_line(
             isofit_version=config.implementation.isofit_version,
             engine_name=engine_name,
             description=(
-                f"L2A Analytical per-pixel non_rfl surface retrieval uncertainty  (segmentation_size={segmentation_size})"
+                f"L2A Analytical per-pixel non_rfl surface retrieval uncertainty  (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
             ),
         )
     else:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -831,6 +831,7 @@ def apply_oe(
                 isofit_config=paths.isofit_full_config_path,
                 nneighbors=nneighbors[0],
                 n_cores=n_cores,
+                segmentation_size=segmentation_size,
             )
         elif analytical_line:
             logging.info("Analytical line inference")

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -847,6 +847,7 @@ def apply_oe(
                 n_atm_neighbors=nneighbors,
                 n_cores=n_cores,
                 smoothing_sigma=atm_sigma,
+                segmentation_size=segmentation_size,
             )
 
     logging.info("Done.")

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -487,6 +487,11 @@ def empirical_line(
     output_metadata = input_radiance_img.metadata
     output_metadata["interleave"] = "bil"
     output_metadata["isofit_version"] = iconfig.implementation.isofit_version
+    output_metadata["engine"] = (
+        iconfig.forward_model.radiative_transfer.radiative_transfer_engines[
+            0
+        ].engine_name
+    )
     output_metadata["description"] = (
         f"L2A empirical line per-pixel surface retrieval (segmentation_size={segmentation_size})"
     )

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -32,7 +32,7 @@ from spectral.io import envi
 from isofit import ray
 from isofit.configs import configs
 from isofit.core.common import envi_header
-from isofit.core.fileio import write_bil_chunk
+from isofit.core.fileio import write_bil_chunk, initialize_output
 from isofit.core.instrument import Instrument
 
 
@@ -486,6 +486,7 @@ def empirical_line(
     # Create output files
     output_metadata = input_radiance_img.metadata
     output_metadata["interleave"] = "bil"
+    output_metadata["wavelength_unts"] = "Nanometers"
     isofit_version = iconfig.implementation.isofit_version
     engine_name = iconfig.forward_model.radiative_transfer.radiative_transfer_engines[
         0
@@ -493,18 +494,11 @@ def empirical_line(
     output_metadata["description"] = (
         f"L2A empirical line per-pixel surface retrieval (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
     )
-    output_reflectance_img = envi.create_image(
-        envi_header(output_reflectance_file),
-        ext="",
-        metadata=output_metadata,
-        force=True,
+    output_reflectance_img = initialize_output(
+        output_metadata, output_reflectance_file, (nll, nlb, nls)
     )
-
-    output_uncertainty_img = envi.create_image(
-        envi_header(output_uncertainty_file),
-        ext="",
-        metadata=output_metadata,
-        force=True,
+    output_uncertainty_img = initialize_output(
+        output_metadata, output_uncertainty_file, (nll, nlb, nls)
     )
 
     # Now cleanup inputs and outputs, we'll write dynamically above

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -486,14 +486,12 @@ def empirical_line(
     # Create output files
     output_metadata = input_radiance_img.metadata
     output_metadata["interleave"] = "bil"
-    output_metadata["isofit_version"] = iconfig.implementation.isofit_version
-    output_metadata["engine"] = (
-        iconfig.forward_model.radiative_transfer.radiative_transfer_engines[
-            0
-        ].engine_name
-    )
+    isofit_version = iconfig.implementation.isofit_version
+    engine_name = iconfig.forward_model.radiative_transfer.radiative_transfer_engines[
+        0
+    ].engine_name
     output_metadata["description"] = (
-        f"L2A empirical line per-pixel surface retrieval (segmentation_size={segmentation_size})"
+        f"L2A empirical line per-pixel surface retrieval (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
     )
     output_reflectance_img = envi.create_image(
         envi_header(output_reflectance_file),

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -366,6 +366,7 @@ def empirical_line(
     isofit_config: str = None,
     n_cores: int = -1,
     reference_class_file: str = None,
+    segmentation_size: int = 40,
 ) -> None:
     """
     Perform an empirical line interpolation for reflectance and uncertainty extrapolation
@@ -388,6 +389,7 @@ def empirical_line(
         isofit_config: path to isofit configuration JSON file
         n_cores: number of cores to run on
         reference_class_file: optional source file for sub-type-classifications, in order: [base, cloud, water]
+        segmentation_size: Number of super pixels
     Returns:
         None
     """
@@ -472,9 +474,22 @@ def empirical_line(
     if nll != n_input_lines or nlb != 3 or nls != n_input_samples:
         raise IndexError("Input location dimension mismatch")
 
+    # setup config
+    if isofit_config is not None:
+        iconfig = configs.create_new_config(isofit_config)
+    else:
+        # If none, create a temporary config to get default ray parameters
+        iconfig = configs.Config({})
+    if n_cores == -1:
+        n_cores = iconfig.implementation.n_cores
+
     # Create output files
     output_metadata = input_radiance_img.metadata
     output_metadata["interleave"] = "bil"
+    output_metadata["isofit_version"] = iconfig.implementation.isofit_version
+    output_metadata["description"] = (
+        f"L2A empirical line per-pixel surface retrieval (segmentation_size={segmentation_size})"
+    )
     output_reflectance_img = envi.create_image(
         envi_header(output_reflectance_file),
         ext="",
@@ -501,13 +516,6 @@ def empirical_line(
 
     # Initialize ray cluster
     start_time = time.time()
-    if isofit_config is not None:
-        iconfig = configs.create_new_config(isofit_config)
-    else:
-        # If none, create a temporary config to get default ray parameters
-        iconfig = configs.Config({})
-    if n_cores == -1:
-        n_cores = iconfig.implementation.n_cores
     rayargs = {
         "ignore_reinit_error": iconfig.implementation.ray_ignore_reinit_error,
         "local_mode": n_cores == 1,

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -30,6 +30,7 @@ from isofit.core.multistate import SurfaceMapping
 from isofit.data import env
 from isofit.radiative_transfer.engines.modtran import ModtranRT
 from isofit.utils.surface_model import surface_model
+from isofit import __version__
 
 
 class Pathnames:
@@ -766,6 +767,8 @@ def build_presolve_config(
             "inversion": {"windows": inversion_windows},
             "n_cores": n_cores,
             "debug_mode": debug,
+            "segmentation_size": spectra_per_inversion,
+            "ISOFIT version": __version__,
         },
     }
 
@@ -1089,6 +1092,7 @@ def build_main_config(
             "n_cores": n_cores,
             "debug_mode": debug,
             "segmentation_size": spectra_per_inversion,
+            "ISOFIT version": __version__,
         },
     }
 

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1088,6 +1088,7 @@ def build_main_config(
             "inversion": {"windows": inversion_windows},
             "n_cores": n_cores,
             "debug_mode": debug,
+            "segmentation_size": spectra_per_inversion,
         },
     }
 

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -767,8 +767,7 @@ def build_presolve_config(
             "inversion": {"windows": inversion_windows},
             "n_cores": n_cores,
             "debug_mode": debug,
-            "segmentation_size": spectra_per_inversion,
-            "ISOFIT version": __version__,
+            "isofit_version": __version__,
         },
     }
 
@@ -1091,8 +1090,7 @@ def build_main_config(
             "inversion": {"windows": inversion_windows},
             "n_cores": n_cores,
             "debug_mode": debug,
-            "segmentation_size": spectra_per_inversion,
-            "ISOFIT version": __version__,
+            "isofit_version": __version__,
         },
     }
 


### PR DESCRIPTION
Adds segmentation size, method (AL vs EL vs per-pixel) , and ISOIFIT version to ENVI hdr `description` (addressing #270 ). Also, this addresses #784 by ensuring we follow ENVI conventions within the hdr outputs. 

Another byproduct of this was finding/fixing just a few inconsistencies of how we write outputs.

Isofit version is also added to main isofit json under implementation config.

