### PR TITLE
Use sRTMnet as the default RT engine

### DIFF
--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -273,6 +273,9 @@ def apply_oe(
     use_multisurface = True if classify_multisurface or surface_class_file else False
 
     # Logic to match engine paths with engine names
+    # This becomes more complicated with backward compatability
+    # TODO Could abstract this into template construction
+    # TODO collapse modtran - emulator paths into single engine path when we eliminate list-based rt_engines
     if engine_name == "sRTMnet" and not emulator_base:
         emulator_base = str(env.path("srtmnet", key="srtmnet.file"))
 
@@ -283,7 +286,12 @@ def apply_oe(
         engine_name = "KernelFlowsGP"
 
     if engine_name == "KernelFlowsGP" and not emulator_base:
-        raise ValueError("emulator_base must be specifief if using Kernel Flows GP")
+        raise ValueError("emulator_base must be specified if using Kernel Flows GP")
+
+    if engine_name == "LibRadTran" and not modtran_path:
+        modtran_path = os.getenv("LIBRADTRAN_DIR", env.libradtran)
+        if not modtran_path:
+            raise ValueError("No LibRadTran installation found. Please set .ini.")
 
     # Determine if we run in multipart-transmittance (4c) mode
     if emulator_base is not None:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -276,19 +276,19 @@ def apply_oe(
     # This becomes more complicated with backward compatability
     # TODO Could abstract this into template construction
     # TODO collapse modtran - emulator paths into single engine path when we eliminate list-based rt_engines
-    if engine_name == "sRTMnet" and not emulator_base:
+    if engine_name.lower() == "srtmnet" and not emulator_base:
         emulator_base = str(env.path("srtmnet", key="srtmnet.file"))
 
-    if engine_name == "modtran" and not modtran_path:
+    if engine_name.lower() == "modtran" and not modtran_path:
         modtran_path = os.getenv("MODTRAN_DIR", env.modtran)
 
     if emulator_base and emulator_base.endswith(".jld2"):
         engine_name = "KernelFlowsGP"
 
-    if engine_name == "KernelFlowsGP" and not emulator_base:
+    if engine_name.lower() == "kernelflowsgp" and not emulator_base:
         raise ValueError("emulator_base must be specified if using Kernel Flows GP")
 
-    if engine_name == "LibRadTran" and not modtran_path:
+    if engine_name.lower() == "libradtran" and not modtran_path:
         modtran_path = os.getenv("LIBRADTRAN_DIR", env.libradtran)
         if not modtran_path:
             raise ValueError("No LibRadTran installation found. Please set .ini.")
@@ -700,7 +700,7 @@ def apply_oe(
             ihaze_type="AER_NONE",
         )
 
-        if emulator_base is None and prebuilt_lut is None:
+        if engine_name.lower() == "modtran" and prebuilt_lut is None:
             max_water = tmpl.calc_modtran_max_water(paths)
         else:
             max_water = 6

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -19,6 +19,7 @@ from spectral.io import envi
 import isofit.utils.template_construction as tmpl
 from isofit.core import isofit, units
 from isofit.core.common import envi_header
+from isofit.data import env
 from isofit.debug.resource_tracker import FileResources
 from isofit.utils import analytical_line as ALAlg
 from isofit.utils import empirical_line as ELAlg
@@ -72,6 +73,7 @@ def apply_oe(
     working_directory,
     sensor,
     surface_path,
+    engine_name="sRTMnet",
     copy_input_files=False,
     modtran_path=None,
     wavelength_path=None,
@@ -139,6 +141,8 @@ def apply_oe(
         settings
     surface_path : str
         Path to surface model or json dict of surface model configuration
+    engine_name : str, default=sRTMnet
+        Name of the RT engine to use for radiative transfer simulations
     copy_input_files : bool, default=False
         Flag to choose to copy input_radiance, input_loc, and input_obs locally into
         the working_directory
@@ -268,6 +272,19 @@ def apply_oe(
     use_superpixels = empirical_line or analytical_line
     use_multisurface = True if classify_multisurface or surface_class_file else False
 
+    # Logic to match engine paths with engine names
+    if engine_name == "sRTMnet" and not emulator_base:
+        emulator_base = str(env.path("srtmnet", key="srtmnet.file"))
+
+    if engine_name == "modtran" and not modtran_path:
+        modtran_path = os.getenv("MODTRAN_DIR", env.modtran)
+
+    if emulator_base and emulator_base.endswith(".jld2"):
+        engine_name = "KernelFlowsGP"
+
+    if engine_name == "KernelFlowsGP" and not emulator_base:
+        raise ValueError("emulator_base must be specifief if using Kernel Flows GP")
+
     # Determine if we run in multipart-transmittance (4c) mode
     if emulator_base is not None:
         if emulator_base.endswith(".jld2"):
@@ -284,7 +301,6 @@ def apply_oe(
 
     else:
         # This is the MODTRAN case.
-        # Do we want to enable the 4c mode by default?
         multipart_transmittance = True
 
     if sensor not in SUPPORTED_SENSORS:
@@ -409,6 +425,7 @@ def apply_oe(
         working_directory=working_directory,
         copy_input_files=copy_input_files,
         modtran_path=modtran_path,
+        emulator_base=emulator_base,
         rdn_factors_path=rdn_factors_path,
         model_discrepancy_path=model_discrepancy_path,
         aerosol_climatology_path=aerosol_climatology_path,
@@ -646,10 +663,10 @@ def apply_oe(
 
     config_params = {
         "paths": paths,
+        "engine_name": engine_name,
         "n_cores": n_cores,
         "use_superpixels": use_superpixels,
         "surface_category": surface_category,
-        "emulator_base": emulator_base,
         "uncorrelated_radiometric_uncertainty": uncorrelated_radiometric_uncertainty,
         "dn_uncertainty_file": dn_uncertainty_file,
         "prebuilt_lut_path": prebuilt_lut,
@@ -895,6 +912,7 @@ def apply_oe(
 @click.argument("working_directory")
 @click.argument("sensor")
 @click.option("--surface_path", "-sp", required=True, type=str)
+@click.option("--engine_name", default="sRTMnet")
 @click.option("--copy_input_files", is_flag=True, default=False)
 @click.option("--modtran_path")
 @click.option("--wavelength_path")

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -46,10 +46,11 @@ class Pathnames:
         surface_class_file,
         surface_path,
         working_directory,
-        ray_temp_dir,
+        ray_temp_dir="/tmp/ray",
         sensor="NA-*",
         copy_input_files=False,
         modtran_path=None,
+        emulator_base=None,
         rdn_factors_path=None,
         model_discrepancy_path=None,
         aerosol_climatology_path=None,
@@ -260,10 +261,8 @@ class Pathnames:
             join(self.config_directory, self.fid + "_h2o.json")
         )
 
-        if modtran_path:
-            self.modtran_path = modtran_path
-        else:
-            self.modtran_path = os.getenv("MODTRAN_DIR", env.modtran)
+        self.modtran_path = modtran_path
+        self.emulator_base = emulator_base
 
         self.sixs_path = os.getenv("SIXS_DIR", env.sixs)
 
@@ -664,6 +663,7 @@ def check_surface_model(
 
 def build_config(
     paths: Pathnames,
+    engine_name: str = "sRTMnet",
     h2o_lut_grid: np.array = None,
     elevation_lut_grid: np.array = None,
     to_sensor_zenith_lut_grid: np.array = None,
@@ -675,8 +675,7 @@ def build_config(
     aerosol_state_vector: dict = None,
     use_superpixels: bool = True,
     n_cores: int = -1,
-    surface_category="multicomponent_surface",
-    emulator_base: str = None,
+    surface_category: str = "multicomponent_surface",
     uncorrelated_radiometric_uncertainty: float = 0.0,
     dn_uncertainty_file: str = None,
     multiple_restarts: bool = False,
@@ -711,7 +710,6 @@ def build_config(
         use_superpixels:                      flag whether or not to use superpixels for the solution
         n_cores:                              the number of cores to use during processing
         surface_category:                     type of surface to use
-        emulator_base:                        the basename of the emulator, if used
         uncorrelated_radiometric_uncertainty: uncorrelated radiometric uncertainty parameter for isofit
         dn_uncertainty_file:                       Path to a linearity .mat file to augment S matrix with linearity uncertainty
         multiple_restarts:                    if true, use multiple restarts
@@ -744,13 +742,6 @@ def build_config(
         else abspath(prebuilt_lut_path)
     )
 
-    if emulator_base is None:
-        engine_name = "modtran"
-    elif emulator_base.endswith(".jld2"):
-        engine_name = "KernelFlowsGP"
-    else:
-        engine_name = "sRTMnet"
-
     radiative_transfer_config = {
         "radiative_transfer_engines": {
             "vswir": {
@@ -774,16 +765,16 @@ def build_config(
     }
 
     vswir = {}
-    if emulator_base is not None:
-        vswir["emulator_file"] = abspath(emulator_base)
+    if paths.emulator_base is not None:
+        vswir["emulator_file"] = abspath(paths.emulator_base)
         vswir["earth_sun_distance_file"] = paths.earth_sun_distance_path
         vswir["irradiance_file"] = paths.irradiance_file
         vswir["engine_base_dir"] = paths.sixs_path
         if multipart_transmittance:
-            vswir["emulator_aux_file"] = abspath(emulator_base)
+            vswir["emulator_aux_file"] = abspath(paths.emulator_base)
         else:
             vswir["emulator_aux_file"] = abspath(
-                os.path.splitext(emulator_base)[0] + "_aux.npz"
+                os.path.splitext(paths.emulator_base)[0] + "_aux.npz"
             )
     else:
         vswir["engine_base_dir"] = paths.modtran_path
@@ -813,11 +804,14 @@ def build_config(
         else:
             lut_grid[gn] = np.array(gc).tolist()
 
-    if emulator_base is not None and os.path.splitext(emulator_base)[1] == ".jld2":
+    if (
+        paths.emulator_base is not None
+        and os.path.splitext(paths.emulator_base)[1] == ".jld2"
+    ):
         from isofit.radiative_transfer.engines.kernel_flows import bounds_check
 
         # Should only modify H2OSTR and surface_elevation_km
-        bounds_check(lut_grid, emulator_base, modify=True)
+        bounds_check(lut_grid, paths.emulator_base, modify=True)
 
     ncds = None
     if prebuilt_lut_path is not None:


### PR DESCRIPTION
Adds an optional `apply_oe` argument, `engine_name`, which defaults to sRTMnet.  I tried to maintain existing `emulator_base`-`modtran_path` structure to maintain backwards compatibility for `emulator_base` run configurations. This would change existing `modtran_path` run configurations, which currently can be run without specifying any paths in the `apply_oe` call.

Decision points:


Key block:
```python
    # Logic to match engine paths with engine names
    if engine_name == "sRTMnet" and not emulator_base:
        emulator_base = str(env.path("srtmnet", key="srtmnet.file"))

    if engine_name == "modtran" and not modtran_path:
        modtran_path = os.getenv("MODTRAN_DIR", env.modtran)

    if emulator_base and emulator_base.endswith(".jld2"):
        engine_name = "KernelFlowsGP"

    if engine_name == "KernelFlowsGP" and not emulator_base:
        raise ValueError("emulator_base must be specifief if using Kernel Flows GP")
```