### PR TITLE
Resources Memory Split

### DIFF
--- a/isofit/debug/resource_tracker.py
+++ b/isofit/debug/resource_tracker.py
@@ -319,7 +319,7 @@ class ResourceTracker:
                     sum([p["mem_actual"] for p in children]) + info["mem_actual"]
                 )
                 info["mem_app_shared_avg"] = (
-                    sum([p["mem_actual"] for p in children]) + info["mem_shared"]
+                    sum([p["mem_shared"] for p in children]) + info["mem_shared"]
                 )
                 info["mem_app_shared_avg"] /= len(children) + 1
 


### PR DESCRIPTION
Refactored the memory tracking to split private and shared memory apart per process in order to better capture actual memory usage. Given we leverage ray shared memory extensively, the current implementation overestimates the total memory usage due to each child process representing shared memory as part of its total memory.

Additionally, the definitions of all memory values for processes has been updated to clarify these are approximates simply due to the accuracy of `psutil` itself

- `mem_used` split into three:
  - `mem_actual` - private memory of the process
  - `mem_shared` - shared memory of the process
  - `mem_total` - private + shared total
- Renamed `mem_total` -> `sys_mem_total` to differentiate with process `mem_total`
- Updated summary stats:
  - `mem_app_actual` - Sum of all `mem_actual`
  - `mem_app_shared_avg` - Sum of all `mem_shared` divided by number of children + 1 (main process)
  - `mem_app_total` - Sum of all `mem_total`

Sister PR: https://github.com/isofit/isofit-plots/pull/18