### PR TITLE
Correct accounting for eq_11 term in surface derivatives

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -235,8 +235,14 @@ class ForwardModel:
 
         return offset
 
-    def calc_rdn(self, x_surface, x_RT, geom):
-        """Calculate the forward model components at RT wavelengths"""
+    def calc_meas(self, x, geom, rfl=[]):
+        """Calculate the model observation at instrument wavelengths."""
+        # Unpack state vector - Copy to not change x fm-wide
+        x_surface, x_RT, x_instrument = self.unpack(np.copy(x))
+
+        # if rfl passed, have to explicitely use those values
+        if len(rfl):
+            x_surface[self.idx_surf_rfl] = rfl
 
         # Call surface reflectance w.r.t. surface, upsample
         rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
@@ -244,16 +250,15 @@ class ForwardModel:
         rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
 
         # Adjacency effects
-        # ToDo: we need to think about if we want to obtain the background reflectance from the Geometry object
-        #  or from the surface model, i.e., the same way as we do with the target pixel reflectance
-
-        rho_dir_dif_hi = self.upsample(
-            self.surface.wl,
-            (geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_dir_dir),
+        rho_dir_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dir_dir_hi
         )
-        rho_dif_dif_hi = self.upsample(
-            self.surface.wl,
-            (geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_dif_dir),
+        rho_dif_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dif_dir_hi
         )
 
         # Get RT quantities
@@ -284,32 +289,6 @@ class ForwardModel:
             r=r,
             geom=geom,
         )
