### PR TITLE
Surface statevector hookups and overhaul.

### DIFF
--- a/isofit/configs/base_config.py
+++ b/isofit/configs/base_config.py
@@ -50,6 +50,7 @@ class BaseConfigSection(object):
 
     def check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
         message_type = (
             "Invalid type for config option {} in config section {}. The provided value"
             " {} is a {}, " + "but the required value should be a {}."
@@ -85,16 +86,20 @@ class BaseConfigSection(object):
                 )
             )
 
-        errors.extend(self._check_config_validity())
+        er, warn = self._check_config_validity()
+        errors.extend(er)
+        warnings.extend(warn)
 
         # Now do a full check on each submodule
         for key in self._get_nontype_attributes():
             value = getattr(self, key)
             if hasattr(value, "check_config_validity"):
                 logging.debug(f"Configuration check of: {key}")
-                errors.extend(value.check_config_validity())
+                er, warn = value.check_config_validity()
+                errors.extend(er)
+                warnings.extend(warn)
 
-        return errors
+        return errors, warnings
 
     def get_config_options_as_dict(self) -> Dict[str, Dict[str, any]]:
         config_options = OrderedDict()
@@ -118,7 +123,7 @@ class BaseConfigSection(object):
         return data
 
     def _check_config_validity(self) -> List[str]:
-        return list()
+        return list(), list()
 
     def _get_expected_type_for_option_key(self, option_key: str) -> type:
         key = f"_{option_key}_type"

--- a/isofit/configs/base_config.py
+++ b/isofit/configs/base_config.py
@@ -172,6 +172,6 @@ class BaseConfigSection(object):
         elements, element_names = self.get_elements()
         return element_names
 
-    def get_single_element_by_name(self, name):
+    def get(self, name):
         elements, element_names = self.get_elements()
         return elements[element_names.index(name)]

--- a/isofit/configs/configs.py
+++ b/isofit/configs/configs.py
@@ -93,8 +93,11 @@ class Config(BaseConfigSection):
         """
         logging.info("Checking config sections for configuration issues")
 
-        errors = self.check_config_validity()
+        errors, warnings = self.check_config_validity()
         errors.extend(self.check_inter_section_validity())
+
+        for w in warnings:
+            logging.warning(w)
 
         for e in errors:
             logging.error(e)

--- a/isofit/configs/sections/forward_model_config.py
+++ b/isofit/configs/sections/forward_model_config.py
@@ -31,6 +31,8 @@ class ForwardModelConfig(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
+        super().__init__()
+
         self._instrument_type = InstrumentConfig
         self.instrument: InstrumentConfig = None
         """
@@ -56,8 +58,3 @@ class ForwardModelConfig(BaseConfigSection):
         """
 
         self.set_config_options(sub_configdic)
-
-    def _check_config_validity(self) -> List[str]:
-        errors = list()
-
-        return errors

--- a/isofit/configs/sections/implementation_config.py
+++ b/isofit/configs/sections/implementation_config.py
@@ -20,9 +20,9 @@
 import os
 from typing import Dict, List, Type
 
+from isofit import __version__
 from isofit.configs.base_config import BaseConfigSection
 from isofit.configs.sections.inversion_config import InversionConfig
-from isofit import __version__
 
 
 class ImplementationConfig(BaseConfigSection):
@@ -30,6 +30,7 @@ class ImplementationConfig(BaseConfigSection):
         """
         Input file(s) configuration.
         """
+        super().__init__()
 
         self._mode_type = str
         self.mode = "inversion"
@@ -95,6 +96,7 @@ class ImplementationConfig(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         valid_implementation_modes = ["inversion", "mcmc_inversion", "simulation"]
         if self.mode not in valid_implementation_modes:
@@ -121,4 +123,4 @@ class ImplementationConfig(BaseConfigSection):
                 " specified"
             )
 
-        return errors
+        return errors, warnings

--- a/isofit/configs/sections/input_config.py
+++ b/isofit/configs/sections/input_config.py
@@ -28,6 +28,7 @@ class InputConfig(BaseConfigSection):
         """
         Input file(s) configuration.
         """
+        super().__init__()
 
         self._measured_radiance_file_type = str
         self.measured_radiance_file = None
@@ -99,6 +100,7 @@ class InputConfig(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         # Check that all input files exist
         for key in self._get_nontype_attributes():
@@ -117,4 +119,4 @@ class InputConfig(BaseConfigSection):
             if callable(key):
                 errors.extend(value.check_config_validity())
 
-        return errors
+        return errors, warnings

--- a/isofit/configs/sections/instrument_config.py
+++ b/isofit/configs/sections/instrument_config.py
@@ -21,7 +21,41 @@ import os
 from typing import Dict, List, Type
 
 from isofit.configs.base_config import BaseConfigSection
-from isofit.configs.sections.statevector_config import StateVectorConfig
+from isofit.configs.sections.statevector_config import (
+    StateVectorConfig,
+    StateVectorElementConfig,
+)
+
+
+class InstrumentStateVectorConfig(StateVectorConfig):
+    """
+    Instrument State vector configuration.
+    """
+
+    def __init__(self, sub_configdic: dict = None):
+        super().__init__(sub_configdic)
+
+        self._EOF_1_type = StateVectorElementConfig
+        self.EOF_1: StateVectorElementConfig = None
+
+        self._EOF_2_type = StateVectorElementConfig
+        self.EOF_2: StateVectorElementConfig = None
+
+        self._EOF_3_type = StateVectorElementConfig
+        self.EOF_3: StateVectorElementConfig = None
+
+        self._GROW_FWHM_type = StateVectorElementConfig
+        self.GROW_FWHM: StateVectorElementConfig = None
+
+        self._WL_SHIFT_type = StateVectorElementConfig
+        self.WL_SHIFT: StateVectorElementConfig = None
+
+        self._WL_SPACE_type = StateVectorElementConfig
+        self.WL_SPACE: StateVectorElementConfig = None
+
+        assert len(self.get_all_elements()) == len(self._get_nontype_attributes())
+
+        self._set_statevector_config_options(sub_configdic)
 
 
 class InstrumentUnknowns(BaseConfigSection):
@@ -84,8 +118,8 @@ class InstrumentConfig(BaseConfigSection):
         self.fast_resample = True
         """bool: Approximates a complete resampling by a convolution with a uniform FWHM."""
 
-        self._statevector_type = StateVectorConfig
-        self.statevector: StateVectorConfig = StateVectorConfig({})
+        self._statevector_type = InstrumentStateVectorConfig
+        self.statevector: StateVectorConfig = InstrumentStateVectorConfig({})
 
         self._SNR_type = float
         self.SNR = None

--- a/isofit/configs/sections/instrument_config.py
+++ b/isofit/configs/sections/instrument_config.py
@@ -33,7 +33,7 @@ class InstrumentStateVectorConfig(StateVectorConfig):
     """
 
     def __init__(self, sub_configdic: dict = None):
