### PR TITLE
CLI Debugging

### DIFF
--- a/isofit/__main__.py
+++ b/isofit/__main__.py
@@ -173,11 +173,13 @@ class CLI(click.Group):
                         logging.exception(
                             "Isoplots does not appear to be installed, install it via `isofit download plots`"
                         )
+                    else:
+                        logging.exception(
+                            f"Failed to import {cmd_name} from {command}:"
+                        )
             except:
                 if self.debug:
-                    logging.exception(
-                        f"Failed to import {cmd_name} from {command.path}:"
-                    )
+                    logging.exception(f"Failed to import {cmd_name} from {command}:")
 
         return super().get_command(ctx, cmd_name)
 


### PR DESCRIPTION
Caught an edge case where the `--debug` flag on the `isofit` command did nothing when the exception raised was `ModuleNotFoundError` and not caused by isoplot