### PR TITLE
h5py pinning

### DIFF
--- a/isofit/radiative_transfer/luts.py
+++ b/isofit/radiative_transfer/luts.py
@@ -87,7 +87,7 @@ class Create:
             List of zero values. Appends to the current Create.zeros list.
         compression : str, default="zlib"
             Compression method to use to the NetCDF. Check https://unidata.github.io/netcdf4-python/
-            for available options. Currently, must use netCDF4 <= 1.7.2 and h5py <= 3.14.0
+            for available options. Currently, must use h5py <= 3.14.0
         complevel : int, default=None
             Compression to use. Impact and levels vary per method.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "click",
   "dask",
   "h5py <= 3.14.0",
-  "netCDF4 <= 1.7.2",
+  "netCDF4",
   "numpy >= 1.20",
   "pyyaml >= 5.3.2",
   "ray >= 1.2.0",

--- a/recipe/isofit.yml
+++ b/recipe/isofit.yml
@@ -9,7 +9,7 @@ dependencies:
   - click
   - dask
   - h5py<=3.14.0
-  - netCDF4<=1.7.2
+  - netCDF4
   - numpy>=1.20.0
   - pre-commit
   - pytest>=3.5.1


### PR DESCRIPTION
GitHub workflows for the examples and slow tests are currently failing on `python>=3.10` due to issues with the new `3.15` version releases of `h5py` ([https://github.com/h5py/h5py/releases](https://github.com/h5py/h5py/releases)). This PR introduces an `h5py<=3.14.0` pinning to fix this behavior.