### PR TITLE
Add file name distinction between 3c and 6c emulator aux files to presolve config build

### DIFF
--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -724,9 +724,14 @@ def build_presolve_config(
             "emulator_file"
         ] = abspath(emulator_base)
 
-        radiative_transfer_config["radiative_transfer_engines"]["vswir"][
-            "emulator_aux_file"
-        ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
+        if multipart_transmittance:
+            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
+                "emulator_aux_file"
+            ] = emulator_base
+        else:
+            radiative_transfer_config["radiative_transfer_engines"]["vswir"][
+                "emulator_aux_file"
+            ] = abspath(os.path.splitext(emulator_base)[0] + "_aux.npz")
 
         radiative_transfer_config["radiative_transfer_engines"]["vswir"][
             "earth_sun_distance_file"
@@ -913,7 +918,6 @@ def build_main_config(
             radiative_transfer_config["radiative_transfer_engines"]["vswir"][
                 "emulator_aux_file"
             ] = emulator_base
-
         else:
             radiative_transfer_config["radiative_transfer_engines"]["vswir"][
                 "emulator_aux_file"


### PR DESCRIPTION
The presolve config build in `template_construction.py` was missing the `if-clause` to distinguish between the different aux file conventions of 3c vs. 6c emulators. This PR fixes the bug.