-        super().__init__(sub_configdic)
+        super().__init__()
 
         self._EOF_1_type = StateVectorElementConfig
         self.EOF_1: StateVectorElementConfig = None
@@ -64,6 +64,8 @@ class InstrumentUnknowns(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
+        super().__init__()
+
         self._channelized_radiometric_uncertainty_file_type = str
         self.channelized_radiometric_uncertainty_file = None
 
@@ -83,6 +85,7 @@ class InstrumentUnknowns(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         file_params = [
             self.channelized_radiometric_uncertainty_file,
@@ -93,7 +96,7 @@ class InstrumentUnknowns(BaseConfigSection):
                 if os.path.isfile(param) is False:
                     errors.append("Instrument unknown file: {} not found".format(param))
 
-        return errors
+        return errors, warnings
 
 
 class InstrumentConfig(BaseConfigSection):
@@ -159,6 +162,7 @@ class InstrumentConfig(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         noise_options = [
             self.SNR,
@@ -186,4 +190,4 @@ class InstrumentConfig(BaseConfigSection):
                 if os.path.isfile(param) is False:
                     errors.append("Instrument config file: {} not found".format(param))
 
-        return errors
+        return errors, warnings

--- a/isofit/configs/sections/inversion_config.py
+++ b/isofit/configs/sections/inversion_config.py
@@ -29,6 +29,8 @@ class InversionConfig(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
+        super().__init__()
+
         self._windows_type = list()
         self.windows = None
         """List[List[float]]: inversion retrieval windows to operate over."""
@@ -71,6 +73,7 @@ class InversionConfig(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         # TODO: add some checking to windows
         if self.windows is None and self.mode != "simulation":
@@ -87,7 +90,7 @@ class InversionConfig(BaseConfigSection):
                         " order".format(subset)
                     )
 
-        return errors
+        return errors, warnings
 
 
 class McmcConfig(BaseConfigSection):
@@ -96,6 +99,8 @@ class McmcConfig(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
+        super().__init__()
+
         self._iterations_type = int
         self.iterations = 10000
         """int: Number of MCMC iterations to run."""
@@ -117,13 +122,6 @@ class McmcConfig(BaseConfigSection):
 
         self.set_config_options(sub_configdic)
 
-    def _check_config_validity(self) -> List[str]:
-        errors = list()
-
-        # TODO: add flags for rile overright, and make sure files don't exist if not checked?
-
-        return errors
-
 
 class LeastSquaresConfig(BaseConfigSection):
     """
@@ -131,6 +129,8 @@ class LeastSquaresConfig(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
+        super().__init__()
+
         self._method_type = str
         self.method = "trf"
         """str: Optimzation method to use. Default 'trf'."""
@@ -164,6 +164,7 @@ class LeastSquaresConfig(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         # TODO: add flags for rile overright, and make sure files don't exist if not checked?
         if self.tr_solver is not None:
@@ -172,4 +173,4 @@ class LeastSquaresConfig(BaseConfigSection):
                     "Least squares tr_solver must be in [None, 'exact', 'lsmr']"
                 )
 
-        return errors
+        return errors, warnings

--- a/isofit/configs/sections/output_config.py
+++ b/isofit/configs/sections/output_config.py
@@ -30,6 +30,8 @@ class OutputConfig(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
+        super().__init__()
+
         self._estimated_state_file_header = (
             "statevector",
             "{State Parameter, Value}",
@@ -129,13 +131,6 @@ class OutputConfig(BaseConfigSection):
         self.mcmc_samples_file = None
 
         self.set_config_options(sub_configdic)
-
-    def _check_config_validity(self) -> List[str]:
-        errors = list()
-
-        # TODO: add flags for rile overright, and make sure files don't exist if not checked?
-
-        return errors
 
     def get_all_output_file_names(self):
         keys = []

--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -284,6 +284,7 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         from isofit.radiative_transfer.engines import Engines
 
@@ -373,7 +374,7 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         if isinstance(self.lut_complevel, int) and self.lut_complevel < 1:
             errors.append("The LUT complevel must be and int greater than 0")
 
-        return errors
+        return errors, warnings
 
 
 class RadiativeTransferUnknownsConfig(BaseConfigSection):
@@ -387,11 +388,6 @@ class RadiativeTransferUnknownsConfig(BaseConfigSection):
         self.H2O_ABSCO = None
 
         self.set_config_options(sub_configdic)
-
-    def _check_config_validity(self) -> List[str]:
-        errors = list()
-
-        return errors
 
 
 class RadiativeTransferConfig(BaseConfigSection):
@@ -467,6 +463,7 @@ class RadiativeTransferConfig(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         for key, item in self.lut_grid.items():
             if len(item) < 2:
@@ -477,7 +474,9 @@ class RadiativeTransferConfig(BaseConfigSection):
                 errors.append(f"Detected duplicate values in lut_grid item {key}")
 
         for rte in self.radiative_transfer_engines:
-            errors.extend(rte.check_config_validity())
+            er, warn = rte.check_config_validity()
+            errors.extend(er)
+            warnings.extend(warn)
 
         kinds = [
             "rg",
@@ -508,4 +507,4 @@ class RadiativeTransferConfig(BaseConfigSection):
                 f"surface->terrain_style is set as {self.terrain_style}, but must be one of: {terrain_options}"
             )
 
-        return errors
+        return errors, warnings

--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -25,8 +25,45 @@ from typing import Dict, List, Type
 import numpy as np
 
 from isofit.configs.base_config import BaseConfigSection
-from isofit.configs.sections.statevector_config import StateVectorConfig
+from isofit.configs.sections.statevector_config import (
+    StateVectorConfig,
+    StateVectorElementConfig,
+)
 from isofit.data import env
+
+
+class RTStateVectorConfig(StateVectorConfig):
+    """
+    RT State vector configuration.
+    """
+
+    def __init__(self, sub_configdic: dict = None):
+        super().__init__(sub_configdic)
+
+        self._H2OSTR_type = StateVectorElementConfig
+        self.H2OSTR: StateVectorElementConfig = None
+
+        self._AOT550_type = StateVectorElementConfig
+        self.AOT550: StateVectorElementConfig = None
+
+        self._AERFRAC_1_type = StateVectorElementConfig
+        self.AERFRAC_1: StateVectorElementConfig = None
+
+        self._AERFRAC_2_type = StateVectorElementConfig
+        self.AERFRAC_2: StateVectorElementConfig = None
+
+        self._AERFRAC_3_type = StateVectorElementConfig
+        self.AERFRAC_3: StateVectorElementConfig = None
+
+        self._AIRT_DELTA_K_type = StateVectorElementConfig
+        self.AIRT_DELTA_K: StateVectorElementConfig = None
+
+        self._surface_elevation_km_type = StateVectorElementConfig
+        self.surface_elevation_km: StateVectorElementConfig = None
+
+        assert len(self.get_all_elements()) == len(self._get_nontype_attributes())
+
+        self._set_statevector_config_options(sub_configdic)
 
 
 class RadiativeTransferEngineConfig(BaseConfigSection):
@@ -363,8 +400,8 @@ class RadiativeTransferConfig(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
-        self._statevector_type = StateVectorConfig
-        self.statevector: StateVectorConfig = StateVectorConfig({})
+        self._statevector_type = RTStateVectorConfig
+        self.statevector: StateVectorConfig = RTStateVectorConfig({})
 
         self._lut_grid_type = OrderedDict
         self.lut_grid = None

--- a/isofit/configs/sections/statevector_config.py
+++ b/isofit/configs/sections/statevector_config.py
@@ -23,6 +23,11 @@ from typing import Dict, List, Type
 import numpy as np
 
 from isofit.configs.base_config import BaseConfigSection
+from isofit.surface.surface_glint_model import (
+    DefaultSkyGlintPrior,
+    DefaultSunGlintPrior,
+)
+from isofit.surface.surface_thermal import DefaultSurfTempKPrior
 
 
 class StateVectorElementConfig(BaseConfigSection):
@@ -54,53 +59,8 @@ class StateVectorElementConfig(BaseConfigSection):
 
 
 class StateVectorConfig(BaseConfigSection):
-    """
-    State vector configuration.
-    """
-
     def __init__(self, sub_configdic: dict = None):
-        self._H2OSTR_type = StateVectorElementConfig
-        self.H2OSTR: StateVectorElementConfig = None
-
-        self._AOT550_type = StateVectorElementConfig
-        self.AOT550: StateVectorElementConfig = None
-
-        self._AERFRAC_1_type = StateVectorElementConfig
-        self.AERFRAC_1: StateVectorElementConfig = None
-
-        self._AERFRAC_2_type = StateVectorElementConfig
-        self.AERFRAC_2: StateVectorElementConfig = None
-
-        self._AERFRAC_3_type = StateVectorElementConfig
-        self.AERFRAC_3: StateVectorElementConfig = None
-
-        self._EOF_1_type = StateVectorElementConfig
-        self.EOF_1: StateVectorElementConfig = None
-
-        self._EOF_2_type = StateVectorElementConfig
-        self.EOF_2: StateVectorElementConfig = None
-
-        self._EOF_3_type = StateVectorElementConfig
-        self.EOF_3: StateVectorElementConfig = None
-
-        self._GROW_FWHM_type = StateVectorElementConfig
-        self.GROW_FWHM: StateVectorElementConfig = None
-
-        self._WL_SHIFT_type = StateVectorElementConfig
-        self.WL_SHIFT: StateVectorElementConfig = None
-
-        self._WL_SPACE_type = StateVectorElementConfig
-        self.WL_SPACE: StateVectorElementConfig = None
-
-        self._AIRT_DELTA_K_type = StateVectorElementConfig
-        self.AIRT_DELTA_K: StateVectorElementConfig = None
-
-        self._surface_elevation_km_type = StateVectorElementConfig
-        self.surface_elevation_km: StateVectorElementConfig = None
-
-        assert len(self.get_all_elements()) == len(self._get_nontype_attributes())
-
-        self._set_statevector_config_options(sub_configdic)
+        super().__init__()
 
     def _check_config_validity(self):
         errors = list()

--- a/isofit/configs/sections/statevector_config.py
+++ b/isofit/configs/sections/statevector_config.py
@@ -36,6 +36,8 @@ class StateVectorElementConfig(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
+        super().__init__()
+
         self._bounds_type = list()
         self.bounds = [np.nan, np.nan]
 
@@ -53,19 +55,10 @@ class StateVectorElementConfig(BaseConfigSection):
 
         self.set_config_options(sub_configdic)
 
-    def _check_config_validity(self) -> List[str]:
-        errors = list()
-        return errors
-
 
 class StateVectorConfig(BaseConfigSection):
     def __init__(self, sub_configdic: dict = None):
         super().__init__()
-
-    def _check_config_validity(self):
-        errors = list()
-
-        return errors
 
     def _set_statevector_config_options(self, configdic):
         # TODO: update using methods below

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -23,6 +23,43 @@ from typing import Dict, List, Type
 import numpy as np
 
 from isofit.configs.base_config import BaseConfigSection
+from isofit.configs.sections.statevector_config import (
+    StateVectorConfig,
+    StateVectorElementConfig,
+)
+from isofit.surface.surface_glint_model import (
+    DefaultSkyGlintPrior,
+    DefaultSunGlintPrior,
+)
+from isofit.surface.surface_thermal import DefaultSurfTempKPrior
+
+
+class SurfaceStateVectorConfig(StateVectorConfig):
+    """
+    Surface State vector configuration.
+    """
+
+    def __init__(self, sub_configdic: dict = None):
+        super().__init__(sub_configdic)
+
+        self._SURF_TEMP_K_type = StateVectorElementConfig
+        self.SURF_TEMP_K: StateVectorElementConfig = StateVectorElementConfig(
+            DefaultSurfTempKPrior._asdict()
+        )
+
+        self._SKY_GLINT_type = StateVectorElementConfig
+        self.SKY_GLINT: StateVectorElementConfig = StateVectorElementConfig(
+            DefaultSkyGlintPrior._asdict()
+        )
+
+        self._SUN_GLINT_type = StateVectorElementConfig
+        self.SUN_GLINT: StateVectorElementConfig = StateVectorElementConfig(
+            DefaultSunGlintPrior._asdict()
+        )
+
+        assert len(self.get_all_elements()) == len(self._get_nontype_attributes())
+
+        self._set_statevector_config_options(sub_configdic)
 
 
 class SurfaceConfig(BaseConfigSection):
@@ -60,19 +97,13 @@ class SurfaceConfig(BaseConfigSection):
         self._selection_metric_type = str
         self.selection_metric = "Euclidean"
 
+        self._statevector_type = SurfaceStateVectorConfig
+        self.statevector: StateVectorConfig = SurfaceStateVectorConfig({})
+
         # Surface Thermal
         """ Initial Value recommended by Glynn Hulley."""
         self._emissivity_for_surface_T_init_type = float
         self.emissivity_for_surface_T_init = 0.98
-
-        self._surface_T_prior_sigma_degK_type = float
-        self.surface_T_prior_sigma_degK = 1.0
-
-        self._sun_glint_prior_sigma_type = float
-        self.sun_glint_prior_sigma = 0.1
-
-        self._sky_glint_prior_sigma_type = float
-        self.sky_glint_prior_sigma = 0.001
 
         self.set_config_options(sub_configdic)
 

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -21,12 +21,15 @@ import os
 from typing import Dict, List, Type
 
 import numpy as np
+from scipy.io import loadmat
 
 from isofit.configs.base_config import BaseConfigSection
 from isofit.configs.sections.statevector_config import (
     StateVectorConfig,
     StateVectorElementConfig,
 )
+from isofit.core.common import recursive_get
+from isofit.surface.surface import DefaultState
 from isofit.surface.surface_glint_model import (
     DefaultSkyGlintPrior,
     DefaultSunGlintPrior,
@@ -40,7 +43,7 @@ class SurfaceStateVectorConfig(StateVectorConfig):
     """
 
     def __init__(self, sub_configdic: dict = None):
-        super().__init__(sub_configdic)
+        super().__init__()
 
         self._SURF_TEMP_K_type = StateVectorElementConfig
         self.SURF_TEMP_K: StateVectorElementConfig = StateVectorElementConfig(
@@ -68,6 +71,8 @@ class SurfaceConfig(BaseConfigSection):
     """
 
     def __init__(self, sub_configdic: dict = None):
+        super().__init__()
+
         self._multi_surface_flag_type = bool
         self.multi_surface_flag = False
 
@@ -109,6 +114,7 @@ class SurfaceConfig(BaseConfigSection):
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
+        warnings = list()
 
         if (self.surface_file is None) and not len(self.Surfaces):
             errors.append(
@@ -167,4 +173,36 @@ class SurfaceConfig(BaseConfigSection):
                     f"int mapping specified for keys: {missing_ints}"
                 )
 
-        return errors
+        # Check statevector
+        mat_files = list(
+            filter(None, recursive_get(self.get_config_as_dict(), "surface_file"))
+        )
+        statevec = {
+            key: value
+            for di in recursive_get(self.get_config_as_dict(), "statevector")
+            for key, value in di.items()
+        }
+
+        mismatch = {}
+        for f in mat_files:
+            model_dict = loadmat(f)
+            for i, name in enumerate(model_dict.get("statevec_names", [])):
+                for key in DefaultState._fields:
+                    if not (
+                        np.all(statevec[name][key] == model_dict[key].squeeze()[i])
+                    ):
+                        mismatch[key] = name
+
+        if len(mismatch):
+            message = (
+                "Configured non-reflectance surface statevector "
+                + "elements do not match .mat file.\nRun will use configured "
+                + "values in the .json config."
+                + "\nMismatching values:"
+            )
+            for key, value in mismatch.items():
+                message += f"\n{value}: {key}"
+
+            warnings.append(message)
+
+        return errors, warnings

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -518,6 +518,30 @@ def recursive_replace(obj, key, val) -> None:
             recursive_replace(item, key, val)
 
 
+def recursive_get(obj, key) -> list:
+    """Find all occurences of a key within a nested struct.
+
+    Args:
+        obj: object to seach within
+        key: key to find
+
+    Returns:
+        list: values at those key locations
+    """
+    results = []
+    if isinstance(obj, dict):
+        if key in obj:
+            results.append(obj[key])
+        for value in obj.values():
+            results.extend(recursive_get(value, key))
+
+    elif isinstance(obj, list):
+        for item in obj:
+            results.extend(recursive_get(item, key))
+
+    return results
+
+
 def get_absorption(wl: np.array, absfile: str) -> (np.array, np.array):
     """Calculate water and ice absorption coefficients using indices of
     refraction, and interpolate them to new wavelengths (user specifies nm).

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -266,6 +266,7 @@ class SpectrumFile:
                     self.file = envi.open(envi_header(fname))
 
             self.open_map_with_retries()
+            logging.debug(self.memmap.shape)
 
     def open_map_with_retries(self):
         """Try to open a memory map, handling Beowulf I/O issues."""

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -20,12 +20,24 @@
 from __future__ import annotations
 
 import logging
+from collections import namedtuple
 
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.io import loadmat
 
 from isofit.core.common import load_spectrum, load_wavelen
+
+DefaultState = namedtuple(
+    "DefaultState",
+    [
+        "bounds",
+        "scale",
+        "prior_mean",
+        "prior_sigma",
+        "init",
+    ],
+)
 
 
 class Surface:
@@ -39,10 +51,10 @@ class Surface:
         self.model_dict = loadmat(config.surface_file)
 
         self.statevec_names = []
+        self.bounds, self.scale, self.init = [], [], []
+        self.prior_mean, self.prior_sigma = [], []
+
         self.idx_surface = np.arange(len(self.statevec_names))
-        self.bounds = np.array([])
-        self.scale = np.array([])
-        self.init = np.array([])
         self.bvec = []
         self.bval = np.array([])
         self.idx_lamb = np.empty(shape=0)

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -23,7 +23,24 @@ import numpy as np
 from scipy.linalg import block_diag
 
 from isofit.core.common import eps, svd_inv_sqrt
+from isofit.surface.surface import DefaultState
 from isofit.surface.surface_multicomp import MultiComponentSurface
+
+DefaultSkyGlintPrior = DefaultState(
+    bounds=[0.0, 100.0],
+    scale=1.0,
+    prior_mean=1 / np.pi,
+    prior_sigma=0.001,
+    init=1 / np.pi,
+)
+
+DefaultSunGlintPrior = DefaultState(
+    bounds=[0.0, 100.0],
+    scale=1.0,
+    prior_mean=0.02,
+    prior_sigma=0.001,
+    init=0.02,
+)
 
 
 class GlintModelSurface(MultiComponentSurface):
@@ -40,33 +57,45 @@ class GlintModelSurface(MultiComponentSurface):
         self.glint_ind = len(self.statevec_names) - 2
         self.sky_glint_ind = self.glint_ind
         self.sun_glint_ind = self.glint_ind + 1
-
-        self.scale.extend([1.0, 1.0])
-
-        # Numbers from Marcel Koenig; used for prior mean
-        self.init.extend([1 / np.pi, 0.02])
-
-        # Gege (2021), WASI user manual
-        self.bounds.extend([[0, 10], [0, 10]])
-
         self.n_state = self.n_state + 2
-
-        # Useful indexes to track
-        self.glint_ind = len(self.statevec_names) - 2
-        self.sky_glint_ind = self.glint_ind
-        self.sun_glint_ind = self.glint_ind + 1
-
         self.idx_surface = np.arange(len(self.statevec_names))
 
-        # Change this if you don't want to analytical solve for all the full statevector elements.
+        # TODO Remove or update ability to smooth on any statevector idx
         self.analytical_iv_idx = np.arange(len(self.statevec_names))
 
-        self.sun_glint_sigma = (
-            config.sun_glint_prior_sigma * np.array(self.scale[self.sun_glint_ind])
-        ) ** 2
-        self.sky_glint_sigma = (
-            config.sky_glint_prior_sigma * np.array(self.scale[self.sky_glint_ind])
-        ) ** 2
+        # Old syntax (setting optimizaion and prior directly from config:
+        # self.sun_glint_sigma = (
+        #     config.sun_glint_prior_sigma
+        #     * np.array(self.scale[self.sun_glint_ind])
+        # ) ** 2
+
+        # New syntax pulling from populated config object
+        self.init.extend(
+            [
+                config.statevector.SKY_GLINT.get("init"),
+                config.statevector.SUN_GLINT.get("init"),
+            ]
+        )
+
+        self.scale.extend(
+            [
+                config.statevector.SKY_GLINT.get("scale"),
+                config.statevector.SUN_GLINT.get("scale"),
+            ]
+        )
+
+        self.bounds.extend(
+            [
+                config.statevector.SKY_GLINT.get("bounds"),
+                config.statevector.SUN_GLINT.get("bounds"),
+            ]
+        )
+
+        self.sky_glint_mean = config.statevector.SKY_GLINT.get("prior_mean")
+        self.sky_glint_sigma = (config.statevector.SKY_GLINT.get("prior_sigma")) ** 2
+
+        self.sun_glint_mean = config.statevector.SUN_GLINT.get("prior_mean")
+        self.sun_glint_sigma = (config.statevector.SUN_GLINT.get("prior_sigma")) ** 2
 
         # Compute and and cache normalized Sa inversions for glint case
         Cov = np.array([[self.sky_glint_sigma, 0], [0, self.sun_glint_sigma]])
@@ -78,7 +107,9 @@ class GlintModelSurface(MultiComponentSurface):
         """Mean of prior distribution, calculated at state x."""
 
         mu = MultiComponentSurface.xa(self, x_surface, geom)
-        mu[self.glint_ind :] = self.init[self.glint_ind :]
+        mu[self.sky_glint_ind] = self.sky_glint_mean
+        mu[self.sun_glint_ind] = self.sun_glint_mean
+
         return mu
 
     def Sa(self, x_surface, geom):

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -78,6 +78,7 @@ class MultiComponentSurface(Surface):
         # Variables retrieved: each channel maps to a reflectance model parameter
         rmin, rmax = -0.05, 2.0
         self.statevec_names = ["RFL_%04i" % int(w) for w in self.wl]
+
         self.idx_surface = np.arange(len(self.statevec_names))
 
         # Change this if you don't want to analytical solve for all the full statevector elements.

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -23,7 +23,16 @@ import numpy as np
 from scipy.linalg import block_diag
 
 from isofit.core.common import emissive_radiance, svd_inv_sqrt
+from isofit.surface.surface import DefaultState
 from isofit.surface.surface_multicomp import MultiComponentSurface
+
+DefaultSurfTempKPrior = DefaultState(
+    bounds=[250.0, 400.0],
+    scale=100.0,
+    prior_mean=300.0,
+    prior_sigma=1.0,
+    init=300.0,
+)
 
 
 class ThermalSurface(MultiComponentSurface):
@@ -37,20 +46,31 @@ class ThermalSurface(MultiComponentSurface):
 
         super().__init__(full_config)
 
-        # TODO: Enforce this attribute in the config, not here (this is hidden)
         # Handle additional state vector elements
-        if "SURF_TEMP_K" not in self.statevec_names:
-            self.statevec_names.extend(["SURF_TEMP_K"])
-            self.init.extend([300.0])  # This is overwritten below
-            self.scale.extend([100.0])
-            self.bounds.extend([[250.0, 400.0]])
+        self.statevec_names.extend(["SURF_TEMP_K"])
+
+        # Old syntax:
+        # self.surface_T_prior_mean_degK = config.statevector.SURF_TEMP_K.get(
+        #     "prior_mean"
+        # )
+        # New syntax from config object:
+        self.init.extend([config.statevector.SURF_TEMP_K.get("init")])
+        self.scale.extend([config.statevector.SURF_TEMP_K.get("scale")])
+        self.bounds.extend([config.statevector.SURF_TEMP_K.get("bounds")])
+
+        self.surface_T_prior_mean_degK = config.statevector.SURF_TEMP_K.get(
+            "prior_mean"
+        )
+        self.surface_T_prior_sigma_degK = config.statevector.SURF_TEMP_K.get(
+            "prior_sigma"
+        )
+
         self.idx_surface = np.arange(len(self.statevec_names))
         self.surf_temp_ind = len(self.statevec_names) - 1
         self.emissive = True
         self.n_state = len(self.init)
 
         self.emissivity_for_surface_T_init = config.emissivity_for_surface_T_init
-        self.surface_T_prior_sigma_degK = config.surface_T_prior_sigma_degK
 
         # Compute and and cache normalized Sa inversions for thermal case
         Cov = np.array([[self.surface_T_prior_sigma_degK**2]])
@@ -64,7 +84,7 @@ class ThermalSurface(MultiComponentSurface):
         normalize the result for the calling function."""
 
         mu = MultiComponentSurface.xa(self, x_surface, geom)
-        mu[self.surf_temp_ind] = self.init[self.surf_temp_ind]
+        mu[self.surf_temp_ind] = self.surface_T_prior_mean_degK
 
         return mu
 

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -45,6 +45,44 @@ def next_diag_val(C: np.ndarray, starting_index, direction):
     return None
 
 
+def unpack_statevector(statevector, surface_category=None):
+    data = {
+        "statevec_names": [],
+        "bounds": [],
+        "init": [],
+        "prior_mean": [],
+        "prior_sigma": [],
+        "scale": [],
+    }
+    if not statevector:
+        return {}
+
+    if isinstance(statevector, list):
+        for state in statevector:
+            data["statevec_names"].append(state["name"])
+            data["bounds"].append(state["bounds"])
+            data["init"].append(state["init"])
+            data["prior_mean"].append(state["prior_mean"])
+            data["prior_sigma"].append(state["prior_sigma"])
+            data["scale"].append(state["scale"])
+
+        return data
+
+    if isinstance(statevector, dict):
+        if surface_category:
+            return unpack_statevector(
+                statevector.get(surface_category), surface_category
+            )
+
+        else:
+            for key, value in statevector.items():
+                category_state = unpack_statevector(value, surface_category=key)
+                for key, values in category_state.items():
+                    data[key].extend(values)
+
+            return data
+
+
 def surface_model(
     config_path: str,
     wavelength_path: str = None,
@@ -417,9 +455,40 @@ def surface_model(
         # Divide up model dict based on surface_type
         surface_categories = np.unique(model["surface_categories"])
         for surface_category in surface_categories:
-            i = np.argwhere(np.array(model["surface_categories"]) == surface_category)
-
             type_model = model.copy()
+
+            type_model.update(
+                unpack_statevector(
+                    config.get("statevector"), surface_category=surface_category
+                )
+            )
+
+            statevector_categories = type_model.get("statevector_surface_category", [])
+            if len(statevector_categories):
+                i = [
+                    i
+                    for i, val in enumerate(statevector_categories)
+                    if val == surface_category
+                ]
+                if not len(i):
+                    type_model.pop("statevec_names", None)
+                    type_model.pop("bounds", None)
+                    type_model.pop("init", None)
+                    type_model.pop("prior_mean", None)
+                    type_model.pop("prior_sigma", None)
+                    type_model.pop("scale", None)
+                    type_model.pop("statevector_surface_category", None)
+                else:
+                    i = i[0]
+                    type_model["statevec_names"] = type_model["statevec_names"][i]
+                    type_model["bounds"] = type_model["bounds"][i]
+                    type_model["init"] = type_model["init"][i]
+                    type_model["prior_mean"] = type_model["prior_mean"][i]
+                    type_model["prior_sigma"] = type_model["prior_sigma"][i]
+                    type_model["scale"] = type_model["scale"][i]
+                    type_model.pop("statevector_surface_category", None)
+
+            i = np.argwhere(np.array(model["surface_categories"]) == surface_category)
             type_model["means"] = np.squeeze(model["means"][i])
             type_model["covs"] = np.squeeze(model["covs"][i])
 
@@ -440,6 +509,7 @@ def surface_model(
             scipy.io.savemat(type_outfile, type_model)
 
     else:
+        model.update(unpack_statevector(config.get("statevector")))
         scipy.io.savemat(outfile, model)
 
 

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1657,7 +1657,9 @@ def make_surface_config(
         surface_mat = loadmat(path)
         statevec_names = surface_mat.get("statevec_names", [])
         if len(statevec_names):
-            surface_config_dict["statevector"] = {}
+            surface_config_dict["statevector"] = surface_config_dict.get(
+                "statevector", {}
+            )
             for i, name in enumerate(statevec_names):
                 surface_config_dict["statevector"][name] = {
                     "bounds": [i for i in surface_mat["bounds"][i]],

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1652,6 +1652,21 @@ def make_surface_config(
         surface_config_dict["surface_file"] = surface_working_paths[surface_category]
         surface_config_dict["surface_category"] = surface_category
 
+    # Accumulate statevector
+    for category, path in surface_working_paths.items():
+        surface_mat = loadmat(path)
+        statevec_names = surface_mat.get("statevec_names", [])
+        if len(statevec_names):
+            surface_config_dict["statevector"] = {}
+            for i, name in enumerate(statevec_names):
+                surface_config_dict["statevector"][name] = {
+                    "bounds": [i for i in surface_mat["bounds"][i]],
+                    "init": surface_mat["init"][0][i],
+                    "prior_mean": surface_mat["prior_mean"][0][i],
+                    "prior_sigma": surface_mat["prior_sigma"][0][i],
+                    "scale": surface_mat["scale"][0][i],
+                }
+
     return surface_config_dict
 
 


### PR DESCRIPTION
Early stages, needs to be tested. Description also to be fleshed out.

This does two things:
1) Allow the user to specify state-vector optimization parameters directly in the `surface.json` file. This can be done by explicitly pointing to a surface model, or broadly including the relevant parameters.

I'll include more fleshed out specifics, but along the lines of:
```
  "SKY_GLINT": {
    "bounds": [
      0.0,
      10.0
    ],
    "init": 0.318,
    "prior_mean": 0.318,
    "prior_sigma": 0.001,
    "scale": 1
 },
```
These will propagate into the surface.mat file, which will in turn be read by the build_config script.

2) I updated how we read in surface statevector optimziation parameters. These now come from (if not specified) named tuples in the same format as the StatevectorConfigElement. Default StatevectorConfigElement are then used for the surface models that have non-rfl state-vector elements. Within this context, values specified in the `surface.json` act as "overrides" for the defaults.

3) I added a `warnings` section for `check_config_validity()`. Currently, this is only used for matching the non-reflectance surface statevector elements between `.json` and `.mat` files. Failing the check prints a warning:
```
WARNING:root:Configured non-reflectance surface statevector elements do not match .mat file.
Run will use configured values in the .json config.
Mismatching values:
SKY_GLINT: prior_mean
SUN_GLINT: init
```

