### PR TITLE
Cache Seps and Sa in AOE

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -241,6 +241,7 @@ def invert_analytical(
     num_iter: int = 1,
     hash_table: OrderedDict = None,
     hash_size: int = None,
+    priors_cache: dict = None,
     diag_uncert: bool = True,
     outside_ret_const: float = -0.01,
     fill_value: float = -9999.0,
@@ -314,8 +315,10 @@ def invert_analytical(
     # Sample just the wavelengths and states of interest
     L = H[winidx, :][:, iv_idx]
 
-    # Assuming x0 is very close (K does not change), we can pull out Seps, Sa and use hashing
-    # NOTE assuming uW/cm2 for rounding for hash table
+    # Use cached priors (computed during Worker init)
+    Sa_inv, xa_surface, prprod = priors_cache[geom.surf_cmp_init]
+
+    # NOTE assuming uW/cm2 for rounding for hash table for Seps
     i = None
     if hash_table is not None:
         i = xxhash.xxh64_digest(np.round(meas, 0))
@@ -323,14 +326,6 @@ def invert_analytical(
         if i in hash_table:
             P, C_rcond, prprod = hash_table[i]
         else:
-            # Use cached scaling factor from inital normalized inverse
-            _, Sa_inv_full, _ = fm.Sa(x, geom)
-            Sa_inv = Sa_inv_full[fm.idx_surface, :][:, fm.idx_surface]
-            xa_surface = fm.xa(x, geom)[fm.idx_surface]
-
-            # Save the product of the prior covariance and mean
-            prprod = Sa_inv @ xa_surface
-
             # Measurement uncertainty
             Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
             P = dpotri(dpotrf(Seps, 1)[0], 1)[0]

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -289,6 +289,24 @@ def invert_analytical(
     rho_dir_dir = fm.upsample(fm.surface.wl, rho_dir_dir)
     rho_dif_dir = fm.upsample(fm.surface.wl, rho_dif_dir)
 
+    # Calc rdn rounded to nearest uW/cm2 for rounding for hash table for Seps
+    Ls = fm.calc_Ls(x, geom)
+    Ls = fm.upsample(fm.surface.wl, Ls)
+    rdn = fm.RT.calc_rdn(
+        x_RT,
+        rho_dir_dir=rho_dir_dir,
+        rho_dif_dir=rho_dif_dir,
+        Ls=Ls,
+        L_tot=L_tot,
+        L_dir_dir=L_dir_dir,
+        L_dif_dir=L_dif_dir,
+        L_dir_dif=L_dir_dif,
+        L_dif_dif=L_dif_dif,
+        r=r,
+        geom=geom,
+    )
+    rdn = np.round(rdn, 0)
+
     # Background conditions equal to the superpixel reflectance
     bg = s * rho_dif_dir
 
@@ -318,10 +336,9 @@ def invert_analytical(
     # Use cached priors (computed during Worker init)
     Sa_inv, xa_surface, prprod = priors_cache[geom.surf_cmp_init]
 
-    # NOTE assuming uW/cm2 for rounding for hash table for Seps
     i = None
     if hash_table is not None:
-        i = xxhash.xxh64_digest(np.round(meas, 0))
+        i = xxhash.xxh64_digest(rdn)
 
         if i in hash_table:
             P, C_rcond = hash_table[i]

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -324,7 +324,7 @@ def invert_analytical(
         i = xxhash.xxh64_digest(np.round(meas, 0))
 
         if i in hash_table:
-            P, C_rcond, prprod = hash_table[i]
+            P, C_rcond = hash_table[i]
         else:
             # Measurement uncertainty
             Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
@@ -336,7 +336,7 @@ def invert_analytical(
             LI_rcond = dpotrf(P_rcond)[0]
             C_rcond = dpotri(LI_rcond)[0]
 
-            hash_table[i] = (P, C_rcond, prprod)
+            hash_table[i] = (P, C_rcond)
 
     y = meas[winidx] - L_atm[winidx] - eof_offset[winidx]
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -18,9 +18,9 @@
 # Author: David R Thompson, david.r.thompson@jpl.nasa.gov
 from __future__ import annotations
 
-import os
 from typing import OrderedDict
 
+import xxhash
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.optimize import least_squares, minimize
@@ -314,37 +314,43 @@ def invert_analytical(
     # Sample just the wavelengths and states of interest
     L = H[winidx, :][:, iv_idx]
 
-    # Use cached scaling factor from inital normalized inverse (outside of loop).
-    Sa, Sa_inv, Sa_inv_sqrt = fm.Sa(x, geom)
-    Sa_inv = Sa_inv[fm.idx_surface, :][:, fm.idx_surface]
-    Sa_inv_sqrt = Sa_inv_sqrt[fm.idx_surface, :][:, fm.idx_surface]
+    # Assuming x0 is very close (K does not change), we can pull out Seps, Sa and use hashing
+    # NOTE assuming uW/cm2 for rounding for hash table
+    i = None
+    if hash_table is not None:
+        i = xxhash.xxh64_digest(np.round(meas, 0))
+
+        if i in hash_table:
+            P, C_rcond, prprod = hash_table[i]
+        else:
+            # Use cached scaling factor from inital normalized inverse
+            _, Sa_inv_full, _ = fm.Sa(x, geom)
+            Sa_inv = Sa_inv_full[fm.idx_surface, :][:, fm.idx_surface]
+            xa_surface = fm.xa(x, geom)[fm.idx_surface]
+
+            # Save the product of the prior covariance and mean
+            prprod = Sa_inv @ xa_surface
+
+            # Measurement uncertainty
+            Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
+            P = dpotri(dpotrf(Seps, 1)[0], 1)[0]
+
+            P_tilde = ((L.T @ P) @ L).T
+            P_rcond = Sa_inv[iv_idx, :][:, iv_idx] + P_tilde
+
+            LI_rcond = dpotrf(P_rcond)[0]
+            C_rcond = dpotri(LI_rcond)[0]
+
+            hash_table[i] = (P, C_rcond, prprod)
+
+    y = meas[winidx] - L_atm[winidx] - eof_offset[winidx]
 
     trajectory = np.zeros((num_iter + 1, len(x)))
     trajectory[0, :] = x
     for n in range(num_iter):
 
-        # Measurement uncertainty
-        Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
-
-        # Prior mean
-        xa_full = fm.xa(x, geom)
-        xa_surface = xa_full[fm.idx_surface]
-
-        # Save the product of the prior covariance and mean
-        prprod = Sa_inv @ xa_surface
-
         x_surface, x_RT, x_instrument = fm.unpack(x)
 
-        C = dpotrf(Seps, 1)[0]
-        P = dpotri(C, 1)[0]
-
-        P_tilde = ((L.T @ P) @ L).T
-        P_rcond = Sa_inv[iv_idx, :][:, iv_idx] + P_tilde
-
-        LI_rcond = dpotrf(P_rcond)[0]
-        C_rcond = dpotri(LI_rcond)[0]
-
-        y = meas[winidx] - L_atm[winidx] - eof_offset[winidx]
         xk = dsymv(
             1,
             C_rcond,

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -336,24 +336,29 @@ def invert_analytical(
     # Use cached priors (computed during Worker init)
     Sa_inv, xa_surface, prprod = priors_cache[geom.surf_cmp_init]
 
+    # Measurement uncertainty
     i = None
+    hash_hit = False
     if hash_table is not None:
         i = xxhash.xxh64_digest(rdn)
-
         if i in hash_table:
             P, C_rcond = hash_table[i]
-        else:
-            # Measurement uncertainty
-            Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
-            P = dpotri(dpotrf(Seps, 1)[0], 1)[0]
+            hash_hit = True
 
-            P_tilde = ((L.T @ P) @ L).T
-            P_rcond = Sa_inv[iv_idx, :][:, iv_idx] + P_tilde
+    if not hash_hit:
+        Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
+        P = dpotri(dpotrf(Seps, 1)[0], 1)[0]
 
-            LI_rcond = dpotrf(P_rcond)[0]
-            C_rcond = dpotri(LI_rcond)[0]
+        P_tilde = ((L.T @ P) @ L).T
+        P_rcond = Sa_inv[iv_idx, :][:, iv_idx] + P_tilde
 
+        LI_rcond = dpotrf(P_rcond)[0]
+        C_rcond = dpotri(LI_rcond)[0]
+
+        if (hash_table is not None) and (hash_size is not None):
             hash_table[i] = (P, C_rcond)
+            while len(hash_table) > hash_size:
+                hash_table.popitem(last=False)
 
     y = meas[winidx] - L_atm[winidx] - eof_offset[winidx]
 

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -441,6 +441,19 @@ class Worker(object):
         self.hash_table = OrderedDict()
         self.hash_size = config.implementation.max_hash_table_size
 
+        # Set priors cache to speed up math in AOE
+        self.priors_cache = {}
+        tmp_x = self.fm.init.copy()
+        tmp_geom = Geometry(obs=self.obs[0, 0, :], loc=self.loc[0, 0, :], esd=self.esd)
+        for i in range(getattr(self.fm.surface, "n_comp", 1)):
+            tmp_geom.surf_cmp_init = i
+            _, Sa_inv_full, _ = self.fm.Sa(tmp_x, tmp_geom)
+            Sa_inv = Sa_inv_full[self.fm.idx_surface, :][:, self.fm.idx_surface]
+            xa_surface = self.fm.xa(tmp_x, tmp_geom)[self.fm.idx_surface]
+            prprod = Sa_inv @ xa_surface
+            self.priors_cache[i] = (Sa_inv, xa_surface, prprod)
+        del tmp_geom, tmp_x
+
         # Can't see any reason to leave these as optional
         self.subs_state_file = subs_state_file
         self.lbl_file = lbl_file
@@ -586,6 +599,7 @@ class Worker(object):
 
             # NOTE: this line needs to be here to ensure geom.surf_cmp_init is populated
             geom.x_surf_init = x0[self.fm.idx_surface]
+            self.fm.surface.xa(geom.x_surf_init, geom)
 
             states, unc = invert_analytical(
                 self.fm,
@@ -597,6 +611,7 @@ class Worker(object):
                 self.num_iter,
                 self.hash_table,
                 self.hash_size,
+                priors_cache=self.priors_cache,
             )
             state_est = states[-1]
 


### PR DESCRIPTION
In our [invert_analytical](https://github.com/isofit/isofit/blob/dev/isofit/inversion/inverse_simple.py#L234) method,  we compute Seps and Sa for all pixels to compute MAP. However, we may want to leverage that some pixels in a given line are similar _enough_ that we may use our xxhash framwork we already have worked into the code.

By assuming a hash table key of `np.round(meas, 0)` ( rounded to the nearest int , um /cm) , and assuming Jacobian is a reasonable estimate from x0 (which I believe is what we are already doing at present) -  we can speed up AOE solutions depending on spatial uniformity in the scene. 

 In the EMIT snow scene I have been testing, this sped up AOE inversions 1.2x. This is also a function of `max_hash_table_size` which is configurable. 

There may be other ways to key the hashtable. Using `meas` was my first idea because it contains information about x_surface, x_RT, and meas (which ticks all the boxes for altering Sa and Seps). However, it is possible that scenes of high noise (dark water pixels) this key would offer not as much of a speed up. 

--



<img width="3074" height="1714" alt="image" src="https://github.com/user-attachments/assets/553f9952-9df7-4705-8a7e-90f69f8abd24" />
