### PR TITLE
AOD Scale Factor

### DIFF
--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1405,7 +1405,7 @@ def load_climatology(
         alr = [aerosol_lut_grid["AOT550"][0], aerosol_lut_grid["AOT550"][-1]]
         aerosol_state_vector["AOT550"] = {
             "bounds": [float(alr[0]), float(alr[1])],
-            "scale": 1,
+            "scale": 0.001,
             "init": float((alr[1] - alr[0]) / 10.0 + alr[0]),
             "prior_sigma": 10.0,
             "prior_mean": float((alr[1] - alr[0]) / 10.0 + alr[0]),


### PR DESCRIPTION

As alluded to in some of our more recent discussions, AOD Scale Factor (used in least squares minimization) likely could be improved by tuning to something other than 1.0. For example, a clear-sky, snow-covered EMIT scene with presolve turned on, produced AOD centered around ~0.4-0.6. This is likely too large for this high altitude site.

[In a previous attempt](https://github.com/isofit/isofit/pull/800), I tried to set scale factor dynamically based on `jac` but this did not work well... I am interested to see if there are other ways we can set this factor based on data. Perhaps leveraging expected derivatives? 

Interestingly, this issue of large AOD values was worse for this image with the presolve turned on. Although I think this change could help both cases.

<img width="989" height="1005" alt="image" src="https://github.com/user-attachments/assets/0cb51211-b714-41e2-874d-8917914b703a" />

Data/Model:
- EMIT 27 March 2025, ran with 6c-exp emulator, with presolve and analytical line turned on.

Also, there appears to be negative values within the atm_interp file which is interesting?
