### PR TITLE
Workflow: Close Test PRs

### DIFF
--- a/.github/workflows/results_close_pr.yml
+++ b/.github/workflows/results_close_pr.yml
@@ -1,7 +1,7 @@
 name: Close Results PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
Changed the `on: action` type for the close isofit-test-results PRs workflow to execute in trusted space and have access to the repo secrets