### PR TITLE
Remove transformation of longitude in geometry init

### DIFF
--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -97,8 +97,6 @@ class Geometry:
             self.surface_elevation_km = units.m_to_km(loc[2])
             self.latitude = loc[1]  # Northing
             self.longitude = loc[0]  # Westing
-            if self.longitude < 0:
-                self.longitude = 360.0 - self.longitude
 
         if loc is not None and obs is not None:
             self.observer_altitude_km = (

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -96,7 +96,7 @@ class Geometry:
         if loc is not None:
             self.surface_elevation_km = units.m_to_km(loc[2])
             self.latitude = loc[1]  # Northing
-            self.longitude = loc[0]  # Westing
+            self.longitude = loc[0]  # Easting
 
         if loc is not None and obs is not None:
             self.observer_altitude_km = (


### PR DESCRIPTION
Raised by #609, this transformation is confusing and there is no need for it as we don't use `geom.longitude` anywhere in the code at present. 