### PR TITLE
Patch to lower sky glint sigma

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -72,7 +72,7 @@ class SurfaceConfig(BaseConfigSection):
         self.sun_glint_prior_sigma = 0.1
 
         self._sky_glint_prior_sigma_type = float
-        self.sky_glint_prior_sigma = 0.01
+        self.sky_glint_prior_sigma = 0.001
 
         self.set_config_options(sub_configdic)
 


### PR DESCRIPTION
Lowering the sky glint variance in the surface prior improves solutions for certain water surfaces. Seen in cases with dark water, inland water, and foamy/whitecap water, the analytical solutions for sky glint blow up, and drive reflectance negative in the blue.

See "foamy" pixels in top right
<img width="1439" height="411" alt="image" src="https://github.com/user-attachments/assets/f3317832-91fe-4402-8f04-eb450ca0f54e" />

With this patch fix:
<img width="1440" height="411" alt="image" src="https://github.com/user-attachments/assets/a122357e-0b3e-47d9-a83d-0a51c5edae3d" />


TODO:
The non-rfl surface state-vector priors are set correctly in the config. We just need to add the hooks to be able to access these values easily via ApplyOE.
