### PR TITLE
Remove Python 3.9

### DIFF
--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: [3.10", "3.11", "3.12"]
         pytest-flags: ["-m unmarked", "-m slow", "-m examples"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "isofit"
 dynamic = ["version"]
 description = "Imaging Spectrometer Optimal FITting"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["isofit"]
 authors = [
@@ -24,7 +24,6 @@ maintainers = [
 classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Python 3.9 is end of life and no longer getting support. Many packages have begun to drop support for it, and we should too. 