### PR TITLE
a marginally better way to do svd_inv_sqrt for when eigenvalues are near zero

### DIFF
--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -300,7 +300,6 @@ def svd_inv_sqrt(
             return hashtable[h]
 
     # Default to using numpy eigh (which uses LAPACK evd driver by default).
-    # In testing, this was found to be more reliable and faster than `evr` for Sa inversion.
     try:
         D, P = np.linalg.eigh(C)
     except:

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -26,7 +26,6 @@ from os.path import expandvars
 from typing import List
 
 import numpy as np
-import scipy.linalg
 
 # sc Adding in xarray for non-gauss SRF file io
 import xarray as xr
@@ -300,7 +299,8 @@ def svd_inv_sqrt(
         if h in hashtable:
             return hashtable[h]
 
-    # Default to using numpy eigh (evd driver), in testing this was ~4-5% faster than evr driver.
+    # Default to using numpy eigh (which uses LAPACK evd driver by default). 
+    # In testing, this was found to be more reliable and faster than `evr` for Sa inversion.
     try:
         D, P = np.linalg.eigh(C)
     except:

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -300,19 +300,27 @@ def svd_inv_sqrt(
         if h in hashtable:
             return hashtable[h]
 
-    D, P = scipy.linalg.eigh(C)
+    D, P = scipy.linalg.eigh(C, driver="evr")
     for count in range(3):
         if np.any(D < 0) or np.any(np.isnan(D)):
             inv_eps = 1e-6 * (count - 1) * 10
-            D, P = scipy.linalg.eigh(C + np.diag(np.ones(C.shape[0]) * inv_eps))
+            D, P = scipy.linalg.eigh(
+                C + np.diag(np.ones(C.shape[0]) * inv_eps), driver="evr"
+            )
+
+            if count == 2:
+                try:
+                    # Before failing, try one more time defaulting to evd.
+                    D, P = np.linalg.eigh(C, driver="evd")
+                    if np.any(D < 0) or np.any(np.isnan(D)):
+                        break
+                except:
+                    raise ValueError(
+                        "Matrix inversion contains negative values,"
+                        + " even after adding {} to the diagonal.".format(inv_eps)
+                    )
         else:
             break
-
-        if count == 2:
-            raise ValueError(
-                "Matrix inversion contains negative values,"
-                + "even after adding {} to the diagonal.".format(inv_eps)
-            )
 
     Ds = np.diag(1 / np.sqrt(D))
     L = P @ Ds

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -299,24 +299,25 @@ def svd_inv_sqrt(
         if h in hashtable:
             return hashtable[h]
 
-    # Default to using numpy eigh (which uses LAPACK evd driver by default). 
+    # Default to using numpy eigh (which uses LAPACK evd driver by default).
     # In testing, this was found to be more reliable and faster than `evr` for Sa inversion.
     try:
         D, P = np.linalg.eigh(C)
     except:
         D, P = None, None
 
-    # Sanity check for edge cases that we encounter with negative eigen values.
-    # adding constant to diagonal, inv_eps.
+    # Sanity check for edge cases that we encounter with negative eigen values, and we offset by inv_eps.
+    inv_eps_checks = [1e-6, 1e-5, 1e-4]
+    inv_eps = None
     if D is None or np.any(D < 0) or np.any(np.isnan(D)):
-        inv_eps = 1e-5
-        try:
-            D, P = np.linalg.eigh(C + np.diag(np.ones(C.shape[0]) * inv_eps))
-        except:
-            D, P = None, None
-
-        # NOTE: this used to be a loop, but now assumes some fixed inv_eps as a fallback
-        if D is None or np.any(D < 0) or np.any(np.isnan(D)):
+        for inv_eps in inv_eps_checks:
+            try:
+                D, P = np.linalg.eigh(C + np.eye(C.shape[0]) * inv_eps)
+                if not (np.any(D < 0) or np.any(np.isnan(D))):
+                    break
+            except:
+                continue
+        else:
             raise ValueError(
                 "Matrix inversion contains negative values, "
                 + "even after adding {} to the diagonal.".format(inv_eps)

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -303,7 +303,7 @@ def svd_inv_sqrt(
     D, P = scipy.linalg.eigh(C, driver="evr")
     for count in range(3):
         if np.any(D < 0) or np.any(np.isnan(D)):
-            inv_eps = 1e-6 * (count - 1) * 10
+            inv_eps = 1e-6 * (count + 1) * 10
             D, P = scipy.linalg.eigh(
                 C + np.diag(np.ones(C.shape[0]) * inv_eps), driver="evr"
             )
@@ -311,7 +311,7 @@ def svd_inv_sqrt(
             if count == 2:
                 try:
                     # Before failing, try one more time defaulting to evd.
-                    D, P = np.linalg.eigh(C, driver="evd")
+                    D, P = np.linalg.eigh(C)
                     if np.any(D < 0) or np.any(np.isnan(D)):
                         break
                 except:

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -88,7 +88,7 @@ def segment_chunk(
 
     mu = x[use, :].mean(axis=0)
     C = np.cov(x[use, :], rowvar=False)
-    [v, d] = scipy.linalg.eigh(C)
+    [v, d] = scipy.linalg.eigh(C, driver="evr")
 
     # Determine segmentation compactness scaling based on eigenvalues
     # Override with a floor value to prevent zeros


### PR DESCRIPTION
Testing water pixels from AVIRIS-NG from a Greenland Arc6 acquisition, I found some dark pixels that would give a LinAlgError that could be traced back to inverting Sa matrix. Digging in a little bit, it seemed that it was caused by machine precision of eigenvalues near zero. Interestingly, altering the drivers fixes this (by default `scipy.linalg.eigh` has [LAPACK driver=`evr`](https://www.netlib.org/lapack/lug/node30.html)). 


- The alternative driver `evd` is actually ~5% faster on trials (n=598pix; 15 trials), when comparing the total inversion time for an AVIRIS-NG sample. Tests were carried out by swapping out scipy vs. numpy implementations in updated svd_inv_sqrt() contained in this PR.

- Testing on EMIT sample (n=94,620pix; March 2025 in Sierras), `evd` is ~10% faster.  With `evd` = 0.161 sec/spectra/core,  and `evr`= 0.177 sec/spectra/core . Resulting rfl were essentially the same, mean RMSD across all samples ~ 0.00001 (max RMSD=0.037 ; 95th Percentile RMSD=0.00003). Spectra of max RMSD shown below:

<img width="1136" height="483" alt="Screenshot 2025-10-14 at 11 31 02" src="https://github.com/user-attachments/assets/7f529b44-c1b9-418a-950e-dbaaa3a813c1" />



--

Therefore, a marginal improvement to svd_inv_sqrt() could be to just have it compute using `evd` which may be less prone to error when eigenvalues are near zero, plus offering a slight speed boost for our usecase. Note: [numpy uses evd by default](https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigh.html#numpy.linalg.eigh) e.g., 

``` python
# equivalent to scipy.linalg.eigh(C, driver="evd")
D, P = np.linalg.eigh(C)

```

Notably, the speed differences are fairly wide ranging, suggesting it could also vary as a function of size of the square matrix to invert. Reading briefly there may be a trade off for some inverse problems and amount of RAM available  ([see LAPACK docs](https://www.netlib.org/lapack/lug/node48.html#subseccompsep), [scipy notes](https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.linalg.eigh.html)). 

