### PR TITLE
Patch fix to upsample call for bg_rfl case

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -284,12 +284,12 @@ def invert_analytical(
     rho_dif_dir = fm.upsample(fm.surface.wl, rho_dif_dir)
 
     rho_dir_dif = (
-        self.upsample(self.surface.wl, geom.bg_rfl)
+        fm.upsample(fm.surface.wl, geom.bg_rfl)
         if isinstance(geom.bg_rfl, np.ndarray)
         else rho_dir_dir
     )
     rho_dif_dif = (
-        self.upsample(self.surface.wl, geom.bg_rfl)
+        fm.upsample(fm.surface.wl, geom.bg_rfl)
         if isinstance(geom.bg_rfl, np.ndarray)
         else rho_dif_dir
     )


### PR DESCRIPTION
This didn't trigger an error yet in our slow tests because `geom.bg_rfl` is not yet populated, but this just changes the `self.upsample` to `fm.upsample`. 