### PR TITLE
Numba grid interpolator

### DIFF
--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -373,7 +373,7 @@ class RadiativeTransferConfig(BaseConfigSection):
         self.unknowns: RadiativeTransferUnknownsConfig = None
 
         self._interpolator_style_type = str
-        self.interpolator_style = "mlg"
+        self.interpolator_style = "mlg_numba"
         """str: Style of interpolation.
         - mlg   = Multilinear Grid
         - rg    = RegularGrid
@@ -442,7 +442,12 @@ class RadiativeTransferConfig(BaseConfigSection):
         for rte in self.radiative_transfer_engines:
             errors.extend(rte.check_config_validity())
 
-        kinds = ["rg", "nds", "mlg"]  # Implemented kinds of interpolator functions
+        kinds = [
+            "rg",
+            "nds",
+            "mlg",
+            "mlg_numba",
+        ]  # Implemented kinds of interpolator functions
         kind = self.interpolator_style[:3]
         degrees = self.interpolator_style[4:]
 

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -30,6 +30,7 @@ import numpy as np
 # sc Adding in xarray for non-gauss SRF file io
 import xarray as xr
 import xxhash
+from numba import float64, int32, njit
 from scipy.interpolate import RegularGridInterpolator
 
 from isofit.core import units
@@ -41,6 +42,105 @@ eps = 1e-5
 Cache = {"stats": {}}
 
 
+@njit(inline="always")
+def fast_searchsorted(array, target):
+    """
+    Numba-optimized binary search to find the insertion index of a target value.
+    Same as np.searchsorted(...,side='left'), but opptimized
+
+    Args:
+        array: 1D array of floats, representing a sorted grid dimension (must be
+               monotonically increasing)
+        target: float value to locate within the grid dimension
+
+    Returns:
+        low: integer index indicating the first element greater than or equal
+             to the target.
+    """
+    low = 0
+    high = len(array) - 1
+    while low < high:
+        mid = (low + high) // 2
+        if array[mid] < target:
+            low = mid + 1
+        else:
+            high = mid
+    return low
+
+
+@njit(cache=True)
+def _numba_mlg_kernel(point, grid_tuples, data):
+    """
+    Numba-accelerated n-dimensional multilinear interpolator kernel. Performs
+    linear interpolation across a multi-dimensional look-up table for a single
+    point, outputting a vector of values.
+
+    Args:
+        point: 1D array of floats, representing the coordinate to interpolate
+               within the n-dimensional grid.
+        grid_tuples: Tuple of 1D arrays of floats, where each array defines the
+                     sorted grid points for a single dimension.
+        data: N+1 dimensional array of floats, where the first N dimensions
+              correspond to grid_tuples and the last dimension contains the
+              output vector (channels).
+
+    Returns:
+        result: 1D array of floats, the interpolated output vector of length
+                equal to data.shape[-1].
+    """
+    dims = len(point)
+    low_indices = np.zeros(dims, dtype=int32)
+    deltas = np.zeros(dims, dtype=float64)
+
+    for i in range(dims):
+        grid = grid_tuples[i]
+        p = point[i]
+
+        # Clamp to grid bounds
+        if p <= grid[0]:
+            low_indices[i] = 0
+            deltas[i] = 0.0
+        elif p >= grid[-1]:
+            low_indices[i] = len(grid) - 2
+            deltas[i] = 1.0
+        else:
+            idx = fast_searchsorted(grid, p) - 1
+            if idx < 0:
+                idx = 0
+            low_indices[i] = idx
+            deltas[i] = (p - grid[idx]) / (grid[idx + 1] - grid[idx])
+
+    num_channels = data.shape[-1]
+    num_corners = 1 << dims
+    result = np.zeros(num_channels)
+
+    # Manual stride calculation for flat indexing
+    strides = np.zeros(dims + 1, dtype=int32)
+    current_stride = 1
+    for i in range(dims, -1, -1):
+        strides[i] = current_stride
+        current_stride *= data.shape[i]
+
+    flat_data = data.ravel()
+
+    for c in range(num_corners):
+        weight = 1.0
+        flat_idx = 0
+        for d in range(dims):
+            if (c >> d) & 1:
+                weight *= deltas[d]
+                flat_idx += (low_indices[d] + 1) * strides[d]
+            else:
+                weight *= 1.0 - deltas[d]
+                flat_idx += low_indices[d] * strides[d]
+
+        start = flat_idx
+        end = start + num_channels
+        result += flat_data[start:end] * weight
+
+    return result
+
+
 class VectorInterpolator:
     """Linear look up table interpolator.  Support linear interpolation through radial space by expanding the look
     up tables with sin and cos dimensions.
