### PR TITLE
Test cleanup

### DIFF
--- a/isofit/test/test_cli_machinery.py
+++ b/isofit/test/test_cli_machinery.py
@@ -57,10 +57,10 @@ def test_subcommand_registration(executable):
         if proc.returncode != 0:
             print()
             print("stdout:")
-            print(stdout_txt, sys.stderr)
+            print(stdout_txt, file=sys.stderr)
             print()
             print("stderr:")
-            print(proc.stdout.read().decode(), file=sys.stderr)
+            print(proc.stderr.read().decode(), file=sys.stderr)
             assert False
 
     subcommand_count = 0

--- a/isofit/test/test_common.py
+++ b/isofit/test/test_common.py
@@ -72,24 +72,22 @@ def test_load_spectrum():
 def test_svd_inv_sqrt():
     # PSD
     sample_array_3 = np.array([[27, 20], [20, 16]])
-    sample_matrix_3 = np.asmatrix(sample_array_3)
     result_matrix_3, result_matrix_sq_3 = svd_inv_sqrt(sample_array_3)
-    assert result_matrix_3.all() == scipy.linalg.inv(sample_matrix_3).all()
-    assert (result_matrix_sq_3 @ result_matrix_sq_3).all() == result_matrix_3.all()
+    assert np.allclose(result_matrix_3, np.linalg.inv(sample_array_3))
+    assert np.allclose(result_matrix_sq_3 @ result_matrix_sq_3, result_matrix_3)
 
     # PD
     sample_array_4 = np.array([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
-    sample_matrix_4 = np.asmatrix(sample_array_4)
     result_matrix_4, result_matrix_sq_4 = svd_inv_sqrt(sample_array_4)
-    assert (scipy.linalg.inv(sample_matrix_4)).all() == result_matrix_4.all()
-    assert (result_matrix_sq_4 @ result_matrix_sq_4).all() == result_matrix_4.all()
+    assert np.allclose(result_matrix_4, np.linalg.inv(sample_array_4))
+    assert np.allclose(result_matrix_sq_4 @ result_matrix_sq_4, result_matrix_4)
 
 
 def test_svd_inv():
     sample_array_3 = np.array([[27, 20], [20, 16]])
-    assert svd_inv(sample_array_3).all() == svd_inv_sqrt(sample_array_3)[0].all()
+    assert np.allclose(svd_inv(sample_array_3), svd_inv_sqrt(sample_array_3)[0])
     sample_array_4 = np.array([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
-    assert svd_inv(sample_array_4).all() == svd_inv_sqrt(sample_array_4)[0].all()
+    assert np.allclose(svd_inv(sample_array_4), svd_inv_sqrt(sample_array_4)[0])
 
 
 def test_recursive_replace():

--- a/isofit/test/test_geometry.py
+++ b/isofit/test/test_geometry.py
@@ -5,8 +5,8 @@ def test_Geometry():
     geom = Geometry()
     assert geom.observer_zenith == 0
     assert geom.observer_azimuth == 0
-    assert geom.observer_altitude_km == None
-    assert geom.surface_elevation_km == None
-    assert geom.latitude == None
-    assert geom.longitude == None
-    assert geom.earth_sun_distance == None
+    assert geom.observer_altitude_km is None
+    assert geom.surface_elevation_km is None
+    assert geom.latitude is None
+    assert geom.longitude is None
+    assert geom.earth_sun_distance is None


### PR DESCRIPTION
A few bug fixes inside tests...found a week or two ago during inversion enhancement testing.

- inversions tests always passed because element-wise comparison wasn't being performed
- stderr & stdout were switched in one portion of test_cli_machinery
- equal sign comparisons with None in test_geometry


Notably, test_forward and test_inverse are effectively bypass functions....we should _really_ fix this.