### PR TITLE
Patch for prebuilt lut

### DIFF
--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -850,7 +850,11 @@ def build_config(
 
     for key, sigma, scale in zip(statekeys, statesigmas, statescale):
         if key in lut_grid:
-            grid = lut_grid[key]
+            grid = (
+                lut_grid[key]
+                if isinstance(lut_grid[key], list)
+                else list(lut_grid[key].values())
+            )
             radiative_transfer_config["statevector"][key] = {
                 "bounds": [grid[0], grid[-1]],
                 "scale": scale,


### PR DESCRIPTION
Caught a potential bug in passing a pre-built LUT path into template construction. get_lut_subset returns a dict. Will be in the format {'gte': val[0], 'lte': val[-1]}. When passed into the block `"bounds": [grid[0], grid[-1]]` raises a KeyError.