### PR TITLE
Adapt docs.yml to isofit.yml.

### DIFF
--- a/recipe/docs.yml
+++ b/recipe/docs.yml
@@ -9,8 +9,8 @@ dependencies:
   - click
   - dask
   - h5py
-  - netCDF4<1.7.1
-  - numpy>=1.20.0,<2.0.0
+  - netCDF4
+  - numpy>=1.20.0
   - pre-commit
   - pytest>=3.5.1
   - python-xxhash<3
@@ -19,7 +19,7 @@ dependencies:
   - scikit-learn>=0.19.1
   - scipy>=1.3.0
   - spectral>=0.19
-  - xarray<2024.1.1
+  - xarray
   - myst-parser
   - sphinx-autoapi
   - sphinx_rtd_theme


### PR DESCRIPTION
The ISOFIT docs build is currently failing on readthedocs due to reaching their 15-minutes time limit while creating the conda environment. This happens because of an outdated `docs.yml` file. This PR adapts it to the `isofit.yml` by removing version pinnings for `netCDF4`, `numpy`, and `xarray`. Local tests confirm that the environment build using `isofit.yml` only takes ~2 minutes.