@@ -49,14 +149,15 @@ class VectorInterpolator:
         grid_input: list of lists of floats, indicating the gridpoint elements in each grid dimension
         data_input: n dimensional array of radiative transfer engine outputs (each dimension size corresponds to the
                     given grid_input list length, with the last dimensions equal to the number of sensor channels)
-        version: version to use: 'rg' for scipy RegularGridInterpolator, 'mlg' for multilinear grid interpolator
+        version: version to use: 'rg' for scipy RegularGridInterpolator, 'mlg' for multilinear grid interpolator,
+                 'mlg_numba' for numba-accelerated multilinear grid interpolator
     """
 
     def __init__(
         self,
         grid_input: List[List[float]],
         data_input: np.array,
-        version="mlg",
+        version="mlg_numba",
     ):
         # Determine if this a singular unique value, if so just return that directly
         val = data_input[(0,) * data_input.ndim]
@@ -97,6 +198,19 @@ class VectorInterpolator:
                 t[1:] - t[:-1] for t in self.gridtuples
             ]  # binwidth arrays for each dimension
             self.maxbaseinds = np.array([len(t) - 1 for t in self.gridtuples])
+
+        elif version == "mlg_numba":
+            self.method = 3
+            # Need to keep types picklable...better performance with numba lists,
+            # but it doesn't play nicely with ray.
+            self.grid_tuples = tuple(
+                [np.array(g, dtype=np.float64) for g in grid_input]
+            )
+            self.gridarrays = data_input.astype(np.float64)
+
+            # run a warm-up for numba
+            dummy_point = np.array([g[0] for g in self.grid_tuples], dtype=np.float64)
+            _ = _numba_mlg_kernel(dummy_point, self.grid_tuples, self.gridarrays)
 
         else:
             raise AttributeError(f"Unknown interpolator version: {version!r}")
@@ -197,6 +311,8 @@ class VectorInterpolator:
             return self._interpolate(*args, **kwargs)
         elif self.method == 2:
             return self._multilinear_grid(*args, **kwargs)
+        if self.method == 3:
+            return _numba_mlg_kernel(args[0], self.grid_tuples, self.gridarrays)
 
 
 def load_wavelen(wavelength_file: str):

--- a/isofit/core/common.py
+++ b/isofit/core/common.py
@@ -69,7 +69,9 @@ def fast_searchsorted(array, target):
 
 
 @njit(cache=True)
-def _numba_mlg_kernel(point, grid_tuples, data):
+def _numba_mlg_kernel(
+    point, grid_tuples, flat_data, strides, low_indices, deltas, num_channels
+):
     """
     Numba-accelerated n-dimensional multilinear interpolator kernel. Performs
     linear interpolation across a multi-dimensional look-up table for a single
@@ -80,7 +82,14 @@ def _numba_mlg_kernel(point, grid_tuples, data):
                within the n-dimensional grid.
         grid_tuples: Tuple of 1D arrays of floats, where each array defines the
                      sorted grid points for a single dimension.
