### PR TITLE
Unbounded rfl statevector elements

### DIFF
--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -104,20 +104,13 @@ class Inversion:
         self.x_fixed = None
 
         # Set least squares params that come from the forward model
-        lb = np.full(self.fm.nstate, fill_value=-np.inf)
-        ub = np.full(self.fm.nstate, fill_value=np.inf)
-
-        bounded_idxs = np.concatenate(
-            [self.fm.idx_surf_nonrfl, self.fm.idx_RT, self.fm.idx_instrument]
-        )
-
-        lb[bounded_idxs] = self.fm.bounds[0][bounded_idxs]
-        ub[bounded_idxs] = self.fm.bounds[1][bounded_idxs]
-
         self.least_squares_params = {
             "method": "trf",
             "max_nfev": 20,
-            "bounds": (lb[self.inds_free], ub[self.inds_free]),
+            "bounds": (
+                self.fm.bounds[0][self.inds_free],
+                self.fm.bounds[1][self.inds_free],
+            ),
             "x_scale": self.fm.scale[self.inds_free],
         }
 

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -104,13 +104,20 @@ class Inversion:
         self.x_fixed = None
 
         # Set least squares params that come from the forward model
+        lb = np.full(self.fm.nstate, fill_value=-np.inf)
+        ub = np.full(self.fm.nstate, fill_value=np.inf)
+
+        bounded_idxs = np.concatenate(
+            [self.fm.idx_surf_nonrfl, self.fm.idx_RT, self.fm.idx_instrument]
+        )
+
+        lb[bounded_idxs] = self.fm.bounds[0][bounded_idxs]
+        ub[bounded_idxs] = self.fm.bounds[1][bounded_idxs]
+
         self.least_squares_params = {
             "method": "trf",
             "max_nfev": 20,
-            "bounds": (
-                self.fm.bounds[0][self.inds_free],
-                self.fm.bounds[1][self.inds_free],
-            ),
+            "bounds": (lb[self.inds_free], ub[self.inds_free]),
             "x_scale": self.fm.scale[self.inds_free],
         }
 

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -47,6 +47,8 @@ class GlintModelSurface(MultiComponentSurface):
         self.init.extend([1 / np.pi, 0.02])
 
         # Gege (2021), WASI user manual
+        rmin, rmax = -0.05, 2.0
+        self.bounds = [[rmin, rmax] for w in self.wl]
         self.bounds.extend([[0, 10], [0, 10]])
 
         self.n_state = self.n_state + 2

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -83,7 +83,7 @@ class MultiComponentSurface(Surface):
         # Change this if you don't want to analytical solve for all the full statevector elements.
         self.analytical_iv_idx = np.arange(len(self.statevec_names))
 
-        self.bounds = [[rmin, rmax] for w in self.wl]
+        self.bounds = [[-np.inf, np.inf] for w in self.wl]
         self.scale = [1.0 for w in self.wl]
         self.init = [0.15 * (rmax - rmin) + rmin for v in self.wl]
         self.idx_lamb = np.arange(self.n_wl)


### PR DESCRIPTION
I believe this can offer a ~1.4-1.5x speed up for per-pixel solve (based on EMIT image on my local machine). 

Scipy least squares allows for [partial bounds](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.least_squares.html#:~:text=Lower%20and%20upper%20bounds%20on%20independent%20variables.%20Defaults%20to%20no%20bounds.%20Each%20array%20must%20match%20the%20size%20of%20x0%20or%20be%20a%20scalar%2C%20in%20the%20latter%20case%20a%20bound%20will%20be%20the%20same%20for%20all%20variables.%20Use%20np.inf%20with%20an%20appropriate%20sign%20to%20disable%20bounds%20on%20all%20or%20some%20variables.) of the constrained problem. Being that most of our state vector is rfl, this can dramatically reduce the computation it would seem. This of course is only on the table if we are okay with reflectance part of state vector to be unbounded. 

