### PR TITLE
Use obs time slice copy in template construction

### DIFF
--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1673,7 +1673,7 @@ def get_metadata_from_obs(
     to_sensor_zenith = obs[:, :, 2]
     to_sun_azimuth = obs[:, :, 3]
     to_sun_zenith = obs[:, :, 4]
-    time = obs[:, :, 9]
+    time = obs[:, :, 9].copy()
 
     # calculate relative to-sun azimuth
     delta_phi = np.abs(to_sun_azimuth - to_sensor_azimuth)


### PR DESCRIPTION
This change fixes a crash caused by modifying a read-only view returned from a memory-mapped ENVI dataset. The obs array is opened with `writable=False`, so slicing `obs[:, :, 9]` produces a read-only view, which raises a `ValueError` when updated in place [here](https://github.com/isofit/isofit/blob/dev/isofit/utils/template_construction.py#L1741):

`time[np.logical_and(time < max_flight_duration_h, valid)] += 24`

Creating `time` with `.copy()` ensures it is writable, allowing the time adjustment to proceed safely without mutating the original dataset.