### PR TITLE
Tutorials website support

### DIFF
--- a/isofit/data/cli/__init__.py
+++ b/isofit/data/cli/__init__.py
@@ -13,19 +13,24 @@ Modules = {
 Essentials = {name: mod for name, mod in Modules.items() if getattr(mod, "ESSENTIAL")}
 
 
-def forEach(modules, func, **kwargs):
+def forEach(modules, func, exclude=[], **kwargs):
     """
     Executes a function of each loaded module
 
     Parameters
     ----------
+    modules : dict
+        Set of modules to iterate over
     func : str
         Name of the function to invoke from the module
+    exclude : list[str], default=[]
+        Modules to exclude
     **kwargs : dict
         Key-word arguments to pass to the function
     """
     pad = "=" * 16
 
+    modules = {k: v for k, v in modules.items() if k not in exclude}
     for i, module in enumerate(modules.values()):
         print(f"{pad} Beginning {func} {i+1} of {len(modules)} {pad}")
 
@@ -39,6 +44,7 @@ def forEach(modules, func, **kwargs):
 @shared.download.command(name="all")
 @shared.check
 @shared.overwrite
+@shared.exclude
 def download_all(**kwargs):
     """\
     Downloads all ISOFIT extra dependencies to the locations specified in the
@@ -51,6 +57,7 @@ def download_all(**kwargs):
 
 
 @shared.validate.command(name="all")
+@shared.exclude
 def validate_all(**kwargs):
     """\
     Validates all ISOFIT extra dependencies at the locations specified in the

--- a/isofit/data/cli/examples.py
+++ b/isofit/data/cli/examples.py
@@ -4,6 +4,8 @@ Downloads the ISOFIT examples from the repository https://github.com/isofit/isof
 
 from pathlib import Path
 
+import click
+
 from isofit.data import env, shared
 from isofit.data.download import download_file, prepare_output, release_metadata, unzip
 
@@ -211,7 +213,12 @@ def update(check=False, **kwargs):
 @shared.tag
 @shared.overwrite
 @shared.check
-def download_cli(**kwargs):
+@click.option(
+    "--neon",
+    is_flag=True,
+    help="Downloads only the NEON dataset to the examples directory",
+)
+def download_cli(neon, **kwargs):
     """\
     Downloads the ISOFIT examples from the repository https://github.com/isofit/isofit-tutorials.
 
@@ -222,7 +229,10 @@ def download_cli(**kwargs):
         - `isofit download examples --path /path/examples`: Temporarily set the output location. This will not be saved in the ini and may need to be manually set.
     It is recommended to use the first style so the download path is remembered in the future.
     """
-    if kwargs.get("overwrite"):
+    if neon:
+        path = kwargs.get("path", env.examples)
+        download_neon(examples=Path(path))
+    elif kwargs.get("overwrite"):
         download(**kwargs)
     else:
         update(**kwargs)

--- a/isofit/data/shared.py
+++ b/isofit/data/shared.py
@@ -35,3 +35,7 @@ check = click.option(
     help="Only check for updates",
     show_default=True,
 )
+
+exclude = click.option(
+    "-e", "--exclude", multiple=True, help="Exclude products from the function"
+)


### PR DESCRIPTION
Some small tweaks to the downloads CLI that I've wanted for a long time as well as facilitates the installation process for executing the ISOFIT tutorials website.

- Added `--exclude` option to the `isofit download/validate all` commands, so certain products can be ignored instead of needing to manually download only the ones desired
- Added `--neon` flag to `isofit download examples` so that only the NEON data gets downloaded and not the rest of the examples. This is needed for the tutorials website which uses a checkout of main instead of downloading the release