### PR TITLE
Try/except checkNumThreads

### DIFF
--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -37,18 +37,22 @@ def checkNumThreads():
     """
     threads = "unknown"
     error = False
-    if info := threadpool_info():
-        threads = info[0]["num_threads"]
-        if threads > 1:
-            error = "greater than"
-    else:
-        error = "not set to"
+    try:
+        if info := threadpool_info():
+            threads = info[0]["num_threads"]
+            if threads > 1:
+                error = "greater than 1"
+        else:
+            error = "not set to 1"
+    except:
+        Logger.exception("Failed to retrieve threadpool_info")
+        error = "undetected"
 
     if error:
         Logger.warning(
             f"""
 ******************************************************************************************
-! Number of threads is {error} 1 (currently: {threads}), this may greatly impact performance
+! Number of threads is {error} (currently: {threads}), this may greatly impact performance
 ! Please set this the environment variables 'MKL_NUM_THREADS' and 'OMP_NUM_THREADS' to '1'
 ******************************************************************************************\
 """


### PR DESCRIPTION
Simply wrapped the `checkNumThreads` function in a try/except clause to hopefully resolve Windows errors that occur when the OS rejects the `threadpool_info` call