### PR TITLE
Adjust airplane altitude calculation in LUT generation

### DIFF
--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -246,9 +246,9 @@ class SixSRT(RadiativeTransferEngine):
 
         if "observer_altitude_km" in vals:
             vals["alt"] = min(vals["observer_altitude_km"], 99)
-        
+
         ### ASL to AGL
-        vals["alt"] = max(min(vals["alt"]-vals["elev"], 99),0.01)
+        vals["alt"] = max(min(vals["alt"] - vals["elev"], 99), 0.01)
 
         if "observer_azimuth" in vals:
             vals["viewaz"] = vals["observer_azimuth"]


### PR DESCRIPTION
This change is about the definition of "airplane altitude".

isofit intended to generate LUT with a fixed airplane altitude (asl) which is described as H1ALT in MODTRAN template file.
However, 6S defines the airplane altitude as "above ground level" and internally add ground altitude to the airplane altitude.
This caused simulating atmospheric transfer functions at different airplane altitudes as follows:
<img width="942" height="359" alt="image" src="https://github.com/user-attachments/assets/75a7d214-e5f9-4819-9b72-716ca8a75e00" />
In the above cases, the H1ATL was set to 1.17 km in isofit, but we found that 6S simulated spectra with different airplane altitudes like 1.17, 2.13, and 3.33.

To correct this issue, I have added one line of code in sixs_s.py calculating above ground level by subtracting surface_elevation_km from observer_altitude_km. When the surface_elevation_km was greater than the observer_altitude_km, I set the AGL to its minimum value of 0.01 km.