### PR TITLE
Heuristic H2O based on continuum removal rather than ratio

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -124,16 +124,16 @@ def heuristic_atmosphere(
             vals = np.interp(wl[blo:bhi], [wl_lo, wl_hi], [r[blo], r[bhi]])
 
             # Minimize the absolute distance between the continuum removed
-            D = np.sum(np.abs(vals - r[blo:bhi]))
+            D = np.sum(vals - r[blo:bhi])
 
             areas.append(D)
             h2os.append(h2o)
 
         # Finally, interpolate to determine the actual water vapor level that
         # would optimize the continuum-relative correction
-        p = interp1d(h2os, areas)
-        bounds = (h2os[0] + 0.001, h2os[-1] - 0.001)
-        best = min1d(lambda h: p(h), bounds=bounds, method="bounded")
+        p = interp1d(h2o_grid, areas)
+        bounds = (h2o_grid[0] + 0.001, h2o_grid[-1] - 0.001)
+        best = min1d(lambda h: abs(p(h)), bounds=bounds, method="bounded")
         x_new[ind_sv] = best.x
 
     return x_new

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -131,8 +131,8 @@ def heuristic_atmosphere(
 
         # Finally, interpolate to determine the actual water vapor level that
         # would optimize the continuum-relative correction
-        p = interp1d(h2o_grid, areas)
-        bounds = (h2o_grid[0] + 0.001, h2o_grid[-1] - 0.001)
+        p = interp1d(h2os, areas)
+        bounds = (h2os[0] + 0.001, h2os[-1] - 0.001)
         best = min1d(lambda h: abs(p(h)), bounds=bounds, method="bounded")
         x_new[ind_sv] = best.x
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -120,12 +120,13 @@ def heuristic_atmosphere(
             )
             r = fm.surface.fit_params(r, geom)[fm.idx_surf_rfl]
 
-            # Following Kokaly and Clark, 1999
+            # Simple linear interpolation
             vals = np.interp(wl[blo:bhi], [wl_lo, wl_hi], [r[blo], r[bhi]])
-            D = 1 - (r[blo:bhi] / vals)
-            Dn = 1 - (r[bcenter] / vals[bcenter - blo])
 
-            areas.append(np.sum(D * Dn))
+            # Minimize the absolute distance between the continuum removed
+            D = np.abs(vals - r[blo:bhi])
+
+            areas.append(np.sum(D))
             h2os.append(h2o)
 
         # Finally, interpolate to determine the actual water vapor level that

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -69,7 +69,7 @@ def heuristic_atmosphere(
     bhi = np.argmin(abs(wl - wl_hi))
 
     offset = 5  # nm
-    if not (any(fm.RT.wl > (blo - offset)) and any(fm.RT.wl < (bhi + offset))):
+    if not (any(fm.RT.wl > (wl_lo - offset)) and any(fm.RT.wl < (wl_hi + offset))):
         logging.warning(
             "Continuum wl block not found in forward model wavelengths, "
             "returning input x_RT."
@@ -128,7 +128,8 @@ def heuristic_atmosphere(
             # Following Kokaly and Clark, 1999
             vals = np.interp(wl[blo:bhi], [wl_lo, wl_hi], [r[blo], r[bhi]])
             D = 1 - (r[blo:bhi] / vals)
-            Dn = 1 - (r[bcenter] / vals[center - blo])
+            Dn = 1 - (r[bcenter] / vals[bcenter - blo])
+
             areas.append(np.sum(D * Dn))
             h2os.append(h2o)
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -101,7 +101,7 @@ def heuristic_atmosphere(
         # calculating the band ratio that we would see if this were the
         # atmospheric H2O content.  It assumes that defaults for all other
         # atmospheric parameters (such as aerosol, if it is there).
-        for h2o in np.unique(my_RT.lut_grid[h2oname]):
+        for h2o in my_RT.lut_grid[h2oname]:
             # Get Atmospheric terms at high spectral resolution
             x_RT_2 = x_RT.copy()
             x_RT_2[ind_sv] = h2o
@@ -124,9 +124,9 @@ def heuristic_atmosphere(
             vals = np.interp(wl[blo:bhi], [wl_lo, wl_hi], [r[blo], r[bhi]])
 
             # Minimize the absolute distance between the continuum removed
-            D = np.abs(vals - r[blo:bhi])
+            D = np.sum(np.abs(vals - r[blo:bhi]))
 
-            areas.append(np.sum(D))
+            areas.append(D)
             h2os.append(h2o)
 
         # Finally, interpolate to determine the actual water vapor level that

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -18,7 +18,6 @@
 # Author: David R Thompson, david.r.thompson@jpl.nasa.gov
 from __future__ import annotations
 
-import logging
 import os
 from typing import OrderedDict
 
@@ -70,10 +69,6 @@ def heuristic_atmosphere(
 
     offset = 5  # nm
     if not (any(fm.RT.wl > (wl_lo - offset)) and any(fm.RT.wl < (wl_hi + offset))):
-        logging.warning(
-            "Continuum wl block not found in forward model wavelengths, "
-            "returning input x_RT."
-        )
         return x_RT
 
     x_new = x_RT.copy()

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -101,7 +101,7 @@ def heuristic_atmosphere(
         # calculating the band ratio that we would see if this were the
         # atmospheric H2O content.  It assumes that defaults for all other
         # atmospheric parameters (such as aerosol, if it is there).
-        for h2o in my_RT.lut_grid[h2oname]:
+        for h2o in np.unique(my_RT.lut_grid[h2oname]):
             # Get Atmospheric terms at high spectral resolution
             x_RT_2 = x_RT.copy()
             x_RT_2[ind_sv] = h2o

--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -892,12 +892,19 @@ def extractPoints(ds: xr.Dataset, names: bool = False) -> np.array:
 def extractGrid(ds: xr.Dataset) -> dict:
     """
     Extracts the LUT grid from a Dataset
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        LUT Dataset object. Carried stacked: Dimensions wl, points
+
     """
     grid = {}
     for dim, vals in ds.coords.items():
         if dim in {"wl", "point"}:
             continue
         if len(vals.data.shape) > 0 and vals.data.shape[0] > 1:
+            # Unique call sorts and filters. Faster than unstacking ds.
             grid[dim] = np.unique(vals.data)
     return grid
 

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -45,9 +45,6 @@ class GlintModelSurface(MultiComponentSurface):
         # Numbers from Marcel Koenig; used for prior mean
         self.init.extend([1 / np.pi, 0.02])
 
-        # Special glint bounds
-        rmin, rmax = -0.05, 2.0
-        self.bounds = [[rmin, rmax] for w in self.wl]
         # Gege (2021), WASI user manual
         self.bounds.extend([[0, 10], [0, 10]])
 

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -80,7 +80,7 @@ class MultiComponentSurface(Surface):
             self.mus.append(self.components[i][0][self.idx_ref])
 
         # Variables retrieved: each channel maps to a reflectance model parameter
-        rmin, rmax = 0, 2.0
+        rmin, rmax = -0.05, 2.0
         self.statevec_names = ["RFL_%04i" % int(w) for w in self.wl]
         self.idx_surface = np.arange(len(self.statevec_names))
 


### PR DESCRIPTION
Perform an area-based continuum removal to estimate H2O rather than the ratio.

Band-block to use is moved to the function arguments.


Testing doesn't show a significant difference in processing time.
Test: Running the heuristic_atmosphere call across a subs_level scene (39741 inversions)

`Dev`
INFO:2025-10-20,09:18:46 ||| Estimation complete.  20.62s total, 1927.5133 spectra/s, 128.5009 spectra/s/core

`Update`
INFO:2025-10-20,09:20:53 ||| Estimation complete.  20.72s total, 1917.5451 spectra/s, 127.8363 spectra/s/core
