### PR TITLE
Simplify to single RTE per run

### DIFF
--- a/isofit/configs/sections/radiative_transfer_config.py
+++ b/isofit/configs/sections/radiative_transfer_config.py
@@ -113,10 +113,6 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         self.template_file = None
         """str: A template file to be used as the base-configuration for the given radiative transfer engine."""
 
-        self._treat_as_emissive_type = bool
-        self.treat_as_emissive = False
-        """bool: Run the simulation in emission mode"""
-
         self._glint_model_type = bool
         self.glint_model = False
         """
@@ -437,6 +433,9 @@ class RadiativeTransferConfig(BaseConfigSection):
         This can avoid runaway results at low cos_i values where diffuse radiance dominates.
         """
 
+        self._engine_type = RadiativeTransferEngineConfig
+        self.engine = None
+
         self.set_config_options(sub_configdic)
 
         # sort lut_grid
@@ -444,22 +443,7 @@ class RadiativeTransferConfig(BaseConfigSection):
             self.lut_grid[key] = sorted(self.lut_grid[key])
         self.lut_grid = OrderedDict(sorted(self.lut_grid.items(), key=lambda t: t[0]))
 
-        # Hold this parameter for after the config_options, as radiative_transfer_engines
-        # have a special (dynamic) load
-        self._radiative_transfer_engines_type = list()
-        self.radiative_transfer_engines = []
-
-        self._set_rt_config_options(sub_configdic["radiative_transfer_engines"])
-
-    def _set_rt_config_options(self, subconfig):
-        if type(subconfig) is list:
-            for rte in subconfig:
-                rt_model = RadiativeTransferEngineConfig(rte)
-                self.radiative_transfer_engines.append(rt_model)
-        elif type(subconfig) is dict:
-            for key in subconfig:
-                rt_model = RadiativeTransferEngineConfig(subconfig[key], name=key)
-                self.radiative_transfer_engines.append(rt_model)
+        self.engine = RadiativeTransferEngineConfig(sub_configdic["engine"])
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
@@ -473,10 +457,9 @@ class RadiativeTransferConfig(BaseConfigSection):
             if np.unique(item).size < len(item):
                 errors.append(f"Detected duplicate values in lut_grid item {key}")
 
-        for rte in self.radiative_transfer_engines:
-            er, warn = rte.check_config_validity()
-            errors.extend(er)
-            warnings.extend(warn)
+        er, warn = self.engine.check_config_validity()
+        errors.extend(er)
+        warnings.extend(warn)
 
         kinds = [
             "rg",

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -373,12 +373,7 @@ class IO:
         self.n_rows = 1
         self.n_cols = 1
         self.bbl = "{" + ",".join([str(1) for n in range(len(self.meas_wl))]) + "}"
-        self.engine_name = (
-            config.forward_model.radiative_transfer.radiative_transfer_engines[
-                0
-            ].engine_name
-        )
-        self.coszen = forward.RT.rt_engines[0].coszen or None
+        self.engine_name = config.forward_model.radiative_transfer.engine.engine_name
 
         # Use the pre-defined full statevec
         if len(full_statevec):
@@ -752,7 +747,7 @@ class IO:
 
             if "atmospheric_coefficients_file" in self.output_datasets:
                 rhoatm, sphalb, L_tot, transup, L_Up = coeffs
-                solar_irr = fm.RT.rt_engines[0].solar_irr
+                solar_irr = fm.RT.solar_irr
 
                 atm_vars = [rhoatm, sphalb, L_tot, solar_irr]
 
@@ -816,11 +811,7 @@ class IO:
         )
         wl_names = [("Channel %i" % i) for i in range(len(wl_init))]
         bbl = "{" + ",".join([str(1) for n in range(len(wl_init))]) + "}"