-        data: N+1 dimensional array of floats, where the first N dimensions
+        flat_data: 1D array of floats, the flattened n-dimensional data array.
+        strides: 1D array of integers, the strides for each dimension in the
+                 flattened data array.
+        low_indices: 1D array of integers, pre-allocated buffer for storing the
+                     lower indices for each dimension.
+        deltas: 1D array of floats, pre-allocated buffer for storing the
+                interpolation weights for each dimension.
+        num_channels: Integer, the number of channels in the output vector.
               correspond to grid_tuples and the last dimension contains the
               output vector (channels).
 
@@ -89,14 +98,12 @@ def _numba_mlg_kernel(point, grid_tuples, data):
                 equal to data.shape[-1].
     """
     dims = len(point)
-    low_indices = np.zeros(dims, dtype=int32)
-    deltas = np.zeros(dims, dtype=float64)
 
+    # Bound the search
     for i in range(dims):
         grid = grid_tuples[i]
         p = point[i]
 
-        # Clamp to grid bounds
         if p <= grid[0]:
             low_indices[i] = 0
             deltas[i] = 0.0
@@ -110,19 +117,9 @@ def _numba_mlg_kernel(point, grid_tuples, data):
             low_indices[i] = idx
             deltas[i] = (p - grid[idx]) / (grid[idx + 1] - grid[idx])
 
-    num_channels = data.shape[-1]
+    # Do the actual interpolation, using pre-calculated strides
     num_corners = 1 << dims
-    result = np.zeros(num_channels)
-
-    # Manual stride calculation for flat indexing
-    strides = np.zeros(dims + 1, dtype=int32)
-    current_stride = 1
-    for i in range(dims, -1, -1):
-        strides[i] = current_stride
-        current_stride *= data.shape[i]
-
-    flat_data = data.ravel()
-
+    result = np.zeros(num_channels, dtype=np.float64)
     for c in range(num_corners):
         weight = 1.0
         flat_idx = 0
@@ -201,16 +198,32 @@ class VectorInterpolator:
 
         elif version == "mlg_numba":
             self.method = 3
-            # Need to keep types picklable...better performance with numba lists,
-            # but it doesn't play nicely with ray.
             self.grid_tuples = tuple(
                 [np.array(g, dtype=np.float64) for g in grid_input]
             )
             self.gridarrays = data_input.astype(np.float64)
 
-            # run a warm-up for numba
+            self.dims = len(grid_input)
+            self.num_channels = self.n
+
+            # Precompute Strides for flat indexing
+            strides = np.zeros(self.dims + 1, dtype=np.int32)
+            current_stride = 1
+            for i in range(self.dims, -1, -1):
+                strides[i] = current_stride
+                current_stride *= data_input.shape[i]
+            self.strides = strides
+
+            # Pre-flatten the data array
+            self.flat_data = self.gridarrays.ravel()
+
+            # Allocate workspace buffers to prevent Numba heap allocation, which does bad things with Ray
+            self.low_indices_workspace = np.zeros(self.dims, dtype=np.int32)
+            self.deltas_workspace = np.zeros(self.dims, dtype=np.float64)
+
+            # Warm-up call to force numba to compile before runtime
             dummy_point = np.array([g[0] for g in self.grid_tuples], dtype=np.float64)
-            _ = _numba_mlg_kernel(dummy_point, self.grid_tuples, self.gridarrays)
+            self(dummy_point)
 
         else:
             raise AttributeError(f"Unknown interpolator version: {version!r}")
@@ -312,7 +325,22 @@ class VectorInterpolator:
         elif self.method == 2:
             return self._multilinear_grid(*args, **kwargs)
         if self.method == 3:
-            return _numba_mlg_kernel(args[0], self.grid_tuples, self.gridarrays)
+
+            # Ray's plasma-store makes zero-copy arrays read-only, so  do a check and
+            # make a local copy on this worker if needed.
+            if not self.low_indices_workspace.flags.writeable:
+                self.low_indices_workspace = np.zeros(self.dims, dtype=np.int32)
+                self.deltas_workspace = np.zeros(self.dims, dtype=np.float64)
+
+            return _numba_mlg_kernel(
+                args[0],
+                self.grid_tuples,
+                self.flat_data,
+                self.strides,
+                self.low_indices_workspace,
+                self.deltas_workspace,
+                self.num_channels,
+            )
 
 
 def load_wavelen(wavelength_file: str):

--- a/isofit/test/test_common.py
+++ b/isofit/test/test_common.py
@@ -145,7 +145,7 @@ def test_recursive_replace():
     assert modified_dict3 == dict3
 
 
-def test_interpolators():
+def interp_test(method_a, method_b):
     grid_input = [[1, 5, 10], [2, 4, 6, 7], [50, 60, 80], [0.1, 0.5]]
     data_input = np.random.random(
         (
@@ -157,8 +157,8 @@ def test_interpolators():
         )
     )
 
-    v_orig = VectorInterpolator(grid_input, data_input, version="rg")
-    v_new = VectorInterpolator(grid_input, data_input, version="mlg")
+    v_orig = VectorInterpolator(grid_input, data_input, version=method_a)
+    v_new = VectorInterpolator(grid_input, data_input, version=method_b)
 
     input_test = np.random.random((100, len(grid_input)))
     for _n in range(len(grid_input)):
@@ -177,3 +177,8 @@ def test_interpolators():
         res_orig.flatten(), res_new.flatten()
     )
     assert rvalue**2 > 1 - 1e-6
+
+
+def test_interpolators():
+    interp_test("rg", "mlg")
+    interp_test("rg", "mlg_numba")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "dask",
   "h5py <= 3.14.0",
   "netCDF4 < 1.7.4",
+  "numba",
   "numpy >= 1.20",
   "torch",
   "pyyaml >= 5.3.2",


### PR DESCRIPTION
On a speedtest as defined below, gives:

Orig: 0.277
New: 0.0456

A factor of 6ish.  TBD what that means for full isofit runs.  Results will vary depending on grid size.  Also TBD if this should be default.

Numba is not bound in pyproj, we may need a minimum.


Speedtest (mostly borrowed from test):

```
import scipy

from isofit.core.common import (
    VectorInterpolator,
    combos,
    eps,
    expand_path,
    get_absorption,
    load_spectrum,
    load_wavelen,
    recursive_replace,
    spectral_response_function,
    svd_inv,
    svd_inv_sqrt,
)

grid_input = [[1, 5, 10], [2, 4, 6, 7], [50, 60, 80], [0.1, 0.5], [380, 420]]
data_input = np.random.random(
    (
        len(grid_input[0]),
        len(grid_input[1]),
        len(grid_input[2]),
        len(grid_input[3]),
        len(grid_input[4]),
        30,
    )
)

v_orig = VectorInterpolator(grid_input, data_input, version="mlg")
v_new = VectorInterpolator(grid_input, data_input, version="mlg_numba")

input_test = np.random.random((10000, len(grid_input)))
for _n in range(len(grid_input)):
    input_test[:, _n] = input_test[:, _n] * (
        np.max(grid_input[_n]) - np.min(grid_input[_n])
    ) + np.min(grid_input[_n])

res_orig = np.zeros((input_test.shape[0], data_input.shape[-1]))
res_new = np.zeros((input_test.shape[0], data_input.shape[-1]))

st = time.time()
for _n in range(res_orig.shape[0]):
    res_orig[_n, :] = v_orig(input_test[_n, :])
print(f'Orig: {time.time() - st}')
st = time.time()
for _n in range(res_orig.shape[0]):
    res_new[_n, :] = v_new(input_test[_n, :])
print(f'New: {time.time() - st}')

slope, intercept, rvalue, pvalue, stderr = scipy.stats.linregress(
    res_orig.flatten(), res_new.flatten()
)
assert rvalue**2 > 1 - 1e-6
```
