### PR TITLE
Surface distance metrics cleanup

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -79,6 +79,11 @@ class SurfaceConfig(BaseConfigSection):
     def _check_config_validity(self) -> List[str]:
         errors = list()
 
+        if (self.surface_file is None) and not len(self.Surfaces):
+            errors.append(
+                "surface_file not specified. All current supported surface models require surface_file to be provided"
+            )
+
         valid_surface_categories = [
             "surface",
             "multicomponent_surface",
@@ -101,5 +106,34 @@ class SurfaceConfig(BaseConfigSection):
         valid_metrics = ("Euclidean", "Mahalanobis")
         if self.selection_metric not in valid_metrics:
             errors.append(f"surface->selection_metric must be one of: {valid_metrics}")
+
+        # multistate checks
+        if len(self.Surfaces):
+            missing_cats, missing_files, missing_ints = [], [], []
+            for name, sub_surface in self.Surfaces.items():
+                if not sub_surface.get("surface_category"):
+                    missing_cats.append(name)
+                if not sub_surface.get("surface_file"):
+                    missing_files.append(name)
+                if sub_surface.get("surface_int", -1) < 0:
+                    missing_ints.append(name)
+
+            if len(missing_cats):
+                errors.append(
+                    "Multi-surface config given and no "
+                    f"surface-category specified for keys: {missing_cats}"
+                )
+
+            if len(missing_files):
+                errors.append(
+                    "Multi-surface config given and "
+                    f"no surface-file specified for keys: {missing_files}"
+                )
+
+            if len(missing_ints):
+                errors.append(
+                    "Multi-surface config given and no surface-"
+                    f"int mapping specified for keys: {missing_ints}"
+                )
 
         return errors

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -103,7 +103,7 @@ class SurfaceConfig(BaseConfigSection):
                 )
             )
 
-        valid_metrics = ("Euclidean", "Mahalanobis")
+        valid_metrics = ("Euclidean", "Spectral")
         if self.selection_metric not in valid_metrics:
             errors.append(f"surface->selection_metric must be one of: {valid_metrics}")
 

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -103,7 +103,7 @@ class SurfaceConfig(BaseConfigSection):
                 )
             )
 
-        valid_metrics = ("Euclidean", "Spectral")
+        valid_metrics = "Euclidean"
         if self.selection_metric not in valid_metrics:
             errors.append(f"surface->selection_metric must be one of: {valid_metrics}")
 

--- a/isofit/core/multistate.py
+++ b/isofit/core/multistate.py
@@ -267,14 +267,11 @@ def update_config_for_surface(config, surface_class_str, clouds=True):
     isurface = config.forward_model.surface.Surfaces.get(surface_class_str)
 
     if not isurface:
-        raise KeyError("Multi-surface flag used, but no multi-surface config")
+        raise KeyError("Multi-surface flag used, but no valid multi-surface config")
 
     surface_category = isurface.get("surface_category")
     surface_file = isurface.get("surface_file")
     glint_model = isurface.get("glint_model")
-
-    if (not surface_category) or (not surface_file):
-        raise KeyError("Failed to parse multi-surface config")
 
     config.forward_model.surface.surface_category = surface_category
     config.forward_model.surface.surface_file = surface_file

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -135,15 +135,11 @@ class MultiComponentSurface(Surface):
         lamb_ref = lamb[self.idx_ref]
         lamb_ref = lamb_ref / self.norm(lamb_ref)
 
-        # Spectral angle or Euclidean distances
-        if self.selection_metric == "Spectral":
-            mds = self.spectral_angle_distance(lamb_ref, self.mus)
-
-        else:
-            mds = self.euclidean_distance(
-                lamb_ref,
-                np.array(self.mus),
-            )
+        # Only support euclidean distance comparrison for now
+        mds = self.euclidean_distance(
+            lamb_ref,
+            np.array(self.mus),
+        )
 
         closest = np.argmin(mds)
 
@@ -359,12 +355,3 @@ class MultiComponentSurface(Surface):
     @staticmethod
     def euclidean_distance(lamb_ref, mus):
         return np.sum(np.power(lamb_ref[np.newaxis, :] - mus, 2), axis=1)
-
-    @staticmethod
-    def spectral_angle_distance(lamb_ref, mus):
-        # np.arccos(x.dot(ref_mu) / (norm(x) * norm(ref_mu))
-        cos_theta = np.einsum("k,ik->i", lamb_ref, mus) / (
-            np.linalg.norm(lamb_ref) * np.linalg.norm(mus, axis=1)
-        )
-        # Clipping for numerical stability, return radians
-        return np.arccos(np.clip(cos_theta, -1.0, 1.0))

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -103,7 +103,7 @@ class MultiComponentSurface(Surface):
             # Caching the normalized Sa inv and Sa inv sqrt
             Cov_full = block_diag(
                 np.zeros((nprefix, nprefix)),
-                self.components[i][1],
+                self.component_covs[i],
                 np.zeros((nsuffix, nsuffix)),
             )
             Cov_normalized = Cov_full / np.mean(np.diag(Cov_full))

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -129,7 +129,6 @@ def surface_model(
         "wl": wl,
         "means": [],
         "covs": [],
-        "covs_base": [],
         "attribute_means": [],
         "attribute_covs": [],
         "attributes": [],
@@ -389,7 +388,6 @@ def surface_model(
                 raise ValueError("Unrecognized normalization: %s\n" % normalize)
             m = m / z
             C = C / (z**2)
-            C_base = C_base / (z**2)
 
             try:
                 Cinv = svd_inv(C)
@@ -399,7 +397,6 @@ def surface_model(
 
             model["means"].append(m)
             model["covs"].append(C)
-            model["covs_base"].append(C_base)
 
             if len(attributes) > 0:
                 model["attribute_means"].append(m_attr)

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -389,7 +389,6 @@ def surface_model(
                 raise ValueError("Unrecognized normalization: %s\n" % normalize)
             m = m / z
             C = C / (z**2)
-            C_unscaled = C
             C_base = C_base / (z**2)
 
             try:

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -129,6 +129,7 @@ def surface_model(
         "wl": wl,
         "means": [],
         "covs": [],
+        "covs_base": [],
         "attribute_means": [],
         "attribute_covs": [],
         "attributes": [],
@@ -388,6 +389,8 @@ def surface_model(
                 raise ValueError("Unrecognized normalization: %s\n" % normalize)
             m = m / z
             C = C / (z**2)
+            C_unscaled = C
+            C_base = C_base / (z**2)
 
             try:
                 Cinv = svd_inv(C)
@@ -397,6 +400,7 @@ def surface_model(
 
             model["means"].append(m)
             model["covs"].append(C)
+            model["covs_base"].append(C_base)
 
             if len(attributes) > 0:
                 model["attribute_means"].append(m_attr)


### PR DESCRIPTION
This PR "fixes" the Mahalanobis distance method for selecting the surface prior and adds a spectral angle method for surface prior selection.

Some notes:

- Even though the Mahalanobis distance seems like the best metric to use (given that the surface priors are statistical distributions), the direct application of the metric on the sampled distributions doesn't produce great results. This could be because of the sampled distributions are poor representation of the population distributions. What ends up happening is that distributions for water and mixed soil-veg end up being overly selected. The selection can be improved by using only the variance portion of the multivariate Gaussian (off-diagonal -> 0), but this becomes essentially a weighted euclidean distance.
- **This removes the Mahalanobis distance from the methods**
- This also abstracts and vectorizes the "distance" calculations.
- This PR also includes some additions to the surface config checks.



