### PR TITLE
Remove ray arg `local_mode`

### DIFF
--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -92,7 +92,6 @@ class Isofit:
             "_temp_dir": self.config.implementation.ray_temp_dir,
             "ignore_reinit_error": self.config.implementation.ray_ignore_reinit_error,
             "include_dashboard": self.config.implementation.ray_include_dashboard,
-            "local_mode": self.config.implementation.n_cores == 1,
         }
 
         # We can only set the num_cpus if running on a single-node

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -296,9 +296,7 @@ def atm_interpolation(
 
     # Initialize ray cluster
     start_time = time.time()
-    ray.init(
-        **{"ignore_reinit_error": True, "local_mode": n_cores == 1, "num_cpus": n_cores}
-    )
+    ray.init(**{"ignore_reinit_error": True, "num_cpus": n_cores})
 
     n_cores = min(n_cores, n_input_lines)
 

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -32,7 +32,7 @@ from spectral.io import envi
 from isofit import ray
 from isofit.configs import configs
 from isofit.core.common import envi_header
-from isofit.core.fileio import write_bil_chunk, initialize_output
+from isofit.core.fileio import initialize_output, write_bil_chunk
 from isofit.core.instrument import Instrument
 
 
@@ -515,7 +515,6 @@ def empirical_line(
     start_time = time.time()
     rayargs = {
         "ignore_reinit_error": iconfig.implementation.ray_ignore_reinit_error,
-        "local_mode": n_cores == 1,
         "address": iconfig.implementation.ip_head,
         "_temp_dir": iconfig.implementation.ray_temp_dir,
         "include_dashboard": iconfig.implementation.ray_include_dashboard,

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -91,7 +91,6 @@ def main(args: SimpleNamespace) -> None:
 
     rayargs = {
         "ignore_reinit_error": True,
-        "local_mode": args.n_cores == 1,
         "_temp_dir": args.ray_tmp_dir,
         "num_cpus": n_cores,
     }

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -165,7 +165,6 @@ def extractions(
     # Start up a ray instance for parallel work
     rayargs = {
         "ignore_reinit_error": True,
-        "local_mode": n_cores == 1,
         "address": ray_address,
         "include_dashboard": False,
         "_temp_dir": ray_temp_dir,

--- a/isofit/utils/multicomponent_classification.py
+++ b/isofit/utils/multicomponent_classification.py
@@ -378,7 +378,6 @@ def multicomponent_classification(
     # Ray initialization
     ray_dict = {
         "ignore_reinit_error": True,
-        "local_mode": n_cores == 1,
         "address": ray_address,
         "include_dashboard": False,
         "_temp_dir": ray_temp_dir,

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -197,7 +197,6 @@ def segment(
     # Start up a ray instance for parallel work
     rayargs = {
         "ignore_reinit_error": True,
-        "local_mode": n_cores == 1,
         "address": ray_address,
         "include_dashboard": False,
         "_temp_dir": ray_temp_dir,

--- a/isofit/utils/skyview.py
+++ b/isofit/utils/skyview.py
@@ -20,14 +20,14 @@
 import logging
 import os
 import shutil
-from os.path import join, isfile, isdir
 import time
 import warnings
+from os.path import isdir, isfile, join
 
 import click
+import netCDF4 as nc
 import numpy as np
 import ray
-import netCDF4 as nc
 from spectral.io import envi
 
 from isofit.core.common import envi_header, eps
@@ -52,17 +52,17 @@ def skyview(
 ):
     """\
     Applies sky view factor calculation for a given projected DEM or DSM. Much of this code was borrowed from ARS Topo-Calc.
-    The key thing here was to create a python-only, rasterio-free port of this that could be used within ISOFIT. We also included 
+    The key thing here was to create a python-only, rasterio-free port of this that could be used within ISOFIT. We also included
     improvements that are current in Jeff Dozier's horizon method in Matlab (https://github.com/DozierJeff/Topographic-Horizons).
     Following suggestions from Dozier (2021), multiprocessing is leveraged here w.r.t. to n_angles rotating the image. As default,
     sky view is computed with n angles = 64 which in most cases is of sufficient accuracy to resolve but more angles may be used.
-    
+
     Optionally to this horizon based method, one can pass method="slope" to compute a faster estimate that may be sufficent for regions with lower relief.
-    The slope based estimate is simply, svf = cos^2(slope/2). 
-    
-    Yet another option is to pass an ISOFIT "OBS" or "LOC" file as input and using the obs_or_loc arg. 
-    OBS files have slope data and can be used for method='slope' only. LOC files have elevation data and can be used for method='slope'. 
-    One can also use the full horizon method on the LOC file although this is not recommended because the edges miss information 
+    The slope based estimate is simply, svf = cos^2(slope/2).
+
+    Yet another option is to pass an ISOFIT "OBS" or "LOC" file as input and using the obs_or_loc arg.
+    OBS files have slope data and can be used for method='slope' only. LOC files have elevation data and can be used for method='slope'.
+    One can also use the full horizon method on the LOC file although this is not recommended because the edges miss information
     (a warning will be triggered in this case).
 
     \b
@@ -79,18 +79,18 @@ def skyview(
         If 'loc' is selected it well select the elevation data from index 2. None will assume a single band elevation data is passed.
     method : str, optional
         Options are either "horizon" or "slope". Passing "horizon" runs the full computation and is recommended for very steep terrain.
-        Passing "slope"" runs the simplifed calculation of svf=cos^2(slope/2) and can be useful for more mild slopes. 
+        Passing "slope"" runs the simplifed calculation of svf=cos^2(slope/2) and can be useful for more mild slopes.
     n_angles : int, optional
         Number of angles used in horizon calculations (default is 64).
-        As a reference, n=72 computes every 5deg, n=64 every 5.6deg, n=32 every 11.25deg, etc.  
+        As a reference, n=72 computes every 5deg, n=64 every 5.6deg, n=32 every 11.25deg, etc.
     keep_horizon_files : bool, optional
-        Horizon angles are created in output_dir as netcdfs. False deletes files, and True keeps them. These angles are based from zenith.        
+        Horizon angles are created in output_dir as netcdfs. False deletes files, and True keeps them. These angles are based from zenith.
     logging_level : str, optional
         Logging verbosity level (default is "INFO"); similar to apply_oe.
     log_file : str or None, optional
         File path to write logs; similar to apply_oe.
     n_cores : int, optional
-        Number of CPU cores to use for parallel processing (default is 1). Only used for method="horizon". 
+        Number of CPU cores to use for parallel processing (default is 1). Only used for method="horizon".
         Note: n_cores should ideally not be larger than n_angles.
     """
     # set up logging for skyview.
@@ -185,7 +185,6 @@ def skyview(
         # Start up a ray instance for parallel work
         rayargs = {
             "ignore_reinit_error": True,
-            "local_mode": n_cores == 1,
             "address": ray_address,
             "include_dashboard": False,
             "_temp_dir": ray_temp_dir,
@@ -435,7 +434,6 @@ def create_shadow_mask(
     # Start up a ray instance for parallel work
     rayargs = {
         "ignore_reinit_error": True,
-        "local_mode": n_cores == 1,
         "address": ray_address,
         "include_dashboard": False,
         "_temp_dir": ray_temp_dir,


### PR DESCRIPTION
Ray now raises an exception if it's set:

```python
if local_mode:
  raise RuntimeError(
    "`local_mode` is no longer supported. For interactive debugging consider using the Ray distributed debugger."
  )
```

This was changed two months ago. Not sure why our workflows are just now hitting it