### PR TITLE
missing skyview path in apply_oe

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -614,6 +614,7 @@ def apply_oe(
                 paths.surface_class_subs_path,
                 reducers.class_priority,
             ),
+            (paths.svf_working_path, paths.svf_subs_path, reducers.band_mean),
         ]:
             if inp and not exists(outp):
                 logging.info("Extracting " + outp)


### PR DESCRIPTION
Simple one liner, and restores skyview extraction for superpixel case. This may have gotten lost along the way in recent edits but discovered on one of my tests.