### PR TITLE
Surface component selection improvements

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -103,7 +103,7 @@ class SurfaceConfig(BaseConfigSection):
                 )
             )
 
-        valid_metrics = "Euclidean"
+        valid_metrics = ["Euclidean", "SGA"]
         if self.selection_metric not in valid_metrics:
             errors.append(f"surface->selection_metric must be one of: {valid_metrics}")
 

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -101,6 +101,9 @@ def surface_model(
     normalize = config["normalize"]
     reference_windows = config["reference_windows"]
 
+    # Get selection metric if it exists
+    selection_metric = config.get("selection_metric", "Euclidean")
+
     # load wavelengths file, and change units to nm if needed
     if os.path.splitext(wavelength_file)[-1] == ".hdr":
         ds = envi.open(wavelength_file)
@@ -126,6 +129,7 @@ def surface_model(
     # create basic model template
     model = {
         "normalize": normalize,
+        "selection_metric": selection_metric,
         "wl": wl,
         "means": [],
         "covs": [],


### PR DESCRIPTION
The current Euclidean surface component selection does not accurately match surface types for many water surfaces. This PR is a limited attempt to improve the prior selection.


For a green open water pixel:
<img width="416" height="418" alt="image" src="https://github.com/user-attachments/assets/9bcaf882-149d-49c4-9fec-69402eb7b596" />

Using the EMIT prior libraries, the surface_liquids prior is selected:
<img width="568" height="417" alt="image" src="https://github.com/user-attachments/assets/1a207ad4-47c6-48c6-82be-cc8b9d8193d1" />

With the same reference wavelengths, but using a spectral gradient angle:
<img width="577" height="413" alt="image" src="https://github.com/user-attachments/assets/12b47fe1-59c8-4873-9469-97f06b722bf6" />

Inland water remains challenging from a prior standpoint:

<img width="509" height="414" alt="image" src="https://github.com/user-attachments/assets/e3afadfd-a1ac-4120-b55a-feef3bbd6a8a" />

Is this background? Floating veg? Algae?
<img width="568" height="413" alt="image" src="https://github.com/user-attachments/assets/ed888bb0-0c56-4f96-9664-abc6fe9047e6" />



Changes:
1. Adding spectral gradient angle matching criteria
2. Adding hooks to specify `selection_metric` within `surface.json`. A couple of ways to do this. I chose not to add another Apply OE hook. Instead, I put this in the surface config. However, to make this backward compatible the existing strategy of default filling the config object from `configs.py` is still in there for now.