### PR TITLE
FileResources Exception Handling

### DIFF
--- a/isofit/debug/resource_tracker.py
+++ b/isofit/debug/resource_tracker.py
@@ -1,5 +1,6 @@
 import atexit
 import json
+import logging
 import os
 import threading
 import time


### PR DESCRIPTION
When the main process dies (like due to an exception), the resources file handler may become closed but the thread still attempting to write to it which raises another exception.