### PR TITLE
x_scale from Jacobian 

### DIFF
--- a/docs/source/custom/best_practices.rst
+++ b/docs/source/custom/best_practices.rst
@@ -154,15 +154,13 @@ We highly recommend the MODTRAN 6.0 radiative transfer model over LibRadTran and
                     "bounds": [ 0.001,  0.5 ],
                     "init": 0.050,
                     "prior_mean": 0.050,
-                    "prior_sigma": 10.0,
-                    "scale": 1
+                    "prior_sigma": 10.0
                 },
                 "H2OSTR": {
                     "bounds": [  1.0, 1.8 ],
                     "init": 1.4,
                     "prior_mean": 1.4,
-                    "prior_sigma": 100.0,
-                    "scale": 0.01
+                    "prior_sigma": 100.0
                 }
             },
             "unknowns": {

--- a/isofit/configs/sections/statevector_config.py
+++ b/isofit/configs/sections/statevector_config.py
@@ -34,9 +34,6 @@ class StateVectorElementConfig(BaseConfigSection):
         self._bounds_type = list()
         self.bounds = [np.nan, np.nan]
 
-        self._scale_type = float
-        self.scale = np.nan
-
         self._prior_mean_type = float
         self.prior_mean = np.nan
 
@@ -110,12 +107,6 @@ class StateVectorConfig(BaseConfigSection):
         for element, name in zip(*self.get_elements()):
             bounds.append(element.bounds)
         return bounds
-
-    def get_all_scales(self):
-        scales = []
-        for element, name in zip(*self.get_elements()):
-            scales.append(element.scale)
-        return scales
 
     def get_all_inits(self):
         inits = []

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -47,7 +47,7 @@ class ForwardModel:
       (2) Radiative Transfer (RT) parameters
       (3) Instrument parameters
 
-    The parameter bounds, scales, initial values, and names are all
+    The parameter bounds, initial values, and names are all
     ordered in this way.  The variable self.statevec contains the name
     of each state vector element, in the proper ordering.
 
@@ -87,10 +87,9 @@ class ForwardModel:
             )
 
         # Build combined vectors from surface, RT, and instrument
-        bounds, scale, init, statevec, bvec, bval = ([] for i in range(6))
+        bounds, init, statevec, bvec, bval = ([] for i in range(5))
         for obj_with_statevec in [self.surface, self.RT, self.instrument]:
             bounds.extend([deepcopy(x) for x in obj_with_statevec.bounds])
-            scale.extend([deepcopy(x) for x in obj_with_statevec.scale])
             init.extend([deepcopy(x) for x in obj_with_statevec.init])
             statevec.extend([deepcopy(x) for x in obj_with_statevec.statevec_names])
 
@@ -98,7 +97,6 @@ class ForwardModel:
             bval.extend([deepcopy(x) for x in obj_with_statevec.bval])
 
         self.bounds = tuple(np.array(bounds).T)
-        self.scale = np.array(scale)
         self.init = np.array(init)
         self.statevec = statevec
         self.nstate = len(self.statevec)

--- a/isofit/core/instrument.py
+++ b/isofit/core/instrument.py
@@ -60,7 +60,6 @@ class Instrument:
         self.fast_resample = config.fast_resample
 
         self.bounds = config.statevector.get_all_bounds()
-        self.scale = config.statevector.get_all_scales()
         self.init = config.statevector.get_all_inits()
         self.prior_mean = np.array(config.statevector.get_all_prior_means())
         self.prior_sigma = np.array(config.statevector.get_all_prior_sigmas())

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -111,7 +111,7 @@ class Inversion:
                 self.fm.bounds[0][self.inds_free],
                 self.fm.bounds[1][self.inds_free],
             ),
-            "x_scale": self.fm.scale[self.inds_free],
+            "x_scale": "jac",
         }
 
         # Update the rest from the config

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -115,18 +115,19 @@ class RadiativeTransfer:
         # initial guesses for each state vector element.  The state
         # vector elements are all free parameters in the RT lookup table,
         # and they all have associated dimensions in the LUT grid.
-        self.bounds, self.scale, self.init = [], [], []
+        self.bounds, self.init = (
+            [],
+            [],
+        )
         self.prior_mean, self.prior_sigma = [], []
 
         for sv, sv_name in zip(*config.statevector.get_elements()):
             self.bounds.append(sv.bounds)
-            self.scale.append(sv.scale)
             self.init.append(sv.init)
             self.prior_sigma.append(sv.prior_sigma)
             self.prior_mean.append(sv.prior_mean)
 
         self.bounds = np.array(self.bounds)
