### PR TITLE
Check for multiple No-Data values in input radiance spectrum

### DIFF
--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -335,14 +335,21 @@ class Worker(object):
             if input_data is not None:
                 nan_locs = np.where(np.isnan(input_data.meas))
                 if len(nan_locs) > 0:
-                    non_nan_locs = np.where(np.isnan(input_data.meas) == False)
-                    interp = scipy.interpolate.interp1d(
-                        self.io.meas_wl[non_nan_locs],
-                        input_data.meas[non_nan_locs],
-                        kind="linear",
-                        fill_value="extrapolate",
-                    )
-                    input_data.meas = interp(self.io.meas_wl)
+                    if len(nan_locs) > 0.25 * len(input_data.meas):
+                        logging.exception(
+                            f"Input data gap >25% for pixel at index ({row}, {col}). "
+                            f"Skipping inversion. Results for this pixel will be all zeros."
+                        )
+                        continue
+                    else:
+                        non_nan_locs = np.where(np.isnan(input_data.meas) == False)
+                        interp = scipy.interpolate.interp1d(
+                            self.io.meas_wl[non_nan_locs],
+                            input_data.meas[non_nan_locs],
+                            kind="linear",
+                            fill_value="extrapolate",
+                        )
+                        input_data.meas = interp(self.io.meas_wl)
 
                 logging.debug("Run model")
                 # The inversion returns a list of states, which are


### PR DESCRIPTION
Updates the catching of No-Data values in the input radiance to reasonably account for large data gaps. The inversion is skipped entirely if more than 25% of the instrument channels hold No-Data instead of physical radiance. This threshold is chosen somewhat arbitrarily, but would cover edge cases like the one mentioned in #799, where one detector of a two detector instrument is missing valid data. Overall, the added if-statement in line 338 will almost never be entered since input data are basically always either completely valid or being flagged as No-Data way beforehand.

Nevertheless, open to any thoughts!

Closes #799 .