### PR TITLE
Cache Rebuild Fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ name: Build
 on:
   pull_request_target:
     branches: ["dev"]
-    paths: ["isofit/**", "recipe/*.yml", "pyproject.toml", ".github/workflows/*"]
+    paths: ["isofit/**", "recipe/*.yml", "pyproject.toml"]
 
 concurrency:
   group: ${{ github.event.pull_request.head.ref }}
@@ -82,21 +82,12 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
-      - name: Set rebuild flag
-        id: rebuild
-        run: |
-          if [[ "${{ github.event.pull_request.body || '' }}" == *"[rebuild-cache]"* ]]; then
-            echo "suffix=-${{ github.run_id }}" >> $GITHUB_OUTPUT
-          else
-            echo "suffix=" >> $GITHUB_OUTPUT
-          fi
-
       - name: Cache Extras
         id: cache-extras
         uses: actions/cache@v4
         with:
           path: .isofit
-          key: cache-extras${{ steps.rebuild.outputs.suffix }}
+          key: cache-extras${{ contains(github.event.pull_request.body || '', '[rebuild-cache]') && format('-{0}', github.run_id) || '' }}
           restore-keys: |
             cache-extras
           enableCrossOsArchive: true
@@ -167,19 +158,19 @@ jobs:
     needs: cache
     uses: ./.github/workflows/test_pip.yml
     with:
-      rebuild-cache: ${{ contains(github.event.pull_request.body || '', '[rebuild-cache]') }}
+      cache-key: cache-extras${{ contains(github.event.pull_request.body || '', '[rebuild-cache]') && format('-{0}', github.run_id) || '' }}
 
   # Test $PYTHONPATH installation
   path:
     needs: cache
     uses: ./.github/workflows/test_path.yml
     with:
-      rebuild-cache: ${{ contains(github.event.pull_request.body || '', '[rebuild-cache]') }}
+      cache-key: cache-extras${{ contains(github.event.pull_request.body || '', '[rebuild-cache]') && format('-{0}', github.run_id) || '' }}
 
   images:
     needs: cache
     uses: ./.github/workflows/images.yml
     with:
-      rebuild-cache: ${{ contains(github.event.pull_request.body || '', '[rebuild-cache]') }}
+      cache-key: cache-extras${{ contains(github.event.pull_request.body || '', '[rebuild-cache]') && format('-{0}', github.run_id) || '' }}
     secrets:
       ISOFIT_TEST_RESULTS: "${{ secrets.ISOFIT_TEST_RESULTS }}"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -3,9 +3,9 @@ name: Generate Plots
 on:
   workflow_call:
     inputs:
-      rebuild-cache:
+      cache-key:
         required: true
-        type: boolean
+        type: string
     secrets:
       ISOFIT_TEST_RESULTS:
         description: 'GH PAT for the results repo'
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .isofit
-          key: cache-extras${{ inputs.rebuild-cache && format('-{0}', github.run_id) || '' }}
+          key: ${{ inputs.cache-key }}
           fail-on-cache-miss: true
           enableCrossOsArchive: true
 

--- a/.github/workflows/test_path.yml
+++ b/.github/workflows/test_path.yml
@@ -5,9 +5,9 @@ name: Test '$PYTHONPATH' installation
 on:
   workflow_call:
     inputs:
-      rebuild-cache:
+      cache-key:
         required: true
-        type: boolean
+        type: string
 
 # concurrency:
 #   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .isofit
-          key: cache-extras${{ inputs.rebuild-cache && format('-{0}', github.run_id) || '' }}
+          key: ${{ inputs.cache-key }}
           fail-on-cache-miss: true
           enableCrossOsArchive: true
 

--- a/.github/workflows/test_pip.yml
+++ b/.github/workflows/test_pip.yml
@@ -24,9 +24,9 @@ name: Test 'pip' Package
 on:
   workflow_call:
     inputs:
-      rebuild-cache:
+      cache-key:
         required: true
-        type: boolean
+        type: string
 
 # concurrency:
 #   group: ${{ github.workflow }}-${{ github.ref }}
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .isofit
-          key: cache-extras${{ inputs.rebuild-cache && format('-{0}', github.run_id) || '' }}
+          key: ${{ inputs.cache-key }}
           fail-on-cache-miss: true
           enableCrossOsArchive: true
 


### PR DESCRIPTION
Fixes an issue with the `[rebuild-cache]` detection where sometimes a PR's body comment contains invalid regex syntax, causing the workflow to fail. This should be more stable.

Also now that PRs cannot edit workflows themselves, I've removed the trigger of workflow execution on workflow file changes