-
-        return (
-            rdn,
-            rho_dir_dir_hi,
-            rho_dif_dir_hi,
-            rho_dir_dif_hi,
-            rho_dif_dif_hi,
-            r,
-            L_tot,
-            L_dir_dir,
-            L_dif_dir,
-            L_dir_dif,
-            L_dif_dif,
-            Ls_hi,
-        )
-
-    def calc_meas(self, x, geom, rfl=[]):
-        """Calculate the model observation at instrument wavelengths."""
-
-        x_surface, x_RT, x_instrument = self.unpack(np.copy(x))
-
-        # if rfl passed, have to explicitely use those values
-        if len(rfl):
-            x_surface[self.idx_surf_rfl] = rfl
-
-        rdn, *_ = self.calc_rdn(x_surface, x_RT, geom)
 
         return self.instrument.sample(x_instrument, self.RT.wl, rdn) + self.eof_offset(
             x_surface, x_RT, x_instrument
@@ -355,20 +334,52 @@ class ForwardModel:
         """
         # Unpack state vector
         x_surface, x_RT, x_instrument = self.unpack(x)
+
+        # Call surface reflectance w.r.t. surface, upsample
+        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
+        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
+        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
+
+        # Adjacency effects
+        rho_dir_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dir_dir_hi
+        )
+        rho_dif_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dif_dir_hi
+        )
+
+        # Get RT quantities
         (
-            rdn,
-            rho_dir_dir_hi,
-            rho_dif_dir_hi,
-            rho_dir_dif_hi,
-            rho_dif_dif_hi,
             r,
             L_tot,
             L_dir_dir,
             L_dif_dir,
             L_dir_dif,
             L_dif_dif,
-            Ls_hi,
-        ) = self.calc_rdn(x_surface, x_RT, geom)
+        ) = self.RT.calc_RT_quantities(x_RT, geom, rho_dif_dif_hi)
+
+        # Call surface emission, upsample
+        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
+
+        rdn = self.RT.calc_rdn(
+            x_RT,
+            rho_dir_dir=rho_dir_dir_hi,
+            rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
+            Ls=Ls_hi,
+            L_tot=L_tot,
+            L_dir_dir=L_dir_dir,
+            L_dif_dir=L_dif_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dif=L_dif_dif,
+            r=r,
+            geom=geom,
+        )
 
         # Call surface emission, upsample
         Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
@@ -435,20 +446,52 @@ class ForwardModel:
 
         # Unpack state vector
         x_surface, x_RT, x_instrument = self.unpack(x)
+
+        # Call surface reflectance w.r.t. surface, upsample
+        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
+        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
+        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
+
+        # Adjacency effects
+        rho_dir_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dir_dir_hi
+        )
+        rho_dif_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dif_dir_hi
+        )
+
+        # Get RT quantities
         (
-            rdn,
-            rho_dir_dir_hi,
-            rho_dif_dir_hi,
-            rho_dir_dif_hi,
-            rho_dif_dif_hi,
             r,
             L_tot,
             L_dir_dir,
             L_dif_dir,
             L_dir_dif,
             L_dif_dif,
-            Ls_hi,
-        ) = self.calc_rdn(x_surface, x_RT, geom)
+        ) = self.RT.calc_RT_quantities(x_RT, geom, rho_dif_dif_hi)
+
+        # Call surface emission, upsample
+        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
+
+        rdn = self.RT.calc_rdn(
+            x_RT,
+            rho_dir_dir=rho_dir_dir_hi,
+            rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
+            Ls=Ls_hi,
+            L_tot=L_tot,
+            L_dir_dir=L_dir_dir,
+            L_dif_dir=L_dif_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dif=L_dif_dif,
+            r=r,
+            geom=geom,
+        )
 
         drdn_dRTb = self.RT.drdn_dRTb(
             x_RT,

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -235,14 +235,26 @@ class ForwardModel:
 
         return offset
 
-    def calc_meas(self, x, geom, rfl=[]):
-        """Calculate the model observation at instrument wavelengths."""
-        # Unpack state vector - Copy to not change x fm-wide
-        x_surface, x_RT, x_instrument = self.unpack(np.copy(x))
+    def calc_rdn(self, x_surface, x_RT, geom):
+        """Calculate the forward model components at RT wavelengths"""
 
-        # if rfl passed, have to explicitely use those values
-        if len(rfl):
-            x_surface[self.idx_surf_rfl] = rfl
+        # Call surface reflectance w.r.t. surface, upsample
+        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
+        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
+        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
+
+        # Adjacency effects
+        # ToDo: we need to think about if we want to obtain the background reflectance from the Geometry object
+        #  or from the surface model, i.e., the same way as we do with the target pixel reflectance
+
+        rho_dir_dif_hi = self.upsample(
+            self.surface.wl,
+            (geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_dir_dir),
+        )
+        rho_dif_dif_hi = self.upsample(
+            self.surface.wl,
+            (geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_dif_dir),
+        )
 
         # Get RT quantities
         (
@@ -252,12 +264,7 @@ class ForwardModel:
             L_dif_dir,
             L_dir_dif,
             L_dif_dif,
-        ) = self.RT.calc_RT_quantities(x_RT, geom)
-
-        # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
-        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
-        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
+        ) = self.RT.calc_RT_quantities(x_RT, geom, rho_dif_dif_hi)
 
         # Call surface emission, upsample
         Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
@@ -266,6 +273,8 @@ class ForwardModel:
             x_RT,
             rho_dir_dir=rho_dir_dir_hi,
             rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
             Ls=Ls_hi,
             L_tot=L_tot,
             L_dir_dir=L_dir_dir,
@@ -275,6 +284,32 @@ class ForwardModel:
             r=r,
             geom=geom,
         )
+
+        return (
+            rdn,
+            rho_dir_dir_hi,
+            rho_dif_dir_hi,
+            rho_dir_dif_hi,
+            rho_dif_dif_hi,
+            r,
+            L_tot,
+            L_dir_dir,
+            L_dif_dir,
+            L_dir_dif,
+            L_dif_dif,
+            Ls_hi,
+        )
+
+    def calc_meas(self, x, geom, rfl=[]):
+        """Calculate the model observation at instrument wavelengths."""
+
+        x_surface, x_RT, x_instrument = self.unpack(np.copy(x))
+
+        # if rfl passed, have to explicitely use those values
+        if len(rfl):
+            x_surface[self.idx_surf_rfl] = rfl
+
+        rdn, *_ = self.calc_rdn(x_surface, x_RT, geom)
 
         return self.instrument.sample(x_instrument, self.RT.wl, rdn) + self.eof_offset(
             x_surface, x_RT, x_instrument
@@ -318,24 +353,22 @@ class ForwardModel:
         the concatenation of jacobians with respect to parameters of the
         surface and radiative transfer model.
         """
-
         # Unpack state vector
         x_surface, x_RT, x_instrument = self.unpack(x)
-
-        # Get RT quantities
         (
+            rdn,
+            rho_dir_dir_hi,
+            rho_dif_dir_hi,
+            rho_dir_dif_hi,
+            rho_dif_dif_hi,
             r,
             L_tot,
             L_dir_dir,
             L_dif_dir,
             L_dir_dif,
             L_dif_dif,
-        ) = self.RT.calc_RT_quantities(x_RT, geom)
-
-        # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
-        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
-        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
+            Ls_hi,
+        ) = self.calc_rdn(x_surface, x_RT, geom)
 
         # Call surface emission, upsample
         Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
