### PR TITLE
Making double negatives in sixs elevation .inp impossible

### DIFF
--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -224,7 +224,7 @@ class SixSRT(RadiativeTransferEngine):
             "O3": 0.30,
             "day": self.engine_config.day,
             "month": self.engine_config.month,
-            "elev": abs(max(self.engine_config.elev, 0.01)),
+            "elev": abs(max(self.engine_config.elev, 0)),
             "alt": min(self.engine_config.alt, 99),
             "atm_file": None,
             "abscf_data_directory": None,
@@ -252,7 +252,7 @@ class SixSRT(RadiativeTransferEngine):
             vals["h2o_mm"] = units.cm_to_mm(vals["H2OSTR"])
 
         if "surface_elevation_km" in vals:
-            vals["elev"] = abs(max(vals["surface_elevation_km"], 0.01))
+            vals["elev"] = abs(max(vals["surface_elevation_km"], 0))
 
         if "observer_altitude_km" in vals:
             vals["alt"] = min(vals["observer_altitude_km"], 99)

--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -252,7 +252,7 @@ class SixSRT(RadiativeTransferEngine):
             vals["h2o_mm"] = units.cm_to_mm(vals["H2OSTR"])
 
         if "surface_elevation_km" in vals:
-            vals["elev"] = abs(vals["surface_elevation_km"])
+            vals["elev"] = abs(max(vals["surface_elevation_km"], 0))
 
         if "observer_altitude_km" in vals:
             vals["alt"] = min(vals["observer_altitude_km"], 99)

--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -224,7 +224,7 @@ class SixSRT(RadiativeTransferEngine):
             "O3": 0.30,
             "day": self.engine_config.day,
             "month": self.engine_config.month,
-            "elev": abs(max(self.engine_config.elev, 0)),
+            "elev": abs(max(self.engine_config.elev, 0.01)),
             "alt": min(self.engine_config.alt, 99),
             "atm_file": None,
             "abscf_data_directory": None,
@@ -252,7 +252,7 @@ class SixSRT(RadiativeTransferEngine):
             vals["h2o_mm"] = units.cm_to_mm(vals["H2OSTR"])
 
         if "surface_elevation_km" in vals:
-            vals["elev"] = abs(max(vals["surface_elevation_km"], 0))
+            vals["elev"] = abs(max(vals["surface_elevation_km"], 0.01))
 
         if "observer_altitude_km" in vals:
             vals["alt"] = min(vals["observer_altitude_km"], 99)

--- a/isofit/radiative_transfer/engines/six_s.py
+++ b/isofit/radiative_transfer/engines/six_s.py
@@ -224,7 +224,7 @@ class SixSRT(RadiativeTransferEngine):
             "O3": 0.30,
             "day": self.engine_config.day,
             "month": self.engine_config.month,
-            "elev": self.engine_config.elev,
+            "elev": abs(max(self.engine_config.elev, 0)),
             "alt": min(self.engine_config.alt, 99),
             "atm_file": None,
             "abscf_data_directory": None,
@@ -252,7 +252,7 @@ class SixSRT(RadiativeTransferEngine):
             vals["h2o_mm"] = units.cm_to_mm(vals["H2OSTR"])
 
         if "surface_elevation_km" in vals:
-            vals["elev"] = vals["surface_elevation_km"]
+            vals["elev"] = abs(vals["surface_elevation_km"])
 
         if "observer_altitude_km" in vals:
             vals["alt"] = min(vals["observer_altitude_km"], 99)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1808,7 +1808,7 @@ def get_metadata_from_loc(
     # Grab zensor position and orientation information
     mean_latitude = np.mean(loc_data[1, valid].flatten())
     mean_longitude = np.mean(-1 * loc_data[0, valid].flatten())
-    mean_elevation_km = units.m_to_km(np.mean(loc_data[2, valid]))
+    mean_elevation_km = max(units.m_to_km(np.mean(loc_data[2, valid])), 0)
 
     # make elevation grid
     min_elev = units.m_to_km(np.min(loc_data[2, valid]))


### PR DESCRIPTION
Would resolve #801

@adamchlus Do you by chance have an example case handy where this occurred. I tried to reproduce locally with some hand constructed configs, but it's hard to know if what I caught covers the initial issue.

I also took the strategy of clipping the elevation before the `abs` call. This is consistent with our treatment of negative surface elevations elsewhere:

L511 of apply_oe.py
```python
 elevation_lut_grid[elevation_lut_grid < 0] = 0
```