### PR TITLE
Replace hardcoded AOE hash table size by default value from implementation config

### DIFF
--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -450,7 +450,7 @@ class Worker(object):
 
         self.completed_spectra = 0
         self.hash_table = OrderedDict()
-        self.hash_size = 500
+        self.hash_size = config.implementation.max_hash_table_size
 
         # Can't see any reason to leave these as optional
         self.subs_state_file = subs_state_file


### PR DESCRIPTION
So far, we've been using a default `hash_size` of 50 set by the implementation config, while the `analytical_line` uses a hardcoded size of 500. This could lead into memory errors when running AOE at full core utilization on large clusters. This PR replaces the hardcoded value bei the config default.

Closes #730.