-        self.scale = np.array(self.scale)
         self.init = np.array(self.init)
         self.prior_mean = np.array(self.prior_mean)
         self.prior_sigma = np.array(self.prior_sigma)

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -41,7 +41,6 @@ class Surface:
         self.statevec_names = []
         self.idx_surface = np.arange(len(self.statevec_names))
         self.bounds = np.array([])
-        self.scale = np.array([])
         self.init = np.array([])
         self.bvec = []
         self.bval = np.array([])

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -40,8 +40,6 @@ class GlintModelSurface(MultiComponentSurface):
         self.sky_glint_ind = self.glint_ind
         self.sun_glint_ind = self.glint_ind + 1
 
-        self.scale.extend([1.0, 1.0])
-
         # Numbers from Marcel Koenig; used for prior mean
         self.init.extend([1 / np.pi, 0.02])
 
@@ -63,12 +61,8 @@ class GlintModelSurface(MultiComponentSurface):
         # Change this if you don't want to analytical solve for all the full statevector elements.
         self.analytical_iv_idx = np.arange(len(self.statevec_names))
 
-        self.sun_glint_sigma = (
-            config.sun_glint_prior_sigma * np.array(self.scale[self.sun_glint_ind])
-        ) ** 2
-        self.sky_glint_sigma = (
-            config.sky_glint_prior_sigma * np.array(self.scale[self.sky_glint_ind])
-        ) ** 2
+        self.sun_glint_sigma = config.sun_glint_prior_sigma**2
+        self.sky_glint_sigma = config.sky_glint_prior_sigma**2
 
     def xa(self, x_surface, geom):
         """Mean of prior distribution, calculated at state x."""

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -47,8 +47,6 @@ class LUTSurface(Surface):
          vector element
       - sigma: an array of n prior standard deviations, one for each
          state vector element
