### PR TITLE
not calling match_statevector on every write

### DIFF
--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -39,7 +39,7 @@ from isofit.core.common import (
     resample_spectrum,
 )
 from isofit.core.geometry import Geometry
-from isofit.core.multistate import match_statevector
+from isofit.core.multistate import fill_statevector, jit_statevector
 from isofit.data import env
 from isofit.inversion.inverse_simple import invert_algebraic
 
@@ -638,8 +638,11 @@ class IO:
             ############ Start with all of the 'independent' calculations
             if "estimated_state_file" in self.output_datasets:
                 # state_est transformed to reflect io.full_statevec
-                to_write["estimated_state_file"] = match_statevector(
-                    state_est, self.full_statevec, fm.statevec
+                # to_write["estimated_state_file"] = jit_statevector(
+                #     state_est, self.full_statevec, fm.statevec
+                # )
+                to_write["estimated_state_file"] = fill_statevector(
+                    state_est, fm.full_idx, fm.full_miss, self.full_statevec
                 )
 
             if "path_radiance_file" in self.output_datasets:
@@ -665,8 +668,14 @@ class IO:
 
             if "posterior_uncertainty_file" in self.output_datasets:
                 S_hat, K, G = iv.calc_posterior(state_est, geom, meas)
-                to_write["posterior_uncertainty_file"] = match_statevector(
-                    np.sqrt(np.diag(S_hat)), self.full_statevec, fm.statevec
+                # to_write["posterior_uncertainty_file"] = jit_statevector(
+                #     np.sqrt(np.diag(S_hat)), self.full_statevec, fm.statevec
+                # )
+                to_write["posterior_uncertainty_file"] = fill_statevector(
+                    np.sqrt(np.diag(S_hat)),
+                    fm.full_idx,
+                    fm.full_miss,
+                    self.full_statevec,
                 )
 
             ############ Now proceed to the calcs where they may be some overlap

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -636,14 +636,15 @@ class IO:
                 raise IOError("len(fm.statevec) > len(self.full_statevec)")
 
             ############ Start with all of the 'independent' calculations
+            full_state = np.zeros((len(full_statevec))) + -9999.0
             if "estimated_state_file" in self.output_datasets:
                 # state_est transformed to reflect io.full_statevec
-                # to_write["estimated_state_file"] = jit_statevector(
-                #     state_est, self.full_statevec, fm.statevec
-                # )
-                to_write["estimated_state_file"] = fill_statevector(
-                    state_est, fm.full_idx, fm.full_miss, self.full_statevec
+                to_write["estimated_state_file"] = jit_statevector(
+                    state_est, self.full_statevec, fm.statevec, full_state
                 )
+                # to_write["estimated_state_file"] = fill_statevector(
+                #     state_est, fm.full_idx, fm.full_miss, self.full_statevec
+                # )
 
             if "path_radiance_file" in self.output_datasets:
                 # Note: for glint models, this will return atm + glint
@@ -668,15 +669,15 @@ class IO:
 
             if "posterior_uncertainty_file" in self.output_datasets:
                 S_hat, K, G = iv.calc_posterior(state_est, geom, meas)
-                # to_write["posterior_uncertainty_file"] = jit_statevector(
-                #     np.sqrt(np.diag(S_hat)), self.full_statevec, fm.statevec
-                # )
-                to_write["posterior_uncertainty_file"] = fill_statevector(
-                    np.sqrt(np.diag(S_hat)),
-                    fm.full_idx,
-                    fm.full_miss,
-                    self.full_statevec,
+                to_write["posterior_uncertainty_file"] = jit_statevector(
+                    np.sqrt(np.diag(S_hat)), self.full_statevec, fm.statevec, full_state
                 )
+                # to_write["posterior_uncertainty_file"] = fill_statevector(
+                #     np.sqrt(np.diag(S_hat)),
+                #     fm.full_idx,
+                #     fm.full_miss,
+                #     self.full_statevec,
+                # )
 
             ############ Now proceed to the calcs where they may be some overlap
 

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -39,7 +39,7 @@ from isofit.core.common import (
     resample_spectrum,
 )
 from isofit.core.geometry import Geometry
-from isofit.core.multistate import fill_statevector, jit_statevector
+from isofit.core.multistate import fill_statevector
 from isofit.data import env
 from isofit.inversion.inverse_simple import invert_algebraic
 
@@ -636,15 +636,11 @@ class IO:
                 raise IOError("len(fm.statevec) > len(self.full_statevec)")
 
             ############ Start with all of the 'independent' calculations
-            full_state = np.zeros((len(full_statevec))) + -9999.0
             if "estimated_state_file" in self.output_datasets:
                 # state_est transformed to reflect io.full_statevec
-                to_write["estimated_state_file"] = jit_statevector(
-                    state_est, self.full_statevec, fm.statevec, full_state
+                to_write["estimated_state_file"] = fill_statevector(
+                    state_est, fm.full_idx, fm.full_miss, self.full_statevec
                 )
-                # to_write["estimated_state_file"] = fill_statevector(
-                #     state_est, fm.full_idx, fm.full_miss, self.full_statevec
-                # )
 
             if "path_radiance_file" in self.output_datasets:
                 # Note: for glint models, this will return atm + glint
@@ -669,15 +665,12 @@ class IO:
 
             if "posterior_uncertainty_file" in self.output_datasets:
                 S_hat, K, G = iv.calc_posterior(state_est, geom, meas)
-                to_write["posterior_uncertainty_file"] = jit_statevector(
-                    np.sqrt(np.diag(S_hat)), self.full_statevec, fm.statevec, full_state
+                to_write["posterior_uncertainty_file"] = fill_statevector(
+                    np.sqrt(np.diag(S_hat)),
+                    fm.full_idx,
+                    fm.full_miss,
+                    self.full_statevec,
                 )
-                # to_write["posterior_uncertainty_file"] = fill_statevector(
-                #     np.sqrt(np.diag(S_hat)),
-                #     fm.full_idx,
-                #     fm.full_miss,
-                #     self.full_statevec,
-                # )
 
             ############ Now proceed to the calcs where they may be some overlap
 

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -30,6 +30,7 @@ from scipy.linalg import block_diag
 from isofit.core.common import eps, svd_inv_sqrt
 from isofit.core.geometry import Geometry
 from isofit.core.instrument import Instrument
+from isofit.core.multistate import match_statevector
 from isofit.radiative_transfer.radiative_transfer import RadiativeTransfer
 from isofit.surface import Surface
 
@@ -114,6 +115,9 @@ class ForwardModel:
         Split surface state vector indices to cover cases where we retrieve
         additional non-reflectance surface parameters
         """
+        self.full_idx = np.arange(len(self.statevec))
+        self.full_miss = []
+
         # entire surface portion
         self.idx_surface = np.arange(len(self.surface.statevec_names), dtype=int)
 
@@ -508,3 +512,8 @@ class ForwardModel:
         x_RT = x[self.idx_RT]
         x_instrument = x[self.idx_instrument]
         return x_surface, x_RT, x_instrument
+
+    def match_statevector(self, full_statevector):
+        self.full_idx, self.full_miss = match_statevector(
+            full_statevector, self.statevec
+        )

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -216,6 +216,7 @@ class Isofit:
 
             # Set forward model
             fm = ForwardModel(config, cache_RT=cache_RT)
+            fm.match_statevector(self.full_statevector)
 
             logging.debug(f"Surface: {surface_class_str}")
 

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -177,8 +177,8 @@ class Isofit:
         input_config = deepcopy(self.config)
 
         # Loop through index pairs and run workers
-        outer_loop_start_time = time.time()
-
+        loop_total_time = 0
+        loop_total_spectra = 0
         cache_RT = None
         surface_index = index_spectra_by_surface(input_config, index_pairs)
         for i, (surface_class_str, class_idx_pairs) in enumerate(surface_index.items()):
@@ -252,11 +252,15 @@ class Isofit:
                 )
             )
 
-            total_time = time.time() - start_time
+            loop_total_time += time.time() - start_time
+            loop_total_spectra += n_iter
             logging.info(f"Pixel class: {surface_class_str} inversions complete.")
-            logging.info(f"{round(total_time,2)}s total")
-            logging.info(f"{round(n_iter/total_time,4)} spectra/s")
-            logging.info(f"{round(n_iter/total_time/n_workers,4)} spectra/s/core")
+            logging.info("Running totals")
+            logging.info(f"{round(loop_total_time,2)}s total")
+            logging.info(f"{round(loop_total_spectra/loop_total_time,4)} spectra/s")
+            logging.info(
+                f"{round(loop_total_spectra/loop_total_time/n_workers,4)} spectra/s/core"
+            )
 
             # Not sure if it's best practice to null out these vars
             self.workers = None
@@ -269,12 +273,12 @@ class Isofit:
             del fm
 
         if len(index_pairs):
-            outer_loop_total_time = time.time() - outer_loop_start_time
             logging.info(f"All Inversions complete.")
-            logging.info(f"{round(outer_loop_total_time,2)}s total")
-            logging.info(f"{round(total_samples/outer_loop_total_time,4)} spectra/s")
+            logging.info("Final totals")
+            logging.info(f"{round(loop_total_time,2)}s total")
+            logging.info(f"{round(loop_total_spectra/loop_total_time,4)} spectra/s")
             logging.info(
-                f"{round(total_samples/outer_loop_total_time/n_workers,4)} spectra/s/core"
+                f"{round(loop_total_spectra/loop_total_time/n_workers,4)} spectra/s/core"
             )
 
 

--- a/isofit/core/multistate.py
+++ b/isofit/core/multistate.py
@@ -332,9 +332,7 @@ def fill_statevector(state_est, idx, miss, full_statevector, null_value=-9999.0)
 
 
 @numba.jit
-def jit_statevector(
-    state_data: np.array, full_statevec: list, fm_statevec: list, null_value=-9999.0
-):
+def jit_statevector(state_data, full_statevec, fm_statevec, full_state):
     """
     A multi-class surface requires some merging across statevectors
     of different length. This function maps the fm-specific state
@@ -348,7 +346,6 @@ def jit_statevector(
     returns:
         full_state: (np.array) Populated full state with null_values in missing elements
     """
-    full_state = np.zeros((len(full_statevec))) + null_value
     idx = []
     for fm_name in fm_statevec:
         for i, full_name in enumerate(full_statevec):

--- a/isofit/core/multistate.py
+++ b/isofit/core/multistate.py
@@ -329,28 +329,3 @@ def fill_statevector(state_est, idx, miss, full_statevector, null_value=-9999.0)
     output[miss] = null_value
 
     return output
-
-
-@numba.jit
-def jit_statevector(state_data, full_statevec, fm_statevec, full_state):
-    """
-    A multi-class surface requires some merging across statevectors
-    of different length. This function maps the fm-specific state
-    to the io-state that captures all state elements present in the
-    image. The full_state will record a Non
-    Args:
-        state_data: (n,) numpy array with the fm-specific state vector
-        full_statevec: [m] list of state-names of the image-universal combined statevector
-        fm_statevec: [n] list of state-names of the fm-specific state vector
-        null_value: (optional) value to fill in the statevector elements that aren't present at a pixel
-    returns:
-        full_state: (np.array) Populated full state with null_values in missing elements
-    """
-    idx = []
-    for fm_name in fm_statevec:
-        for i, full_name in enumerate(full_statevec):
-            if fm_name == full_name:
-                idx.append(i)
-    full_state[idx] = state_data
-
-    return full_state

--- a/isofit/core/multistate.py
+++ b/isofit/core/multistate.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 import time
 
+import numba
 import numpy as np
 from scipy.interpolate import interp1d
 from spectral.io import envi
@@ -292,7 +293,46 @@ def update_config_for_surface(config, surface_class_str, clouds=True):
     return config
 
 
-def match_statevector(
+def match_statevector(full_statevec: list, fm_statevec: list):
+    """
+    A multi-class surface requires some merging across statevectors
+    of different length. This function maps the fm-specific state
+    to the io-state that captures all state elements present in the
+    image. The full_state will record a Non
+    Args:
+        full_statevec: [m] list of state-names of the image-universal combined statevector
+        fm_statevec: [n] list of state-names of the fm-specific state vector
+    returns:
+        idx: list(int) mapping for which statevector elements are present in fm
+        miss: list(int) mapping for non-present statevector elements
+
+    """
+    idx = []
+    for fm_name in fm_statevec:
+        for i, full_name in enumerate(full_statevec):
+            if fm_name == full_name:
+                idx.append(i)
+
+    rang = set([i for i in range(len(full_statevec))])
+    idx_rng = set(sorted(idx))
+    miss = sorted(list(rang - idx_rng))
+
+    return idx, miss
+
+
+def fill_statevector(state_est, idx, miss, full_statevector, null_value=-9999.0):
+    """
+    Map a fm output onto a full statevector
+    """
+    output = np.empty((len(full_statevector)))
+    output[idx] = state_est
+    output[miss] = null_value
+
+    return output
+
+
+@numba.jit
+def jit_statevector(
     state_data: np.array, full_statevec: list, fm_statevec: list, null_value=-9999.0
 ):
     """

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -38,8 +38,9 @@ from isofit.core.forward import ForwardModel
 from isofit.core.geometry import Geometry
 from isofit.core.multistate import (
     construct_full_state,
+    fill_statevector,
     index_spectra_by_surface,
-    match_statevector,
+    jit_statevector,
     update_config_for_surface,
 )
 from isofit.inversion.inverse_simple import (
@@ -285,6 +286,7 @@ def analytical_line(
         config = update_config_for_surface(deepcopy(input_config), surface_class_str)
 
         fm = ForwardModel(config, cache_RT)
+        fm.match_statevector(full_statevector)
 
         # Initialize workers
         wargs = [ray.put(obj) for obj in (config, fm)]
@@ -600,13 +602,17 @@ class Worker(object):
             )
             state_est = states[-1]
 
-            full_state_est = match_statevector(
-                state_est, self.full_statevector, self.fm.statevec
+            full_state_est = fill_statevector(
+                state_est, self.fm.full_idx, self.fm.full_miss, self.full_statevector
             )
+            # full_state_est = ji_statevector(
+            #     state_est, self.full_statevector, self.fm.statevec
+            # )
             output_rfl[r - start_line, c, :] = full_state_est[self.full_idx_surf_rfl]
 
-            full_unc_est = match_statevector(
-                unc, self.full_statevector, self.fm.statevec
+            # full_unc_est = jit_statevector(un, self.full_statevector, self.fm.statevec)
+            full_unc_est = fill_statevector(
+                unc, self.fm.full_idx, self.fm.full_miss, self.full_statevector
             )
             output_rfl_unc[r - start_line, c, :] = full_unc_est[self.full_idx_surf_rfl]
 

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -40,7 +40,6 @@ from isofit.core.multistate import (
     construct_full_state,
     fill_statevector,
     index_spectra_by_surface,
-    jit_statevector,
     update_config_for_surface,
 )
 from isofit.inversion.inverse_simple import (
@@ -602,21 +601,14 @@ class Worker(object):
             )
             state_est = states[-1]
 
-            # full_state_est = fill_statevector(
-            #     state_est, self.fm.full_idx, self.fm.full_miss, self.full_statevector
-            # )
-            full_state = np.zeros((len(full_statevec))) + -9999.0
-            full_state_est = ji_statevector(
-                state_est, self.full_statevector, self.fm.statevec, full_state
+            full_state_est = fill_statevector(
+                state_est, self.fm.full_idx, self.fm.full_miss, self.full_statevector
             )
             output_rfl[r - start_line, c, :] = full_state_est[self.full_idx_surf_rfl]
 
-            full_unc_est = jit_statevector(
-                un, self.full_statevector, self.fm.statevec, full_state
+            full_unc_est = fill_statevector(
+                unc, self.fm.full_idx, self.fm.full_miss, self.full_statevector
             )
-            # full_unc_est = fill_statevector(
-            #     unc, self.fm.full_idx, self.fm.full_miss, self.full_statevector
-            # )
             output_rfl_unc[r - start_line, c, :] = full_unc_est[self.full_idx_surf_rfl]
 
             full_state_est[len(self.full_idx_surf_rfl) : self.n_non_rfl_bands]

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -602,18 +602,21 @@ class Worker(object):
             )
             state_est = states[-1]
 
-            full_state_est = fill_statevector(
-                state_est, self.fm.full_idx, self.fm.full_miss, self.full_statevector
-            )
-            # full_state_est = ji_statevector(
-            #     state_est, self.full_statevector, self.fm.statevec
+            # full_state_est = fill_statevector(
+            #     state_est, self.fm.full_idx, self.fm.full_miss, self.full_statevector
             # )
+            full_state = np.zeros((len(full_statevec))) + -9999.0
+            full_state_est = ji_statevector(
+                state_est, self.full_statevector, self.fm.statevec, full_state
+            )
             output_rfl[r - start_line, c, :] = full_state_est[self.full_idx_surf_rfl]
 
-            # full_unc_est = jit_statevector(un, self.full_statevector, self.fm.statevec)
-            full_unc_est = fill_statevector(
-                unc, self.fm.full_idx, self.fm.full_miss, self.full_statevector
+            full_unc_est = jit_statevector(
+                un, self.full_statevector, self.fm.statevec, full_state
             )
+            # full_unc_est = fill_statevector(
+            #     unc, self.fm.full_idx, self.fm.full_miss, self.full_statevector
+            # )
             output_rfl_unc[r - start_line, c, :] = full_unc_est[self.full_idx_surf_rfl]
 
             full_state_est[len(self.full_idx_surf_rfl) : self.n_non_rfl_bands]


### PR DESCRIPTION
Low-hanging fruit for some potential gains.

Needs debugging and testing.

From some per-pixel profiling on the analytical line:

The highlighted field is the cumulative time. Run calls on far left is the same.

With the old match_statevector:
<img width="1006" height="35" alt="Screenshot 2026-03-12 at 11 09 18 AM" src="https://github.com/user-attachments/assets/073ccfcc-fc84-4836-9b05-2eb1e1cf4de8" />

With these updates:
<img width="1119" height="35" alt="Screenshot 2026-03-12 at 11 11 05 AM" src="https://github.com/user-attachments/assets/fd10eb31-be86-4af5-8ba6-3bf4de4d0fd3" />

Looks like this is considerable (on the AV5 scene that we've been using as benchmark):

```
With change:

AOE:

INFO:2026-03-12,12:12:30 || analytical_line.py:analytical_line() | Analytical line inversions complete. 
 1121.75s total, 2209.0579 spectra/s, 34.5165 spectra/s/core

```

I've removed the highlights of the OE times. It looks like speed gain for OE is minor (altough there is some) compared to the AOE