-        engine_name = (
-            config.forward_model.radiative_transfer.radiative_transfer_engines[
-                0
-            ].engine_name
-        )
+        engine_name = config.forward_model.radiative_transfer.engine.engine_name
 
         for element, element_header, element_name in zip(
             *config.output.get_output_files()

--- a/isofit/core/multistate.py
+++ b/isofit/core/multistate.py
@@ -95,9 +95,9 @@ def construct_full_state(full_config):
     # Pull the rt names from the config. Seems to be most commonly present.
     rt_config = full_config.forward_model.radiative_transfer
 
-    rt_states = vars(rt_config.radiative_transfer_engines[0])["statevector_names"]
+    rt_states = vars(rt_config.engine)["statevector_names"]
     if not rt_states:
-        rt_states = sorted(rt_config.radiative_transfer_engines[0].lut_names.keys())
+        rt_states = sorted(rt_config.engine.lut_names.keys())
 
     # Check for config type
     if full_config.forward_model.surface.multi_surface_flag:
@@ -286,9 +286,7 @@ def update_config_for_surface(config, surface_class_str, clouds=True):
         )
 
         # Add the statevector names
-        config.forward_model.radiative_transfer.radiative_transfer_engines[
-            0
-        ].statevector_names.append(key)
+        config.forward_model.radiative_transfer.engine.statevector_names.append(key)
 
     return config
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -73,16 +73,6 @@ def heuristic_atmosphere(
 
     x_new = x_RT.copy()
 
-    # Figure out which RT object we are using
-    # TODO: this is currently very specific to vswir-tir 2-mode, eventually generalize
-    my_RT = None
-    for rte in fm.RT.rt_engines:
-        if rte.treat_as_emissive is False:
-            my_RT = rte
-            break
-    if not my_RT:
-        raise ValueError("No suitable RT object for initialization")
-
     # Band ratio retrieval of H2O.  Depending on the radiative transfer
     # model we are using, this state parameter could go by several names.
     for h2oname in ["H2OSTR", "h2o"]:
@@ -90,7 +80,7 @@ def heuristic_atmosphere(
             continue
 
         # ignore unused names
-        if h2oname not in my_RT.lut_names:
+        if h2oname not in fm.RT.engine.lut_names:
             continue
 
         # find the index in the lookup table associated with water vapor
@@ -101,7 +91,7 @@ def heuristic_atmosphere(
         # calculating the band ratio that we would see if this were the
         # atmospheric H2O content.  It assumes that defaults for all other
         # atmospheric parameters (such as aerosol, if it is there).
-        for h2o in my_RT.lut_grid[h2oname]:
+        for h2o in fm.RT.engine.lut_grid[h2oname]:
             # Get Atmospheric terms at high spectral resolution
             x_RT_2 = x_RT.copy()
             x_RT_2[ind_sv] = h2o
@@ -169,15 +159,6 @@ def invert_algebraic(
         rfl_est: estimate of the surface reflectance based on the given surface model and specified atmospheric state
         coeffs: atmospheric parameters used for the inversion, returned for convenience
     """
-    # Figure out which RT object we are using
-    # TODO: this is currently very specific to vswir-tir 2-mode, eventually generalize
-    my_RT = None
-    for rte in RT.rt_engines:
-        if rte.treat_as_emissive is False:
-            my_RT = rte
-            break
-    if not my_RT:
-        raise ValueError("No suitable RT object for initialization")
 
     _, rho_init = surface.calc_rfl(x_surface, geom)
 

--- a/isofit/radiative_transfer/engines/modtran.py
+++ b/isofit/radiative_transfer/engines/modtran.py
@@ -269,16 +269,6 @@ class ModtranRT(RadiativeTransferEngine):
         solzen = self.load_tp6(f"{file}.tp6")
         coszen = np.cos(np.deg2rad(solzen))
         params = self.load_chn(f"{file}.chn", coszen)
-
-        # Remove thermal terms in VSWIR runs to avoid incorrect usage
-        if self.treat_as_emissive is False:
-            for key in ["thermal_upwelling", "thermal_downwelling"]:
-                if key in params:
-                    Logger.debug(
-                        f"Deleting key because treat_as_emissive is False: {key}"
-                    )
-                    del params[key]
-
         params["solzen"] = solzen
         params["coszen"] = coszen
 

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -73,41 +73,28 @@ class RadiativeTransfer:
     def __init__(self, full_config: Config):
         config = full_config.forward_model.radiative_transfer
         confIT = full_config.forward_model.instrument
+        confRT = config.engine
 
         self.lut_grid = config.lut_grid
         self.statevec_names = config.statevector.get_element_names()
 
-        self.rt_engines = []
-        for idx in range(len(config.radiative_transfer_engines)):
-            confRT = config.radiative_transfer_engines[idx]
+        # Generate the params for this RTE
+        params = {
+            key: confPriority(key, [confRT, confIT, config]) for key in self._keys
+        }
+        params["engine_config"] = confRT
+        params["n_cores"] = full_config.implementation.n_cores
 
-            if confRT.engine_name not in Engines:
-                raise AttributeError(
-                    f"Invalid radiative transfer engine choice. Got: {confRT.engine_name}; Must be one of: {list(Engines)}"
-                )
+        # Select the right RTE and initialize it
+        self.engine = Engines[confRT.engine_name](**params)
 
-            # Generate the params for this RTE
-            params = {
-                key: confPriority(key, [confRT, confIT, config]) for key in self._keys
-            }
-            params["engine_config"] = confRT
-            params["n_cores"] = full_config.implementation.n_cores
-
-            # Select the right RTE and initialize it
-            rte = Engines[confRT.engine_name](**params)
-            self.rt_engines.append(rte)
-
-            # Make sure the length of the config statevectores match the engine's assumed statevectors
-            if (expected := len(config.statevector.get_element_names())) != (
-                got := len(rte.indices.x_RT)
-            ):
-                error = f"Mismatch between the number of elements for the config statevector and LUT.indices.x_RT: {expected=}, {got=}"
-                Logger.error(error)
-                raise AttributeError(error)
-
-        # The rest of the code relies on sorted order of the individual RT engines which cannot
-        # be guaranteed by the dict JSON or YAML input
-        self.rt_engines.sort(key=lambda x: x.wl[0])
+        # Make sure the length of the config statevectores match the engine's assumed statevectors
+        if (expected := len(self.statevec_names)) != (
+            got := len(self.engine.indices.x_RT)
+        ):
+            error = f"Mismatch between the number of elements for the config and LUT grid: {expected=}, {got=}"
+            Logger.error(error)
+            raise AttributeError(error)
 
         # Retrieved variables.  We establish scaling, bounds, and
         # initial guesses for each state vector element.  The state
@@ -134,15 +121,12 @@ class RadiativeTransfer:
             self.Sa_normalized
         )
 
-        self.wl = np.concatenate([RT.wl for RT in self.rt_engines])
+        self.wl = self.engine.wl
 
         self.bvec = config.unknowns.get_element_names()
         self.bval = np.array([x for x in config.unknowns.get_elements()[0]])
 
-        self.solar_irr = np.concatenate([RT.solar_irr for RT in self.rt_engines])
-
-        # 1c or 3c?
-        self.multipart_transmittance = self.rt_engines[0].multipart_transmittance
+        self.solar_irr = self.engine.solar_irr
 
     def xa(self):
         """Pull the priors from each of the individual RTs."""
@@ -155,16 +139,6 @@ class RadiativeTransfer:
     def Sb(self):
         """Uncertainty due to unmodeled variables."""
         return np.diagflat(np.power(self.bval, 2))
-
-    def get_shared_rtm_quantities(self, x_RT, geom):
-        """Return only the set of RTM quantities (transup, sphalb, etc.) that are contained
-        in all RT engines.
-        """
-        ret = []
-        for RT in self.rt_engines:
-            ret.append(RT.get(x_RT, geom))
-
-        return self.pack_arrays(ret)
 
     def calc_rdn(
         self,
@@ -194,7 +168,7 @@ class RadiativeTransfer:
         atm_surface_scattering = s_alb * rho_dif_dif
 
         # Special case: 1-component model
-        if not self.multipart_transmittance:
+        if not self.engine.multipart_transmittance:
             # we assume rho_dir_dir = rho_dif_dir = rho_dir_dif = rho_dif_dif
             rho_dif_dif = rho_dir_dir
             # eliminate spherical albedo and one reflectance term from numerator if using 1-component model
@@ -256,22 +230,14 @@ class RadiativeTransfer:
         Returns:
             interpolated modeled atmospheric path radiance
         """
-        L_atms = []
 
-        for RT in self.rt_engines:
-            if RT.treat_as_emissive:
-                r = RT.get(x_RT, geom)
-                rdn = r["thermal_upwelling"]
-                L_atms.append(rdn)
-            else:
-                r = RT.get(x_RT, geom)
-                if RT.rt_mode == "rdn":
-                    L_atm = r["rhoatm"]
-                else:
-                    rho_atm = r["rhoatm"]
-                    L_atm = units.transm_to_rdn(rho_atm, geom.coszen, self.solar_irr)
-                L_atms.append(L_atm)
-        return np.hstack(L_atms)
+        r = self.engine.get(x_RT, geom)
+        if self.engine.rt_mode == "rdn":
+            L_atm = r["rhoatm"]
+        else:
+            rho_atm = r["rhoatm"]
+            L_atm = units.transm_to_rdn(rho_atm, geom.coszen, self.solar_irr)
+        return L_atm
 
     def get_L_coupled(self, r: dict, geom: Geometry, rho_dif_dif: np.ndarray = 0):
         """Get the interpolated radiance terms on the sun-to-surface-to-sensor path.
@@ -296,12 +262,12 @@ class RadiativeTransfer:
         # radiances along all optical paths
         L_coupled = []
 
-        for key in self.rt_engines[0].coupling_terms:
+        for key in self.engine.coupling_terms:
             L_coupled.append(
                 units.transm_to_rdn(
                     r[key], coszen=geom.coszen, solar_irr=self.solar_irr
                 )
-                if self.rt_engines[0].rt_mode == "transm"
+                if self.engine.rt_mode == "transm"
                 else r[key]
             )
 
@@ -372,32 +338,27 @@ class RadiativeTransfer:
         """
 
         # Propogate LUT
-        r = self.get_shared_rtm_quantities(x_RT, geom)
+        r = self.engine.get(x_RT, geom)
 
         # Handle 1c L_tot. NOTE: transm_down_dif = total transm for 1c case.
-        if self.multipart_transmittance:
+        if self.engine.multipart_transmittance:
             # Get directional radiances
             L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(
                 r, geom, rho_dif_dif=rho_dif_dif
             )
-        if not self.multipart_transmittance:
-            L_tots = []
-            for RT in self.rt_engines:
-                r = RT.get(x_RT, geom)
-                if RT.treat_as_emissive:
-                    rdn = r["thermal_downwelling"]
-                    L_tots.append(rdn)
+        if not self.engine.multipart_transmittance:
+            r = self.engine.get(x_RT, geom)
+            if self.engine.treat_as_emissive:
+                rdn = r["thermal_downwelling"]
+            else:
+                if self.engine.rt_mode == "rdn":
+                    L_tot = r["transm_down_dif"]
                 else:
-                    if RT.rt_mode == "rdn":
-                        L_tot = r["transm_down_dif"]
-                    else:
-                        L_tot = units.transm_to_rdn(
-                            r["transm_down_dif"],
-                            geom.coszen,
-                            self.solar_irr,
-                        )
-                    L_tots.append(L_tot)
-            L_tot = np.hstack(L_tots)
+                    L_tot = units.transm_to_rdn(
+                        r["transm_down_dif"],
+                        geom.coszen,
+                        self.solar_irr,
+                    )
             L_dir_dir = 0
             L_dif_dir = 0
             L_dir_dif = 0
@@ -543,32 +504,7 @@ class RadiativeTransfer:
         return Kb_RT
 
     def summarize(self, x_RT, geom):
-        ret = []
-        for RT in self.rt_engines:
-            ret.append(RT.summarize(x_RT, geom))
-        ret = "\n".join(ret)
-        return ret
-
-    def pack_arrays(self, rtm_quantities_from_RT_engines):
-        """Take the list of dict outputs from each RT engine and
-        stack their internal arrays in the same order. Keep only
-        those quantities that are common to all RT engines.
-        """
-        # Get the intersection of the sets of keys from each of the rtm_quantities_from_RT_engines
-        shared_rtm_keys = set(rtm_quantities_from_RT_engines[0].keys())
-        if len(rtm_quantities_from_RT_engines) > 1:
-            for rtm_quantities_from_one_RT_engine in rtm_quantities_from_RT_engines[1:]:
-                shared_rtm_keys.intersection_update(
-                    rtm_quantities_from_one_RT_engine.keys()
-                )
-
-        # Concatenate the different band ranges
-        rtm_quantities_concatenated_over_RT_bands = {}
-        for key in shared_rtm_keys:
-            temp = [x[key] for x in rtm_quantities_from_RT_engines]
-            rtm_quantities_concatenated_over_RT_bands[key] = np.hstack(temp)
-
-        return rtm_quantities_concatenated_over_RT_bands
+        return self.engine.summarize(x_RT, geom)
 
 
 def ext550_to_vis(ext550):

--- a/isofit/radiative_transfer/radiative_transfer_engine.py
+++ b/isofit/radiative_transfer/radiative_transfer_engine.py
@@ -106,7 +106,6 @@ class RadiativeTransferEngine:
         self.interpolator_style = interpolator_style
         self.overwrite_interpolator = overwrite_interpolator
 
-        self.treat_as_emissive = engine_config.treat_as_emissive
         self.engine_base_dir = engine_config.engine_base_dir
         self.sim_path = engine_config.sim_path
         if self.sim_path:

--- a/isofit/test/test_examples.py
+++ b/isofit/test/test_examples.py
@@ -202,8 +202,7 @@ def test_multisurface_inversions(args, monkeypatch):
     assert np.isclose(val, args[5][1], atol=0.01)
 
 
-@pytest.mark.xfail
-@pytest.mark.examples
+@pytest.mark.skip(reason="Thermal-IR implementation needs to be updated")
 def test_modtran_one(monkeypatch):
     """Run MODTRAN example dataset."""
 

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -197,9 +197,7 @@ def analytical_line(
     ]
     bbl = "{" + ",".join([f"{x}" for x in outside_ret_windows]) + "}"
     num_bands = len(full_idx_surf_rfl)
-    engine_name = config.forward_model.radiative_transfer.radiative_transfer_engines[
-        0
-    ].engine_name
+    engine_name = config.forward_model.radiative_transfer.engine.engine_name
     isofit_version = config.implementation.isofit_version
     rfl_output = initialize_output(
         output_metadata,

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -488,9 +488,7 @@ def empirical_line(
     output_metadata["interleave"] = "bil"
     output_metadata["wavelength_unts"] = "Nanometers"
     isofit_version = iconfig.implementation.isofit_version
-    engine_name = iconfig.forward_model.radiative_transfer.radiative_transfer_engines[
-        0
-    ].engine_name
+    engine_name = iconfig.forward_model.radiative_transfer.engine.engine_name
     output_metadata["description"] = (
         f"L2A empirical line per-pixel surface retrieval (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
     )

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1477,15 +1477,13 @@ def make_rt_config(
         engine_name = "sRTMnet"
 
     radiative_transfer_config = {
-        "radiative_transfer_engines": {
-            "vswir": {
-                "engine_name": engine_name,
-                "multipart_transmittance": multipart_transmittance,
-                "sim_path": lut_dir,
-                "lut_path": lut_path,
-                "aerosol_template_file": aerosol_tpl_path,
-                "template_file": modtran_template_path,
-            }
+        "engine": {
+            "engine_name": engine_name,
+            "multipart_transmittance": multipart_transmittance,
+            "sim_path": lut_dir,
+            "lut_path": lut_path,
+            "aerosol_template_file": aerosol_tpl_path,
+            "template_file": modtran_template_path,
         },
         "statevector": {},
         "lut_grid": {},
@@ -1494,26 +1492,24 @@ def make_rt_config(
         "max_slope": max_slope,
     }
 
-    vswir = {}
+    rte = {}
     if emulator_base is not None:
-        vswir["emulator_file"] = abspath(emulator_base)
-        vswir["earth_sun_distance_file"] = earth_sun_distance_path
-        vswir["irradiance_file"] = irradiance_file
-        vswir["engine_base_dir"] = sixs_path
+        rte["emulator_file"] = abspath(emulator_base)
+        rte["earth_sun_distance_file"] = earth_sun_distance_path
+        rte["irradiance_file"] = irradiance_file
+        rte["engine_base_dir"] = sixs_path
         if multipart_transmittance:
-            vswir["emulator_aux_file"] = abspath(emulator_base)
+            rte["emulator_aux_file"] = abspath(emulator_base)
         else:
-            vswir["emulator_aux_file"] = abspath(
+            rte["emulator_aux_file"] = abspath(
                 os.path.splitext(emulator_base)[0] + "_aux.npz"
             )
     else:
-        vswir["engine_base_dir"] = modtran_path
-    radiative_transfer_config["radiative_transfer_engines"]["vswir"].update(vswir)
+        rte["engine_base_dir"] = modtran_path
+    radiative_transfer_config["engine"].update(rte)
 
     if aerosol_model_file is None:
-        radiative_transfer_config["radiative_transfer_engines"]["vswir"][
-            "aerosol_model_file"
-        ] = aerosol_model_file
+        radiative_transfer_config["engine"]["aerosol_model_file"] = aerosol_model_file
 
     # First, build the general lut grid
     lut_grid = {
@@ -1556,7 +1552,7 @@ def make_rt_config(
         lut_grid.pop(tr)
 
     radiative_transfer_config["lut_grid"].update(lut_grid)
-    radiative_transfer_config["radiative_transfer_engines"]["vswir"]["lut_names"] = {
+    radiative_transfer_config["engine"]["lut_names"] = {
         key: None for key in lut_grid.keys()
     }
 
@@ -1591,10 +1587,10 @@ def make_rt_config(
     if aerosol_state_vector is not None and presolve is False:
         radiative_transfer_config["statevector"].update(aerosol_state_vector)
 
-    # MODTRAN should know about our whole LUT grid and all of our statevectors, so copy them in
-    radiative_transfer_config["radiative_transfer_engines"]["vswir"][
-        "statevector_names"
-    ] = list(radiative_transfer_config["statevector"].keys())
+    # RTE should know about our whole LUT grid and all of our statevectors, so copy them in
+    radiative_transfer_config["engine"]["statevector_names"] = list(
+        radiative_transfer_config["statevector"].keys()
+    )
 
     return radiative_transfer_config
 

--- a/isofit/utils/wavelength_cal.py
+++ b/isofit/utils/wavelength_cal.py
@@ -39,9 +39,9 @@ def add_wavelength_elements(config_path, state_type="shift", spline_indices=[]):
     n = np.ones(len(x))
     D = np.c_[n, x, w]
     np.savetxt(hi_res_wavlengths, D, fmt="%8.6f")
-    config["forward_model"]["radiative_transfer"]["radiative_transfer_engines"][
-        "vswir"
-    ]["wavelength_file"] = hi_res_wavlengths
+    config["forward_model"]["radiative_transfer"]["engine"][
+        "wavelength_file"
+    ] = hi_res_wavlengths
 
     # Flag case where spline_indices is empty and using spline
     if not spline_indices and (


### PR DESCRIPTION
The proposed change to config:

- current: `["radiative_transfer"]["radiative_transfer_engines"]["vswir"]["engine_name"] = "sRTMnet"`
 
- proposed: `["radiative_transfer"]["engine"]["engine_name"] = "sRTMnet"`

And so, this works just fine however, the test data will need to be updated before (https://github.com/isofit/isofit-tutorials/pull/45) we are able to merge this PR. 