@@ -351,27 +384,14 @@ class ForwardModel:
             self.surface.wl, self.surface.dLs_dsurface(x_surface, geom).T
         ).T
 
-        # Need to pass calc rdn into instrument derivative
-        rdn = self.RT.calc_rdn(
-            x_RT,
-            rho_dir_dir=rho_dir_dir_hi,
-            rho_dif_dir=rho_dif_dir_hi,
-            Ls=Ls_hi,
-            L_tot=L_tot,
-            L_dir_dir=L_dir_dir,
-            L_dif_dir=L_dif_dir,
-            L_dir_dif=L_dir_dif,
-            L_dif_dif=L_dif_dif,
-            r=r,
-            geom=geom,
-        )
-
         # To get the derivative w.r.t. RT
         drdn_dRT = self.RT.drdn_dRT(
             x_RT,
             geom,
             rho_dir_dir=rho_dir_dir_hi,
             rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
             Ls=Ls_hi,
             rdn=rdn,
         )
@@ -415,44 +435,28 @@ class ForwardModel:
 
         # Unpack state vector
         x_surface, x_RT, x_instrument = self.unpack(x)
-
-        # Get RT quantities
         (
+            rdn,
+            rho_dir_dir_hi,
+            rho_dif_dir_hi,
+            rho_dir_dif_hi,
+            rho_dif_dif_hi,
             r,
             L_tot,
             L_dir_dir,
             L_dif_dir,
             L_dir_dif,
             L_dif_dif,
-        ) = self.RT.calc_RT_quantities(x_RT, geom)
-
-        # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
-        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
-        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
-
-        # Call surface emission, upsample
-        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
-
-        rdn = self.RT.calc_rdn(
-            x_RT,
-            rho_dir_dir=rho_dir_dir_hi,
-            rho_dif_dir=rho_dif_dir_hi,
-            Ls=Ls_hi,
-            L_tot=L_tot,
-            L_dir_dir=L_dir_dir,
-            L_dif_dir=L_dif_dir,
-            L_dir_dif=L_dir_dif,
-            L_dif_dif=L_dif_dif,
-            r=r,
-            geom=geom,
-        )
+            Ls_hi,
+        ) = self.calc_rdn(x_surface, x_RT, geom)
 
         drdn_dRTb = self.RT.drdn_dRTb(
             x_RT,
             geom=geom,
             rho_dir_dir=rho_dir_dir_hi,
             rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
             Ls=Ls_hi,
             rdn=rdn,
         )

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -179,6 +179,7 @@ def invert_algebraic(
     if not my_RT:
         raise ValueError("No suitable RT object for initialization")
 
+    _, rho_init = surface.calc_rfl(x_surface, geom)
     # Get all radiance terms
     (
         rhi,
@@ -187,7 +188,7 @@ def invert_algebraic(
         L_dif_dir,
         L_dir_dif,
         L_dif_dif,
-    ) = RT.calc_RT_quantities(x_RT, geom)
+    ) = RT.calc_RT_quantities(x_RT, geom, rho_init)
     L_atm = RT.get_L_atm(x_RT, geom)
     sphalb = rhi["sphalb"]
     Ls = surface.calc_Ls(x_surface, geom)

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -180,6 +180,9 @@ def invert_algebraic(
         raise ValueError("No suitable RT object for initialization")
 
     _, rho_init = surface.calc_rfl(x_surface, geom)
+
+    rho_dif_dif = geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_init
+
     # Get all radiance terms
     (
         rhi,
@@ -188,7 +191,7 @@ def invert_algebraic(
         L_dif_dir,
         L_dir_dif,
         L_dif_dif,
-    ) = RT.calc_RT_quantities(x_RT, geom, rho_init)
+    ) = RT.calc_RT_quantities(x_RT, geom, rho_dif_dif=rho_dif_dif)
     L_atm = RT.get_L_atm(x_RT, geom)
     sphalb = rhi["sphalb"]
     Ls = surface.calc_Ls(x_surface, geom)
@@ -272,15 +275,6 @@ def invert_analytical(
     x = x0.copy()
     x_surface, x_RT, x_instrument = fm.unpack(x)
 
-    # Get all the RT quantities
-    (r, L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif) = fm.RT.calc_RT_quantities(
-        x_RT, geom
-    )
-
-    # Path radiance and spherical albedo
-    L_atm = fm.RT.get_L_atm(x_RT, geom)
-    s = r["sphalb"]
-
     # Get all the surface quantities for the super pixel
     sub_surface, sub_RT, sub_instrument = fm.unpack(sub_state)
 
@@ -288,6 +282,26 @@ def invert_analytical(
     rho_dir_dir, rho_dif_dir = fm.calc_rfl(sub_surface, geom)
     rho_dir_dir = fm.upsample(fm.surface.wl, rho_dir_dir)
     rho_dif_dir = fm.upsample(fm.surface.wl, rho_dif_dir)
+
+    rho_dir_dif = (
+        self.upsample(self.surface.wl, geom.bg_rfl)
+        if isinstance(geom.bg_rfl, np.ndarray)
+        else rho_dir_dir
+    )
+    rho_dif_dif = (
+        self.upsample(self.surface.wl, geom.bg_rfl)
+        if isinstance(geom.bg_rfl, np.ndarray)
+        else rho_dif_dir
+    )
+
+    # Get all the RT quantities
+    (r, L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif) = fm.RT.calc_RT_quantities(
+        x_RT, geom, rho_dif_dif=rho_dif_dif
+    )
+
+    # Path radiance and spherical albedo
+    L_atm = fm.RT.get_L_atm(x_RT, geom)
+    s = r["sphalb"]
 
     # Background conditions equal to the superpixel reflectance
     bg = s * rho_dif_dir

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -143,6 +143,9 @@ class RadiativeTransfer:
 
         self.solar_irr = np.concatenate([RT.solar_irr for RT in self.rt_engines])
 
+        # 1c or 3c?
+        self.multipart_transmittance = self.rt_engines[0].multipart_transmittance
+
     def xa(self):
         """Pull the priors from each of the individual RTs."""
         return self.prior_mean
@@ -180,6 +183,8 @@ class RadiativeTransfer:
         x_RT,
         rho_dir_dir,
         rho_dif_dir,
+        rho_dir_dif,
+        rho_dif_dif,
         Ls,
         L_tot,
         L_dir_dir,
@@ -193,32 +198,19 @@ class RadiativeTransfer:
         Physics-based forward model to calculate at-sensor radiance.
         Includes topography, background reflectance, and glint.
         """
-        # Adjacency effects
-        # ToDo: we need to think about if we want to obtain the background reflectance from the Geometry object
-        #  or from the surface model, i.e., the same way as we do with the target pixel reflectance
-
-        rho_dir_dif = (
-            geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_dir_dir
-        )
-        rho_dif_dif = (
-            geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_dif_dir
-        )
-
         # Atmospheric path radiance
         L_atm = self.get_L_atm(x_RT, geom)
 
         # Atmospheric spherical albedo
         s_alb = r["sphalb"]
         atm_surface_scattering = s_alb * rho_dif_dif
-        eq_11_term = 1 - atm_surface_scattering
 
         # Special case: 1-component model
-        if not isinstance(L_dir_dir, np.ndarray) or len(L_dir_dir) == 1:
+        if not self.multipart_transmittance:
             # we assume rho_dir_dir = rho_dif_dir = rho_dir_dif = rho_dif_dif
             rho_dif_dif = rho_dir_dir
             # eliminate spherical albedo and one reflectance term from numerator if using 1-component model
             atm_surface_scattering = 1
-            eq_11_term = 1
 
         # Thermal transmittance
         L_up = Ls * self.get_upward_transm(r=r, geom=geom)
@@ -257,9 +249,9 @@ class RadiativeTransfer:
         ret = (
             L_atm
             + L_dir_dir * rho_dir_dir
-            + L_dif_dir * rho_dif_dir / eq_11_term
+            + L_dif_dir * rho_dif_dir
             + L_dir_dif * rho_dir_dif
-            + L_dif_dif * rho_dif_dif / eq_11_term
+            + L_dif_dif * rho_dif_dif
             + (L_tot * atm_surface_scattering * rho_dif_dif) / (1 - s_alb * rho_dif_dif)
             + L_up
         )
@@ -296,7 +288,7 @@ class RadiativeTransfer:
                 L_atms.append(L_atm)
         return np.hstack(L_atms)
 
-    def get_L_coupled(self, r: dict, geom: Geometry):
+    def get_L_coupled(self, r: dict, geom: Geometry, rho_dif_dif: np.ndarray):
         """Get the interpolated radiance terms on the sun-to-surface-to-sensor path.
         These follow the physics as presented in Guanter (2006), Vermote et al. (1997), and Tanre et al. (1983).
 
@@ -328,12 +320,7 @@ class RadiativeTransfer:
         # radiances along all optical paths
         L_coupled = []
 
-        if any(
-            [
-                not isinstance(r[key], np.ndarray) or len(r[key]) == 1
-                for key in self.rt_engines[0].coupling_terms
-            ]
-        ):
+        if not self.multipart_transmittance:
             # In case of the 1-component model, we cannot populate the coupling terms
             L_coupled = [
                 0,
@@ -369,9 +356,18 @@ class RadiativeTransfer:
         L_dif_dir *= hays_model
         L_dif_dif *= hays_model
 
-        return L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
+        # Apply equation 11
+        eq_11_term = 1 - (r["sphalb"] * rho_dif_dif)
 
-    def calc_RT_quantities(self, x_RT: np.ndarray, geom: Geometry):
+        L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
+        L_dif_dir /= eq_11_term
+        L_dif_dif /= eq_11_term
+
+        return L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
+
+    def calc_RT_quantities(
+        self, x_RT: np.ndarray, geom: Geometry, rho_dif_dif: np.ndarray
+    ):
         """Retrieves the RT quantities including the LUT sample (r),
         and the radiances (L). This function handles the hand-off between
         the 1c and 4c model.
@@ -390,11 +386,12 @@ class RadiativeTransfer:
         r = self.get_shared_rtm_quantities(x_RT, geom)
 
         # Default: get directional radiances
-        L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(r, geom)
-        L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
+        L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(
+            r, geom, rho_dif_dif
+        )
 
         # Handle 1c L_tot. NOTE: transm_down_dif = total transm for 1c case.
-        if not isinstance(L_tot, np.ndarray) or len(L_tot) == 1:
+        if not self.multipart_transmittance:
             coszen = geom.verify(self.coszen)["coszen"]
             L_tots = []
             for RT in self.rt_engines:
@@ -449,7 +446,9 @@ class RadiativeTransfer:
                 )
             return transup
 
-    def drdn_dRT(self, x_RT, geom, rho_dir_dir, rho_dif_dir, Ls, rdn):
+    def drdn_dRT(
+        self, x_RT, geom, rho_dir_dir, rho_dif_dir, rho_dir_dif, rho_dif_dif, Ls, rdn
+    ):
         """Derivative of estimated radiance w.r.t. RT statevector elements.
         We use a numerical approach to approximate dRT with a constant surface
         reflectance. This is a reasonable approx. for the multicomponent surface.
@@ -468,13 +467,15 @@ class RadiativeTransfer:
                 L_dif_dir,
                 L_dir_dif,
                 L_dif_dif,
-            ) = self.calc_RT_quantities(x_RT_perturb, geom)
+            ) = self.calc_RT_quantities(x_RT_perturb, geom, rho_dif_dif)
 
             # Surface state is held constant?
             rdne = self.calc_rdn(
                 x_RT_perturb,
                 rho_dir_dir,
                 rho_dif_dir,
+                rho_dir_dif,
+                rho_dif_dif,
                 Ls,
                 L_tot,
                 L_dir_dir,
@@ -490,7 +491,9 @@ class RadiativeTransfer:
 
         return K_RT
 
-    def drdn_dRTb(self, x_RT, geom, rho_dir_dir, rho_dif_dir, Ls, rdn):
+    def drdn_dRTb(
+        self, x_RT, geom, rho_dir_dir, rho_dif_dir, rho_dir_dif, rho_dif_dif, Ls, rdn
+    ):
         """Derivative of estimated rdn w.r.t. H2O_ABSCO
 
         Currently, the K_b matrix only covers forward model derivatives
@@ -525,12 +528,14 @@ class RadiativeTransfer:
                         L_dif_dir,
                         L_dir_dif,
                         L_dif_dif,
-                    ) = self.calc_RT_quantities(x_RT_perturb, geom)
+                    ) = self.calc_RT_quantities(x_RT_perturb, geom, rho_dif_dif)
 
                     rdne = self.calc_rdn(
                         x_RT_perturb,
                         rho_dir_dir,
                         rho_dif_dir,
+                        rho_dir_dif,
+                        rho_dif_dif,
                         Ls,
                         L_tot,
                         L_dir_dir,

--- a/isofit/radiative_transfer/radiative_transfer.py
+++ b/isofit/radiative_transfer/radiative_transfer.py
@@ -288,9 +288,12 @@ class RadiativeTransfer:
                 L_atms.append(L_atm)
         return np.hstack(L_atms)
 
-    def get_L_coupled(self, r: dict, geom: Geometry, rho_dif_dif: np.ndarray):
+    def get_L_coupled(self, r: dict, geom: Geometry, rho_dif_dif: np.ndarray = 0):
         """Get the interpolated radiance terms on the sun-to-surface-to-sensor path.
         These follow the physics as presented in Guanter (2006), Vermote et al. (1997), and Tanre et al. (1983).
+
+        Note:   This function is only applicable to the 6c run case
+                where r contains populated separated transmittances
 
         Args:
             r:      interpolated radiative transfer quantities from the LUT
@@ -320,21 +323,12 @@ class RadiativeTransfer:
         # radiances along all optical paths
         L_coupled = []
 
-        if not self.multipart_transmittance:
-            # In case of the 1-component model, we cannot populate the coupling terms
-            L_coupled = [
-                0,
-                0,
-                0,
-                0,
-            ]
-        else:
-            for key in self.rt_engines[0].coupling_terms:
-                L_coupled.append(
-                    units.transm_to_rdn(r[key], coszen=coszen, solar_irr=self.solar_irr)
-                    if self.rt_engines[0].rt_mode == "transm"
-                    else r[key]
-                )
+        for key in self.rt_engines[0].coupling_terms:
+            L_coupled.append(
+                units.transm_to_rdn(r[key], coszen=coszen, solar_irr=self.solar_irr)
+                if self.rt_engines[0].rt_mode == "transm"
+                else r[key]
+            )
         # Topographic shadow mask (0=shadow, 1=sunlit pixel).
         # for now, this is always set to 1.0.
         b = 1.0
@@ -357,6 +351,7 @@ class RadiativeTransfer:
         L_dif_dif *= hays_model
 
         # Apply equation 11
+        # If no rho_dif_dif passed eq_11_term -> 1
         eq_11_term = 1 - (r["sphalb"] * rho_dif_dif)
 
         L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
@@ -366,31 +361,45 @@ class RadiativeTransfer:
         return L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
 
     def calc_RT_quantities(
-        self, x_RT: np.ndarray, geom: Geometry, rho_dif_dif: np.ndarray
+        self, x_RT: np.ndarray, geom: Geometry, rho_dif_dif: np.ndarray = 0
     ):
         """Retrieves the RT quantities including the LUT sample (r),
         and the radiances (L). This function handles the hand-off between
-        the 1c and 4c model.
+        the 1c and 6c model.
 
         In the 1c case, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = 0,
         and L_tot, L_down_dir, and L_down_dif are populated within the
         if statement.
 
-        In the 4c case, we always use returns from get_L_coupled
-
+        In the 6c case, we always use returns from get_L_coupled
         All quantities are on the sun-to-surface-to-sensor path.
 
+        Args:
+            x_RT: RT portion of the state vector.
+            geom: Geometry object for the current observation.
+            rho_dif_dif: Apparent surface reflectance for
+                hemispherical-hemispherical photon paths.
+                Included here to incorporate surface-atm coupling
+                following Eq. 11 of Guanter et al, 2009.
+
+        Returns:
+            r: LUT sample dictionary of shared RT quantities.
+            L_tot: total downwelling radiance (uW/nm/sr/cm2).
+            L_dir_dir: direct-to-direct radiance component; zero in 1c mode.
+            L_dif_dir: diffuse-to-direct radiance component; zero in 1c mode.
+            L_dir_dif: direct-to-diffuse radiance component; zero in 1c mode.
+            L_dif_dif: diffuse-to-diffuse radiance component; zero in 1c mode.
         """
 
         # Propogate LUT
         r = self.get_shared_rtm_quantities(x_RT, geom)
 
-        # Default: get directional radiances
-        L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(
-            r, geom, rho_dif_dif
-        )
-
         # Handle 1c L_tot. NOTE: transm_down_dif = total transm for 1c case.
+        if self.multipart_transmittance:
+            # Get directional radiances
+            L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(
+                r, geom, rho_dif_dif=rho_dif_dif
+            )
         if not self.multipart_transmittance:
             coszen = geom.verify(self.coszen)["coszen"]
             L_tots = []
@@ -410,6 +419,10 @@ class RadiativeTransfer:
                         )
                     L_tots.append(L_tot)
             L_tot = np.hstack(L_tots)
+            L_dir_dir = 0
+            L_dif_dir = 0
+            L_dir_dif = 0
+            L_dif_dif = 0
 
         return (
             r,


### PR DESCRIPTION
The previous location of the `eq_11_term` correction in the `RT.calc_rdn` function meant that the `L_x_x` values were inconsistently scaled between `calc_rdn` and `drdn_dsurface`.

This PR moves the `eq_11_term` accounting into the `get_L_coupled` function (consistent with the hays model).

This does have some visible impact. Testing on a snow covered shady pixel (bright, but with high proportion of L_dif) Images courtesy of @brentwilder.

In reflectance space:
<img width="2194" height="1086" alt="image" src="https://github.com/user-attachments/assets/89f6606f-b5b8-43c7-8e77-528c901ba689" />

In derivative space:
<img width="2386" height="1614" alt="image" src="https://github.com/user-attachments/assets/17fee383-1ca0-4fb8-83ee-521f792cf425" />


Other note to keep track of that was discussed:

Introducing the eq_11 term into the forward model is another step towards more atmosphere-surface coupling within the model. This may be more accurate physics, but it potentially makes the code organization a bit more confusing. The radiative_transfer module is increasingly in charge of forward model physics that incorporate surface-atmosphere coupling despite the name implying that it is principally responsible for the radiative transfer component. The fuzziness continues with #915, a necessary change, but would further muddy the distinction and purpose of a separate `radiative_transfer_engine` module.