-      - scale: an array of n scale values, one for each state vector
-         element
 
     """
 
@@ -66,7 +64,6 @@ class LUTSurface(Surface):
         self.wl = model_dict["wl"][0]
         self.n_wl = len(self.wl)
         self.bounds = self.model_dict["bounds"]
-        self.scale = self.model_dict["scale"][0]
         self.init = self.model_dict["init"][0]
         self.mean = self.model_dict["mean"][0]
         self.sigma = self.model_dict["sigma"][0]

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -88,7 +88,6 @@ class MultiComponentSurface(Surface):
         self.analytical_iv_idx = np.arange(len(self.statevec_names))
 
         self.bounds = [[rmin, rmax] for w in self.wl]
-        self.scale = [1.0 for w in self.wl]
         self.init = [0.15 * (rmax - rmin) + rmin for v in self.wl]
         self.idx_lamb = np.arange(self.n_wl)
         self.n_state = len(self.statevec_names)

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -41,7 +41,6 @@ class ThermalSurface(MultiComponentSurface):
         if "SURF_TEMP_K" not in self.statevec_names:
             self.statevec_names.extend(["SURF_TEMP_K"])
             self.init.extend([300.0])  # This is overwritten below
-            self.scale.extend([100.0])
             self.bounds.extend([[250.0, 400.0]])
         self.idx_surface = np.arange(len(self.statevec_names))
         self.surf_temp_ind = len(self.statevec_names) - 1

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -707,7 +707,6 @@ def build_presolve_config(
                     float(np.min(lut_grid["H2OSTR"])),
                     float(np.max(lut_grid["H2OSTR"])),
                 ],
-                "scale": 0.01,
                 "init": np.percentile(lut_grid["H2OSTR"], 25),
                 "prior_sigma": 100.0,
                 "prior_mean": 1.5,
@@ -1040,7 +1039,6 @@ def build_main_config(
     if h2o_lut_grid is not None:
         radiative_transfer_config["statevector"]["H2OSTR"] = {
             "bounds": [h2o_lut_grid[0], h2o_lut_grid[-1]],
-            "scale": 1,
             "init": (h2o_lut_grid[1] + h2o_lut_grid[-1]) / 2.0,
             "prior_sigma": 100.0,
             "prior_mean": (h2o_lut_grid[1] + h2o_lut_grid[-1]) / 2.0,
@@ -1049,7 +1047,6 @@ def build_main_config(
     if pressure_elevation:
         radiative_transfer_config["statevector"]["surface_elevation_km"] = {
             "bounds": [elevation_lut_grid[0], elevation_lut_grid[-1]],
-            "scale": 100,
             "init": (elevation_lut_grid[0] + elevation_lut_grid[-1]) / 2.0,
             "prior_sigma": 1000.0,
             "prior_mean": (elevation_lut_grid[0] + elevation_lut_grid[-1]) / 2.0,
@@ -1352,7 +1349,6 @@ def load_climatology(
         if aerosol_lut is not None:
             aerosol_state_vector["AERFRAC_{}".format(_a)] = {
                 "bounds": [float(alr[0]), float(alr[1])],
-                "scale": 1,
                 "init": float((alr[1] - alr[0]) / 10.0 + alr[0]),
                 "prior_sigma": 10.0,
                 "prior_mean": float((alr[1] - alr[0]) / 10.0 + alr[0]),
@@ -1372,7 +1368,6 @@ def load_climatology(
         alr = [aerosol_lut_grid["AOT550"][0], aerosol_lut_grid["AOT550"][-1]]
         aerosol_state_vector["AOT550"] = {
             "bounds": [float(alr[0]), float(alr[1])],
-            "scale": 1,
             "init": float((alr[1] - alr[0]) / 10.0 + alr[0]),
             "prior_sigma": 10.0,
             "prior_mean": float((alr[1] - alr[0]) / 10.0 + alr[0]),

--- a/isofit/utils/wavelength_cal.py
+++ b/isofit/utils/wavelength_cal.py
@@ -58,14 +58,12 @@ def add_wavelength_elements(config_path, state_type="shift", spline_indices=[]):
                 "init": 0,
                 "prior_mean": 0,
                 "prior_sigma": 100.0,
-                "scale": 1,
             },
             "WL_SHIFT": {
                 "bounds": [-5, 5],
                 "init": 0,
                 "prior_mean": 0,
                 "prior_sigma": 100.0,
-                "scale": 1,
             },
         }
     elif state_type == "shift-only":
@@ -75,7 +73,6 @@ def add_wavelength_elements(config_path, state_type="shift", spline_indices=[]):
                 "init": 0,
                 "prior_mean": 0,
                 "prior_sigma": 100.0,
-                "scale": 1,
             }
         }
     elif state_type == "spline":
@@ -85,7 +82,6 @@ def add_wavelength_elements(config_path, state_type="shift", spline_indices=[]):
                 "init": 0,
                 "prior_mean": 0,
                 "prior_sigma": 100.0,
-                "scale": 1,
             }
         }
         for spline_index in spline_indices:
@@ -96,7 +92,6 @@ def add_wavelength_elements(config_path, state_type="shift", spline_indices=[]):
                 "init": 0,
                 "prior_mean": 0,
                 "prior_sigma": 100.0,
-                "scale": 1,
             }
     elif state_type == "spline-only":
         for spline_index in spline_indices:
@@ -107,7 +102,6 @@ def add_wavelength_elements(config_path, state_type="shift", spline_indices=[]):
                 "init": 0,
                 "prior_mean": 0,
                 "prior_sigma": 100.0,
-                "scale": 1,
             }
 
     logging.info(f"Writing config update with WL cal parameters to {config_path}")


### PR DESCRIPTION
We currently set `x_scale` for least squares with hard-coded values based on the assumed derivatives and step sizes (at various places in the code: surface, template_construnction, etc). Evidently, the scipy `least_squares` method allows for, `x_scale="jac"`, instead of supplying a pre-determined vector if there is a Jacobian provided as input. This should be fairly low stakes since we use a trust region approach, we have built a fairly reliable Jacobian method at this point,  and would match the literature to ensure scale invariance ([Moré, 2006](https://www.osti.gov/servlets/purl/7256021-WWC9hw/)).

```python
# Set least squares params that come from the forward model
self.least_squares_params = {
    "method": "trf",
    "max_nfev": 20,
    "bounds": (
        self.fm.bounds[0][self.inds_free],
        self.fm.bounds[1][self.inds_free],
    ),
    "x_scale": "jac",
}
```

To test this, I sampled dev vs. this PR for an EMIT scene (n=890pix) and compared the final cost (left) and length of trajectory (right). There was not a significant difference in cost (p=0.58), while there was a statistically significant difference in number of iterations, with `x_scale="jac"` case taking 0.31 more iterations on average (p=0.0002). Perhaps suggesting there could be an ever so-slight drop in speed by using  `x_scale="jac"`. In my tests, I found default had speed of 0.118 sec/inversion, and `x_scale="jac"` had speed of 0.119 sec/inversion (<1% diff).

The best advantage I see here though is that it's one less thing we need to revisit when we make alterations to the forward model. And since all updates impact the Jacobian anyway, we can leverage it in `x_scale` arg ... I'd be curious to hear if there are any other drawbacks to this approach / perhaps flexibility for some use-cases we would lose by a change like this?

<img width="1461" height="496" alt="Screenshot 2025-11-17 at 10 58 37" src="https://github.com/user-attachments/assets/32f90e46-ac16-4c8b-a22c-3db07b7a2b1b" />
