### PR TITLE
Setting segmentation size in slow tests

### DIFF
--- a/isofit/test/test_cli.py
+++ b/isofit/test/test_cli.py
@@ -102,7 +102,8 @@ def test_apply_oe(files, args, surface):
         "--n_cores",
         CORES,
         "--analytical_line",
-        "--segmentation_size 400",
+        "--segmentation_size",
+        "400",
         "--logging_level",
         "DEBUG",
     ] + args

--- a/isofit/test/test_cli.py
+++ b/isofit/test/test_cli.py
@@ -91,7 +91,7 @@ def test_apply_oe(files, args, surface):
     Executes the isofit apply_oe cli command for various test cases
     """
     ray.shutdown()
-    sleep(120)
+    sleep(10)
 
     emulator = env.path("srtmnet", key="srtmnet.file")
     args = [
@@ -102,6 +102,7 @@ def test_apply_oe(files, args, surface):
         "--n_cores",
         CORES,
         "--analytical_line",
+        "--segmentation_size 400",
         "--logging_level",
         "DEBUG",
     ] + args

--- a/isofit/test/test_cli.py
+++ b/isofit/test/test_cli.py
@@ -82,8 +82,8 @@ def files(cwd):
 # fmt: off
 @pytest.mark.slow
 @pytest.mark.parametrize("args", [
-    ["-nn", 10, "-nn", 50,],
-    ["-nn", 10, "-nn", 50, "-nn", 10, "--pressure_elevation",],
+    [], # No additional args for first test
+    ["--pressure_elevation"], # Test pressure elevation on second
 ])
 # fmt: on
 def test_apply_oe(files, args, surface):
@@ -103,7 +103,7 @@ def test_apply_oe(files, args, surface):
         CORES,
         "--analytical_line",
         "--segmentation_size",
-        "400",
+        400,
         "--logging_level",
         "DEBUG",
     ] + args


### PR DESCRIPTION
Dimensions of `rdn_7k-8K`: (1000, 100, 425)

Main bottleneck is not `segmentation_size`, but actually just number of inversions for analytical line (100,000 pixels). And so, we could accept this as shown right now ( ~65-80 min for slow tests).

But if we wanted to decrease time further it would be a matter of decreasing the dimensions of medium image cube.