### PR TITLE
Refactor of forward.py.

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -247,7 +247,7 @@ class ForwardModel:
             x_surface[self.idx_surf_rfl] = rfl
 
         # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
+        rho_dir_dir, rho_dif_dir = self.calc_rfl(x, geom)
         rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
         rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
 
@@ -336,8 +336,7 @@ class ForwardModel:
             L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(
                 r, geom, rho_dif_dif=rho_dif_dif
             )
-        if not self.atmosphere.multipart_transmittance:
-            r = self.atmosphere.get(x_atmosphere, geom)
+        else:
             if self.atmosphere.atmosphere_mode == "rdn":
                 L_tot = r["transm_down_dif"]
             else:
@@ -421,9 +420,9 @@ class ForwardModel:
         # If no rho_dif_dif passed eq_11_term -> 1
         eq_11_term = 1 - (r["sphalb"] * rho_dif_dif)
 
-        L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
         L_dif_dir /= eq_11_term
         L_dif_dif /= eq_11_term
+        L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
 
         return L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
 
@@ -549,7 +548,7 @@ class ForwardModel:
         x_surface, x_atmosphere, x_instrument = self.unpack(x)
 
         # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
+        rho_dir_dir, rho_dif_dir = self.calc_rfl(x, geom)
         rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
         rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
 
@@ -593,9 +592,6 @@ class ForwardModel:
             r=r,
             geom=geom,
         )
-
-        # Call surface emission, upsample
-        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
 
         # Call derivative of rfl wrt surface state, upsample
         drfl_dsurface_hi = self.upsample(
@@ -664,7 +660,7 @@ class ForwardModel:
         x_surface, x_atmosphere, x_instrument = self.unpack(x)
 
         # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
+        rho_dir_dir, rho_dif_dir = self.calc_rfl(x, geom)
         rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
         rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
 
@@ -806,7 +802,7 @@ class ForwardModel:
         (which is very unlikely though).
         """
         if len(self.bvec) == 0:
-            Kb_atmosphere = np.zeros((0, len(self.atmosphere.wl.shape)))
+            Kb_atmosphere = np.zeros((0, len(self.atmosphere.wl)))
 
         # ToDo: might require modification in case more unknowns are added
         # The following statement captures the case that H2O is not part

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -27,11 +27,12 @@ from scipy.interpolate import interp1d
 from scipy.io import loadmat
 from scipy.linalg import block_diag
 
-from isofit.core.common import eps, svd_inv_sqrt
+from isofit.atmosphere.atmosphere import Atmosphere
+from isofit.core.common import eps
 from isofit.core.geometry import Geometry
 from isofit.core.instrument import Instrument
 from isofit.core.multistate import match_statevector
-from isofit.radiative_transfer.radiative_transfer import RadiativeTransfer
+from isofit.core.units import transm_to_rdn
 from isofit.surface import Surface
 
 Logger = logging.getLogger(__file__)
@@ -60,7 +61,7 @@ class ForwardModel:
     noise for the purpose of weighting the measurement information
     against the prior."""
 
-    def __init__(self, full_config: Config, cache_RT: RadiativeTransfer = None):
+    def __init__(self, full_config: Config, cache_atmosphere: Atmosphere = None):
         # load in the full config (in case of inter-module dependencies) and
         # then designate the current config
         self.full_config = full_config
@@ -70,27 +71,27 @@ class ForwardModel:
         self.n_meas = self.instrument.n_chan
 
         # Build the radiative transfer model
-        if cache_RT:
-            self.RT = cache_RT
+        if cache_atmosphere:
+            self.atmosphere = cache_atmosphere
         else:
-            self.RT = RadiativeTransfer(self.full_config)
+            self.atmosphere = Atmosphere(self.full_config)
 
         # Build the surface model
         self.surface = Surface(full_config)
 
         # Check to see if using supported calibration surface model
-        if self.surface.n_wl != len(self.RT.wl) or not np.all(
-            np.isclose(self.surface.wl, self.RT.wl, atol=0.01)
+        if self.surface.n_wl != len(self.atmosphere.wl) or not np.all(
+            np.isclose(self.surface.wl, self.atmosphere.wl, atol=0.01)
         ):
             Logger.warning(
-                "Surface and RTM wavelengths differ - if running at higher RTM"
+                "Surface and atmosphere wavelengths differ - if running at higher atmosphere"
                 " spectral resolution or with variable wavelength position, this"
-                " is expected.  Otherwise, consider checking the surface model."
+                " is expected. Otherwise, consider checking the surface model."
             )
 
-        # Build combined vectors from surface, RT, and instrument
+        # Build combined vectors from surface, atmosphere, and instrument
         bounds, scale, init, statevec, bvec = ([] for i in range(5))
-        for obj_with_statevec in [self.surface, self.RT, self.instrument]:
+        for obj_with_statevec in [self.surface, self.atmosphere, self.instrument]:
             bounds.extend([deepcopy(x) for x in obj_with_statevec.bounds])
             scale.extend([deepcopy(x) for x in obj_with_statevec.scale])
             init.extend([deepcopy(x) for x in obj_with_statevec.init])
@@ -112,6 +113,7 @@ class ForwardModel:
 
         Sometimes, it's convenient to have the index of the entire surface
         as one variable, and sometimes you want the sub-components
+        
         Split surface state vector indices to cover cases where we retrieve
         additional non-reflectance surface parameters
         """
@@ -128,25 +130,25 @@ class ForwardModel:
         self.idx_surf_nonrfl = self.idx_surface[len(self.surface.idx_lamb) :]
 
         # radiative transfer portion
-        self.idx_RT = np.arange(len(self.RT.statevec_names), dtype=int) + len(
-            self.idx_surface
-        )
+        self.idx_atmosphere = np.arange(
+            len(self.atmosphere.statevec_names), dtype=int
+        ) + len(self.idx_surface)
 
         # instrument portion
         self.idx_instrument = (
             np.arange(len(self.instrument.statevec_names), dtype=int)
             + len(self.idx_surface)
-            + len(self.idx_RT)
+            + len(self.idx_atmosphere)
         )
 
         self.surface_b_inds = np.arange(len(self.surface.bvec), dtype=int)
-        self.RT_b_inds = np.arange(len(self.RT.bvec), dtype=int) + len(
+        self.atmosphere_b_inds = np.arange(len(self.atmosphere.bvec), dtype=int) + len(
             self.surface_b_inds
         )
         self.instrument_b_inds = (
             np.arange(len(self.instrument.bvec), dtype=int)
             + len(self.surface_b_inds)
-            + len(self.RT_b_inds)
+            + len(self.atmosphere_b_inds)
         )
 
         # Load model discrepancy correction
@@ -159,17 +161,16 @@ class ForwardModel:
     def out_of_bounds(self, x):
         """Check if state vector is within bounds."""
 
-        x_RT = x[self.idx_RT]
+        x_atmosphere = x[self.idx_atmosphere]
         bound_lwr = self.bounds[0]
         bound_upr = self.bounds[1]
-        return any(x_RT >= (bound_upr[self.idx_RT] - eps * 2.0)) or any(
-            x_RT <= (bound_lwr[self.idx_RT] + eps * 2.0)
+        return any(x_atmosphere >= (bound_upr[self.idx_atmosphere] - eps * 2.0)) or any(
+            x_atmosphere <= (bound_lwr[self.idx_atmosphere] + eps * 2.0)
         )
 
     def xa(self, x, geom):
         """Calculate the prior mean of the state vector (the concatenation
-        of state vectors for the surface, Radiative Transfer model, and
-        instrument).
+        of state vectors for the surface, atmosphere, and instrument).
 
         NOTE: the surface prior mean depends on the current state;
         this is so we can calculate the local prior.
@@ -177,14 +178,13 @@ class ForwardModel:
 
         x_surface = x[self.idx_surface]
         xa_surface = self.surface.xa(x_surface, geom)
-        xa_RT = self.RT.xa()
+        xa_atmosphere = self.atmosphere.xa()
         xa_instrument = self.instrument.xa()
-        return np.concatenate((xa_surface, xa_RT, xa_instrument), axis=0)
+        return np.concatenate((xa_surface, xa_atmosphere, xa_instrument), axis=0)
 
     def Sa(self, x, geom):
         """Calculate the prior covariance of the state vector (the
-        concatenation of state vectors for the surface and radiative transfer
-        model).
+        concatenation of state vectors for the surface and the atmosphere).
 
         NOTE: the surface prior depends on the current state; this
         is so we can calculate the local prior.
@@ -194,43 +194,45 @@ class ForwardModel:
         Sa_surface, Sa_surf_inv_norm, Sa_surf_inv_sqrt_norm = self.surface.Sa(
             x_surface, geom
         )
-        Sa_RT = self.RT.Sa()
+        Sa_atmosphere = self.atmosphere.Sa()
         Sa_instrument = self.instrument.Sa()
-        Sa_state = block_diag(Sa_surface[:, :], Sa_RT[:, :], Sa_instrument[:, :])
+        Sa_state = block_diag(
+            Sa_surface[:, :], Sa_atmosphere[:, :], Sa_instrument[:, :]
+        )
 
         # per block variance scaling for normalization
-        scale_surf = np.sqrt(np.mean(np.diag(Sa_surface[:, :])))
-        scale_RT = np.sqrt(np.mean(np.diag(Sa_RT[:, :])))
-        scale_inst = np.sqrt(np.mean(np.diag(Sa_instrument[:, :])))
+        scale_surface = np.sqrt(np.mean(np.diag(Sa_surface[:, :])))
+        scale_atmosphere = np.sqrt(np.mean(np.diag(Sa_atmosphere[:, :])))
+        scale_instrument = np.sqrt(np.mean(np.diag(Sa_instrument[:, :])))
 
         # Compute the Sa inv and Sa inv sqrt for measurement
         Sa_inv_state = block_diag(
-            Sa_surf_inv_norm / scale_surf**2,
-            self.RT.Sa_inv_normalized / scale_RT**2,
-            self.instrument.Sa_inv_normalized / scale_inst**2,
+            Sa_surf_inv_norm / scale_surface**2,
+            self.atmosphere.Sa_inv_normalized / scale_atmosphere**2,
+            self.instrument.Sa_inv_normalized / scale_instrument**2,
         )
 
         Sa_inv_sqrt_state = block_diag(
-            Sa_surf_inv_sqrt_norm / scale_surf,
-            self.RT.Sa_inv_sqrt_normalized / scale_RT,
-            self.instrument.Sa_inv_sqrt_normalized / scale_inst,
+            Sa_surf_inv_sqrt_norm / scale_surface,
+            self.atmosphere.Sa_inv_sqrt_normalized / scale_atmosphere,
+            self.instrument.Sa_inv_sqrt_normalized / scale_instrument,
         )
 
         return Sa_state, Sa_inv_state, Sa_inv_sqrt_state
 
-    def Sb(self, x, meas, geom):
+    def Sb(self, meas):
         """Accumulate the uncertainty due to unmodeled variables within
         respective forward model portions."""
         Sb_surface = self.surface.Sb()
-        Sb_RT = self.RT.Sb()
+        Sb_atmosphere = self.atmosphere.Sb()
         Sb_instrument = self.instrument.Sb(meas)
 
-        return block_diag(Sb_surface, Sb_RT, Sb_instrument)
+        return block_diag(Sb_surface, Sb_atmosphere, Sb_instrument)
 
-    def eof_offset(self, x_surface, x_RT, x_instrument):
-        """Empirical orthogonal fucntion offset. FM wrapper in the style
+    def eof_offset(self, x_instrument):
+        """Empirical orthogonal function offset. FM wrapper in the style
         of xa, Sa, Seps in case we want to be able to extend this
-        across surface, RT, and instrument"""
+        across surface, atmosphere, and instrument"""
         offset = self.instrument.eof_offset(x_instrument)
 
         return offset
@@ -238,9 +240,9 @@ class ForwardModel:
     def calc_meas(self, x, geom, rfl=[]):
         """Calculate the model observation at instrument wavelengths."""
         # Unpack state vector - Copy to not change x fm-wide
-        x_surface, x_RT, x_instrument = self.unpack(np.copy(x))
+        x_surface, x_atmosphere, x_instrument = self.unpack(np.copy(x))
 
-        # if rfl passed, have to explicitely use those values
+        # if rfl passed, have to explicitly use those values
         if len(rfl):
             x_surface[self.idx_surf_rfl] = rfl
 
@@ -261,7 +263,7 @@ class ForwardModel:
             else rho_dif_dir_hi
         )
 
-        # Get RT quantities
+        # Get atmosphere quantities
         (
             r,
             L_tot,
@@ -269,13 +271,13 @@ class ForwardModel:
             L_dif_dir,
             L_dir_dif,
             L_dif_dif,
-        ) = self.RT.calc_RT_quantities(x_RT, geom, rho_dif_dif_hi)
+        ) = self.calc_atmosphere_quantities(x_atmosphere, geom, rho_dif_dif_hi)
 
         # Call surface emission, upsample
         Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
 
-        rdn = self.RT.calc_rdn(
-            x_RT,
+        rdn = self.calc_rdn(
+            x_atmosphere,
             rho_dir_dir=rho_dir_dir_hi,
             rho_dif_dir=rho_dif_dir_hi,
             rho_dir_dif=rho_dir_dif_hi,
@@ -290,286 +292,144 @@ class ForwardModel:
             geom=geom,
         )
 
-        return self.instrument.sample(x_instrument, self.RT.wl, rdn) + self.eof_offset(
-            x_surface, x_RT, x_instrument
-        )
+        return self.instrument.sample(
+            x_instrument, self.atmosphere.wl, rdn
+        ) + self.eof_offset(x_instrument)
 
-    def calc_Ls(self, x, geom):
-        """Calculate the surface emission."""
+    def calc_atmosphere_quantities(
+        self, x_atmosphere: np.ndarray, geom: Geometry, rho_dif_dif: np.ndarray = 0
+    ):
+        """Retrieves the atmosphere quantities including the LUT sample (r),
+        and the radiances (L). This function handles the hand-off between
+        the 1c and 6c model.
 
-        return self.surface.calc_Ls(x[self.idx_surface], geom)
+        In the 1c case, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = 0,
+        and L_tot, L_down_dir, and L_down_dif are populated within the
+        if statement.
 
-    def calc_rfl(self, x, geom):
-        """Calculate the surface reflectance."""
+        In the 6c case, we always use returns from get_L_coupled
+        All quantities are on the sun-to-surface-to-sensor path.
 
-        return self.surface.calc_rfl(x[self.idx_surface], geom)
+        Args:
+            x_atmosphere: atmosphere portion of the state vector.
+            geom: Geometry object for the current observation.
+            rho_dif_dif: Apparent surface reflectance for
+                hemispherical-hemispherical photon paths.
+                Included here to incorporate surface-atm coupling
+                following Eq. 11 of Guanter et al., 2009.
 
-    def calc_lamb(self, x, geom):
-        """Calculate the Lambertian surface reflectance."""
-
-        return self.surface.calc_lamb(x[self.idx_surface], geom)
-
-    def Seps(self, x, meas, geom):
-        """Calculate the total uncertainty of the observation, including
-        up to three terms: (1) the instrument noise; (2) the uncertainty
-        due to explicit unmodeled variables, i.e. the S_epsilon matrix of
-        Rodgers et al.; and (3) an aggregate 'model discrepancy' term,
-        Gamma."""
-
-        if self.model_discrepancy is not None:
-            Gamma = self.model_discrepancy
-        else:
-            Gamma = 0
-
-        Sb = self.Sb(x, meas, geom)
-        Kb = self.Kb(x, geom)
-        Sy = self.instrument.Sy(meas, geom)
-
-        return Sy + Kb.dot(Sb).dot(Kb.T) + Gamma
-
-    def K(self, x, geom):
-        """Derivative of observation with respect to state vector. This is
-        the concatenation of jacobians with respect to parameters of the
-        surface and radiative transfer model.
+        Returns:
+            r: LUT sample dictionary of shared atmosphere quantities.
+            L_tot: total downwelling radiance (uW/nm/sr/cm2).
+            L_dir_dir: direct-to-direct radiance component; zero in 1c mode.
+            L_dif_dir: diffuse-to-direct radiance component; zero in 1c mode.
+            L_dir_dif: direct-to-diffuse radiance component; zero in 1c mode.
+            L_dif_dif: diffuse-to-diffuse radiance component; zero in 1c mode.
         """
-        # Unpack state vector
-        x_surface, x_RT, x_instrument = self.unpack(x)
 
-        # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
-        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
-        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
+        # Propogate LUT
+        r = self.atmosphere.get(x_atmosphere, geom)
 
-        # Adjacency effects
-        rho_dir_dif_hi = (
-            self.upsample(self.surface.wl, geom.bg_rfl)
-            if isinstance(geom.bg_rfl, np.ndarray)
-            else rho_dir_dir_hi
-        )
-        rho_dif_dif_hi = (
-            self.upsample(self.surface.wl, geom.bg_rfl)
-            if isinstance(geom.bg_rfl, np.ndarray)
-            else rho_dif_dir_hi
-        )
-
-        # Get RT quantities
-        (
-            r,
-            L_tot,
-            L_dir_dir,
-            L_dif_dir,
-            L_dir_dif,
-            L_dif_dif,
-        ) = self.RT.calc_RT_quantities(x_RT, geom, rho_dif_dif_hi)
-
-        # Call surface emission, upsample
-        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
-
-        rdn = self.RT.calc_rdn(
-            x_RT,
-            rho_dir_dir=rho_dir_dir_hi,
-            rho_dif_dir=rho_dif_dir_hi,
-            rho_dir_dif=rho_dir_dif_hi,
-            rho_dif_dif=rho_dif_dif_hi,
-            Ls=Ls_hi,
-            L_tot=L_tot,
-            L_dir_dir=L_dir_dir,
-            L_dif_dir=L_dif_dir,
-            L_dir_dif=L_dir_dif,
-            L_dif_dif=L_dif_dif,
-            r=r,
-            geom=geom,
-        )
-
-        # Call surface emission, upsample
-        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
-
-        # Call derivative of rfl wrt surface state, upsample
-        drfl_dsurface_hi = self.upsample(
-            self.surface.wl,
-            self.surface.drfl_dsurface(x_surface, geom).T,
-        ).T
-
-        # Call derivative of surface emission wrt surface state, upsample
-        dLs_dsurface_hi = self.upsample(
-            self.surface.wl, self.surface.dLs_dsurface(x_surface, geom).T
-        ).T
-
-        # To get the derivative w.r.t. RT
-        drdn_dRT = self.RT.drdn_dRT(
-            x_RT,
-            geom,
-            rho_dir_dir=rho_dir_dir_hi,
-            rho_dif_dir=rho_dif_dir_hi,
-            rho_dir_dif=rho_dir_dif_hi,
-            rho_dif_dif=rho_dif_dif_hi,
-            Ls=Ls_hi,
-            rdn=rdn,
-        )
-
-        # To get the derivative w.r.t. Surface
-        drdn_dsurface = self.surface.drdn_dsurface(
-            rho_dif_dir=rho_dif_dir_hi,
-            drfl_dsurface=drfl_dsurface_hi,
-            dLs_dsurface=dLs_dsurface_hi,
-            s_alb=r["sphalb"],
-            t_total_up=self.RT.get_upward_transm(r=r, geom=geom),
-            L_tot=L_tot,
-            L_dir_dir=L_dir_dir,
-            L_dir_dif=L_dir_dif,
-            L_dif_dir=L_dif_dir,
-            L_dif_dif=L_dif_dif,
-        )
-
-        # To get derivatives w.r.t. instrument, downsample to instrument wavelengths
-        dmeas_dsurface = self.instrument.sample(
-            x_instrument, self.RT.wl, drdn_dsurface.T
-        ).T
-        dmeas_dRT = self.instrument.sample(x_instrument, self.RT.wl, drdn_dRT.T).T
-        dmeas_dinstrument = self.instrument.dmeas_dinstrument(
-            x_instrument, self.RT.wl, rdn
-        )
-
-        # Put it all together
-        K = np.zeros((self.n_meas, self.nstate), dtype=float)
-        K[:, self.idx_surface] = dmeas_dsurface
-        K[:, self.idx_RT] = dmeas_dRT
-        K[:, self.idx_instrument] = dmeas_dinstrument
-        return K
-
-    def Kb(self, x, geom):
-        """Derivative of measurement with respect to unmodeled & unretrieved
-        unknown variables, e.g. S_b. This is  the concatenation of Jacobians
-        with respect to parameters of the surface, radiative transfer model,
-        and instrument.  Currently we only treat uncertainties in the
-        instrument and RT model."""
-
-        # Unpack state vector
-        x_surface, x_RT, x_instrument = self.unpack(x)
-
-        # Call surface reflectance w.r.t. surface, upsample
-        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
-        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
-        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
-
-        # Adjacency effects
-        rho_dir_dif_hi = (
-            self.upsample(self.surface.wl, geom.bg_rfl)
-            if isinstance(geom.bg_rfl, np.ndarray)
-            else rho_dir_dir_hi
-        )
-        rho_dif_dif_hi = (
-            self.upsample(self.surface.wl, geom.bg_rfl)
-            if isinstance(geom.bg_rfl, np.ndarray)
-            else rho_dif_dir_hi
-        )
-
-        # Get RT quantities
-        (
-            r,
-            L_tot,
-            L_dir_dir,
-            L_dif_dir,
-            L_dir_dif,
-            L_dif_dif,
-        ) = self.RT.calc_RT_quantities(x_RT, geom, rho_dif_dif_hi)
-
-        # Call surface emission, upsample
-        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
-
-        rdn = self.RT.calc_rdn(
-            x_RT,
-            rho_dir_dir=rho_dir_dir_hi,
-            rho_dif_dir=rho_dif_dir_hi,
-            rho_dir_dif=rho_dir_dif_hi,
-            rho_dif_dif=rho_dif_dif_hi,
-            Ls=Ls_hi,
-            L_tot=L_tot,
-            L_dir_dir=L_dir_dir,
-            L_dif_dir=L_dif_dir,
-            L_dir_dif=L_dir_dif,
-            L_dif_dif=L_dif_dif,
-            r=r,
-            geom=geom,
-        )
-
-        drdn_dRTb = self.RT.drdn_dRTb(
-            x_RT,
-            geom=geom,
-            rho_dir_dir=rho_dir_dir_hi,
-            rho_dif_dir=rho_dif_dir_hi,
-            rho_dir_dif=rho_dir_dif_hi,
-            rho_dif_dif=rho_dif_dif_hi,
-            Ls=Ls_hi,
-            rdn=rdn,
-        )
-
-        # To get derivatives w.r.t. instrument, downsample to instrument wavelengths
-        dmeas_dRTb = self.instrument.sample(x_instrument, self.RT.wl, drdn_dRTb.T).T
-        dmeas_dinstrumentb = self.instrument.dmeas_dinstrumentb(
-            x_instrument, self.RT.wl, rdn
-        )
-
-        # Put it together
-        Kb = np.zeros((self.n_meas, self.nbvec), dtype=float)
-        Kb[:, self.RT_b_inds] = dmeas_dRTb
-        Kb[:, self.instrument_b_inds] = dmeas_dinstrumentb
-        return Kb
-
-    def summarize(self, x, geom):
-        """State vector summary."""
-
-        x_surface, x_RT, x_instrument = self.unpack(x)
-        return (
-            self.surface.summarize(x_surface, geom)
-            + " "
-            + self.RT.summarize(x_RT, geom)
-            + " "
-            + self.instrument.summarize(x_instrument, geom)
-        )
-
-    def calibration(self, x):
-        """Calculate measured wavelengths and fwhm."""
-
-        x_inst = x[self.idx_instrument]
-        return self.instrument.calibration(x_inst)
-
-    def upsample(self, wl, q):
-        """Linear interpolation to RT wavelengths."""
-        # Only interpolate if these aren't close
-        close = len(wl) == len(self.RT.wl) and np.allclose(wl, self.RT.wl)
-
-        # or if any dimension is the wrong size
-        interp = (np.array(q.shape) != len(self.RT.wl)).all()
-
-        if not close or interp:
-            if q.ndim > 1:
-                return np.array(
-                    [interp1d(wl, qi, fill_value="extrapolate")(self.RT.wl) for qi in q]
-                )
+        # Handle 1c L_tot. NOTE: transm_down_dif = total transm for 1c case.
+        if self.atmosphere.multipart_transmittance:
+            # Get directional radiances
+            L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(
+                r, geom, rho_dif_dif=rho_dif_dif
+            )
+        if not self.atmosphere.multipart_transmittance:
+            r = self.atmosphere.get(x_atmosphere, geom)
+            if self.atmosphere.atmosphere_mode == "rdn":
+                L_tot = r["transm_down_dif"]
             else:
-                p = interp1d(wl, q, fill_value="extrapolate")
-                return p(self.RT.wl)
-        return q
+                L_tot = transm_to_rdn(
+                    r["transm_down_dif"],
+                    geom.coszen,
+                    self.atmosphere.solar_irr,
+                )
+            L_dir_dir = 0
+            L_dif_dir = 0
+            L_dir_dif = 0
+            L_dif_dif = 0
 
-    def unpack(self, x):
-        """Unpack the state vector in appropriate index ordering."""
-
-        x_surface = x[self.idx_surface]
-        x_RT = x[self.idx_RT]
-        x_instrument = x[self.idx_instrument]
-        return x_surface, x_RT, x_instrument
-
-    def match_statevector(self, full_statevector):
-        self.full_idx, self.full_miss = match_statevector(
-            full_statevector, self.statevec
+        return (
+            r,
+            L_tot,
+            L_dir_dir,
+            L_dif_dir,
+            L_dir_dif,
+            L_dif_dif,
         )
 
-    # These are moved from radiative_transfer.py and need all references checked
+    def get_L_coupled(self, r: dict, geom: Geometry, rho_dif_dif: np.ndarray = 0):
+        """Get the interpolated radiance terms on the sun-to-surface-to-sensor path.
+        These follow the physics as presented in Guanter (2006), Vermote et al. (1997), and Tanre et al. (1983).
+
+        Note:   This function is only applicable to the 6c run case
+                where r contains populated separated transmittances
+
+        Args:
+            r:      interpolated radiative transfer quantities from the LUT
+            coszen: top-of-atmosphere solar zenith angle
+            cos_i:  local solar zenith angle at the surface
+
+        Returns:
+            interpolated radiances along all optical paths:
+            L_dir_dir => downward direct * upward direct
+            L_dif_dir => downward diffuse * upward direct
+            L_dir_dif => downward direct * upward diffuse
+            L_dif_dif => downward diffuse * upward diffuse
+        """
+
+        # radiances along all optical paths
+        L_coupled = []
+
+        for key in self.atmosphere.coupling_terms:
+            L_coupled.append(
+                transm_to_rdn(
+                    r[key], coszen=geom.coszen, solar_irr=self.atmosphere.solar_irr
+                )
+                if self.atmosphere.atmosphere_mode == "transm"
+                else r[key]
+            )
+
+        # Topographic shadow mask (0=shadow, 1=sunlit pixel).
+        # for now, this is always set to 1.0.
+        b = 1.0
+
+        # Assumption of the topography of the background
+        cos_i_bg = geom.coszen
+        skyview_factor_bg = 1.0
+
+        # Assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle.
+        # Downward diffuse components are scaled by viewable sky fraction (i.e., "ungula" of viewable sky in solid geometry terms).
+        L_dir_dir = L_coupled[0] / geom.coszen * geom.cos_i * b
+        L_dif_dir = L_coupled[1]
+        L_dir_dif = L_coupled[2] / geom.coszen * cos_i_bg
+        L_dif_dif = L_coupled[3]
+
+        # Note - we should really be doing the multiplication upstream before convolution - this is an approximation
+        # Correct downward diffuse term for topographic assuming Hay's model (Hay 1979; Richter 1998; Guanter et al., 2009)
+        t_down_dir = r["transm_down_dir"]
+        L_dif_dir *= (b * t_down_dir * (geom.cos_i / geom.coszen)) + (
+            (1 - b * t_down_dir) * geom.skyview_factor
+        )
+        L_dif_dif *= (t_down_dir * (cos_i_bg / geom.coszen)) + (
+            (1 - t_down_dir) * skyview_factor_bg
+        )
+
+        # Apply equation 11
+        # If no rho_dif_dif passed eq_11_term -> 1
+        eq_11_term = 1 - (r["sphalb"] * rho_dif_dif)
+
+        L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
+        L_dif_dir /= eq_11_term
+        L_dif_dif /= eq_11_term
+
+        return L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
 
     def calc_rdn(
         self,
-        x_RT,
+        x_atmosphere,
         rho_dir_dir,
         rho_dif_dir,
         rho_dir_dif,
@@ -588,21 +448,21 @@ class ForwardModel:
         Includes topography, background reflectance, and glint.
         """
         # Atmospheric path radiance
-        L_atm = self.get_L_atm(x_RT, geom)
+        L_atm = self.atmosphere.get_L_atm(x_atmosphere, geom)
 
         # Atmospheric spherical albedo
         s_alb = r["sphalb"]
         atm_surface_scattering = s_alb * rho_dif_dif
 
         # Special case: 1-component model
-        if not self.engine.multipart_transmittance:
+        if not self.atmosphere.multipart_transmittance:
             # we assume rho_dir_dir = rho_dif_dir = rho_dir_dif = rho_dif_dif
             rho_dif_dif = rho_dir_dir
             # eliminate spherical albedo and one reflectance term from numerator if using 1-component model
             atm_surface_scattering = 1
 
         # Thermal transmittance
-        L_up = Ls * self.get_upward_transm(r=r, geom=geom)
+        L_up = Ls * self.atmosphere.get_upward_transm(r=r, geom=geom)
 
         # Our radiance model follows the physics as presented in Guanter (2006), Vermote et al. (1997), and
         # Tanre et al. (1983). This particular formulation facilitates the consideration of topographic effects,
@@ -647,154 +507,255 @@ class ForwardModel:
 
         return ret
 
-    def get_L_coupled(self, r: dict, geom: Geometry, rho_dif_dif: np.ndarray = 0):
-        """Get the interpolated radiance terms on the sun-to-surface-to-sensor path.
-        These follow the physics as presented in Guanter (2006), Vermote et al. (1997), and Tanre et al. (1983).
+    def calc_Ls(self, x, geom):
+        """Calculate the surface emission."""
 
-        Note:   This function is only applicable to the 6c run case
-                where r contains populated separated transmittances
+        return self.surface.calc_Ls(x[self.idx_surface], geom)
 
-        Args:
-            r:      interpolated radiative transfer quantities from the LUT
-            coszen: top-of-atmosphere solar zenith angle
-            cos_i:  local solar zenith angle at the surface
+    def calc_rfl(self, x, geom):
+        """Calculate the surface reflectance."""
 
-        Returns:
-            interpolated radiances along all optical paths:
-            L_dir_dir => downward direct * upward direct
-            L_dif_dir => downward diffuse * upward direct
-            L_dir_dif => downward direct * upward diffuse
-            L_dif_dif => downward diffuse * upward diffuse
+        return self.surface.calc_rfl(x[self.idx_surface], geom)
+
+    def calc_lamb(self, x, geom):
+        """Calculate the Lambertian surface reflectance."""
+
+        return self.surface.calc_lamb(x[self.idx_surface], geom)
+
+    def Seps(self, x, meas, geom):
+        """Calculate the total uncertainty of the observation, including
+        up to three terms: (1) the instrument noise; (2) the uncertainty
+        due to explicit unmodeled variables, i.e. the S_epsilon matrix of
+        Rodgers et al.; and (3) an aggregate 'model discrepancy' term,
+        Gamma."""
+
+        if self.model_discrepancy is not None:
+            Gamma = self.model_discrepancy
+        else:
+            Gamma = 0
+
+        Sb = self.Sb(meas)
+        Kb = self.Kb(x, geom)
+        Sy = self.instrument.Sy(meas, geom)
+
+        return Sy + Kb.dot(Sb).dot(Kb.T) + Gamma
+
+    def K(self, x, geom):
+        """Derivative of observation with respect to state vector. This is
+        the concatenation of jacobians with respect to parameters of the
+        surface and the atmosphere.
         """
+        # Unpack state vector
+        x_surface, x_atmosphere, x_instrument = self.unpack(x)
 
-        # radiances along all optical paths
-        L_coupled = []
+        # Call surface reflectance w.r.t. surface, upsample
+        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
+        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
+        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
 
-        for key in self.engine.coupling_terms:
-            L_coupled.append(
-                units.transm_to_rdn(
-                    r[key], coszen=geom.coszen, solar_irr=self.solar_irr
-                )
-                if self.engine.rt_mode == "transm"
-                else r[key]
-            )
-
-        # Topographic shadow mask (0=shadow, 1=sunlit pixel).
-        # for now, this is always set to 1.0.
-        b = 1.0
-
-        # Assumption of the topography of the background
-        cos_i_bg = geom.coszen
-        skyview_factor_bg = 1.0
-
-        # Assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle.
-        # Downward diffuse components are scaled by viewable sky fraction (i.e., "ungula" of viewable sky in solid geometry terms).
-        L_dir_dir = L_coupled[0] / geom.coszen * geom.cos_i * b
-        L_dif_dir = L_coupled[1]
-        L_dir_dif = L_coupled[2] / geom.coszen * cos_i_bg
-        L_dif_dif = L_coupled[3]
-
-        # Note - we should really be doing the multiplication upstream before convolution - this is an approximation
-        # Correct downward diffuse term for topographic assuming Hay's model (Hay 1979; Richter 1998; Guanter et al., 2009)
-        t_down_dir = r["transm_down_dir"]
-        L_dif_dir *= (b * t_down_dir * (geom.cos_i / geom.coszen)) + (
-            (1 - b * t_down_dir) * geom.skyview_factor
+        # Adjacency effects
+        rho_dir_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dir_dir_hi
         )
-        L_dif_dif *= (t_down_dir * (cos_i_bg / geom.coszen)) + (
-            (1 - t_down_dir) * skyview_factor_bg
+        rho_dif_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dif_dir_hi
         )
 
-        # Apply equation 11
-        # If no rho_dif_dif passed eq_11_term -> 1
-        eq_11_term = 1 - (r["sphalb"] * rho_dif_dif)
-
-        L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
-        L_dif_dir /= eq_11_term
-        L_dif_dif /= eq_11_term
-
-        return L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
-
-    def calc_RT_quantities(
-        self, x_RT: np.ndarray, geom: Geometry, rho_dif_dif: np.ndarray = 0
-    ):
-        """Retrieves the RT quantities including the LUT sample (r),
-        and the radiances (L). This function handles the hand-off between
-        the 1c and 6c model.
-
-        In the 1c case, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = 0,
-        and L_tot, L_down_dir, and L_down_dif are populated within the
-        if statement.
-
-        In the 6c case, we always use returns from get_L_coupled
-        All quantities are on the sun-to-surface-to-sensor path.
-
-        Args:
-            x_RT: RT portion of the state vector.
-            geom: Geometry object for the current observation.
-            rho_dif_dif: Apparent surface reflectance for
-                hemispherical-hemispherical photon paths.
-                Included here to incorporate surface-atm coupling
-                following Eq. 11 of Guanter et al, 2009.
-
-        Returns:
-            r: LUT sample dictionary of shared RT quantities.
-            L_tot: total downwelling radiance (uW/nm/sr/cm2).
-            L_dir_dir: direct-to-direct radiance component; zero in 1c mode.
-            L_dif_dir: diffuse-to-direct radiance component; zero in 1c mode.
-            L_dir_dif: direct-to-diffuse radiance component; zero in 1c mode.
-            L_dif_dif: diffuse-to-diffuse radiance component; zero in 1c mode.
-        """
-
-        # Propogate LUT
-        r = self.engine.get(x_RT, geom)
-
-        # Handle 1c L_tot. NOTE: transm_down_dif = total transm for 1c case.
-        if self.engine.multipart_transmittance:
-            # Get directional radiances
-            L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = self.get_L_coupled(
-                r, geom, rho_dif_dif=rho_dif_dif
-            )
-        if not self.engine.multipart_transmittance:
-            r = self.engine.get(x_RT, geom)
-            if self.engine.treat_as_emissive:
-                rdn = r["thermal_downwelling"]
-            else:
-                if self.engine.rt_mode == "rdn":
-                    L_tot = r["transm_down_dif"]
-                else:
-                    L_tot = units.transm_to_rdn(
-                        r["transm_down_dif"],
-                        geom.coszen,
-                        self.solar_irr,
-                    )
-            L_dir_dir = 0
-            L_dif_dir = 0
-            L_dir_dif = 0
-            L_dif_dif = 0
-
-        return (
+        # Get atmosphere quantities
+        (
             r,
             L_tot,
             L_dir_dir,
             L_dif_dir,
             L_dir_dif,
             L_dif_dif,
+        ) = self.calc_atmosphere_quantities(x_atmosphere, geom, rho_dif_dif_hi)
+
+        # Call surface emission, upsample
+        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
+
+        rdn = self.calc_rdn(
+            x_atmosphere,
+            rho_dir_dir=rho_dir_dir_hi,
+            rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
+            Ls=Ls_hi,
+            L_tot=L_tot,
+            L_dir_dir=L_dir_dir,
+            L_dif_dir=L_dif_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dif=L_dif_dif,
+            r=r,
+            geom=geom,
         )
 
-    def drdn_dRT(
-        self, x_RT, geom, rho_dir_dir, rho_dif_dir, rho_dir_dif, rho_dif_dif, Ls, rdn
+        # Call surface emission, upsample
+        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
+
+        # Call derivative of rfl wrt surface state, upsample
+        drfl_dsurface_hi = self.upsample(
+            self.surface.wl,
+            self.surface.drfl_dsurface(x_surface, geom).T,
+        ).T
+
+        # Call derivative of surface emission wrt surface state, upsample
+        dLs_dsurface_hi = self.upsample(
+            self.surface.wl, self.surface.dLs_dsurface(x_surface, geom).T
+        ).T
+
+        # To get the derivative w.r.t. atmosphere
+        drdn_datmosphere = self.drdn_datmosphere(
+            x_atmosphere,
+            geom,
+            rho_dir_dir=rho_dir_dir_hi,
+            rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
+            Ls=Ls_hi,
+            rdn=rdn,
+        )
+
+        # To get the derivative w.r.t. Surface
+        # ToDo: Move this to ForwardModel as well?
+        drdn_dsurface = self.surface.drdn_dsurface(
+            rho_dif_dir=rho_dif_dir_hi,
+            drfl_dsurface=drfl_dsurface_hi,
+            dLs_dsurface=dLs_dsurface_hi,
+            s_alb=r["sphalb"],
+            t_total_up=self.atmosphere.get_upward_transm(r=r, geom=geom),
+            L_tot=L_tot,
+            L_dir_dir=L_dir_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dir=L_dif_dir,
+            L_dif_dif=L_dif_dif,
+        )
+
+        # To get derivatives w.r.t. instrument, downsample to instrument wavelengths
+        dmeas_dsurface = self.instrument.sample(
+            x_instrument, self.atmosphere.wl, drdn_dsurface.T
+        ).T
+        dmeas_datmosphere = self.instrument.sample(
+            x_instrument, self.atmosphere.wl, drdn_datmosphere.T
+        ).T
+        dmeas_dinstrument = self.instrument.dmeas_dinstrument(
+            x_instrument, self.atmosphere.wl, rdn
+        )
+
+        # Put it all together
+        K = np.zeros((self.n_meas, self.nstate), dtype=float)
+        K[:, self.idx_surface] = dmeas_dsurface
+        K[:, self.idx_atmosphere] = dmeas_datmosphere
+        K[:, self.idx_instrument] = dmeas_dinstrument
+        return K
+
+    def Kb(self, x, geom):
+        """Derivative of measurement with respect to unmodeled & unretrieved
+        unknown variables, e.g. S_b. This is  the concatenation of Jacobians
+        with respect to parameters of the surface, atmosphere,
+        and instrument. Currently, we only treat uncertainties in the
+        instrument and atmosphere model."""
+
+        # Unpack state vector
+        x_surface, x_atmosphere, x_instrument = self.unpack(x)
+
+        # Call surface reflectance w.r.t. surface, upsample
+        rho_dir_dir, rho_dif_dir = self.calc_rfl(x_surface, geom)
+        rho_dir_dir_hi = self.upsample(self.surface.wl, rho_dir_dir)
+        rho_dif_dir_hi = self.upsample(self.surface.wl, rho_dif_dir)
+
+        # Adjacency effects
+        rho_dir_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dir_dir_hi
+        )
+        rho_dif_dif_hi = (
+            self.upsample(self.surface.wl, geom.bg_rfl)
+            if isinstance(geom.bg_rfl, np.ndarray)
+            else rho_dif_dir_hi
+        )
+
+        # Get atmosphere quantities
+        (
+            r,
+            L_tot,
+            L_dir_dir,
+            L_dif_dir,
+            L_dir_dif,
+            L_dif_dif,
+        ) = self.calc_atmosphere_quantities(x_atmosphere, geom, rho_dif_dif_hi)
+
+        # Call surface emission, upsample
+        Ls_hi = self.upsample(self.surface.wl, self.calc_Ls(x_surface, geom))
+
+        rdn = self.calc_rdn(
+            x_atmosphere,
+            rho_dir_dir=rho_dir_dir_hi,
+            rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
+            Ls=Ls_hi,
+            L_tot=L_tot,
+            L_dir_dir=L_dir_dir,
+            L_dif_dir=L_dif_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dif=L_dif_dif,
+            r=r,
+            geom=geom,
+        )
+
+        drdn_datmosphereb = self.drdn_datmosphereb(
+            x_atmosphere,
+            geom=geom,
+            rho_dir_dir=rho_dir_dir_hi,
+            rho_dif_dir=rho_dif_dir_hi,
+            rho_dir_dif=rho_dir_dif_hi,
+            rho_dif_dif=rho_dif_dif_hi,
+            Ls=Ls_hi,
+            rdn=rdn,
+        )
+
+        # To get derivatives w.r.t. instrument, downsample to instrument wavelengths
+        dmeas_datmosphereb = self.instrument.sample(
+            x_instrument, self.atmosphere.wl, drdn_datmosphereb.T
+        ).T
+        dmeas_dinstrumentb = self.instrument.dmeas_dinstrumentb(
+            x_instrument, self.atmosphere.wl, rdn
+        )
+
+        # Put it together
+        Kb = np.zeros((self.n_meas, self.nbvec), dtype=float)
+        Kb[:, self.atmosphere_b_inds] = dmeas_datmosphereb
+        Kb[:, self.instrument_b_inds] = dmeas_dinstrumentb
+        return Kb
+
+    def drdn_datmosphere(
+        self,
+        x_atmosphere,
+        geom,
+        rho_dir_dir,
+        rho_dif_dir,
+        rho_dir_dif,
+        rho_dif_dif,
+        Ls,
+        rdn,
     ):
-        """Derivative of estimated radiance w.r.t. RT statevector elements.
-        We use a numerical approach to approximate dRT with a constant surface
+        """Derivative of estimated radiance w.r.t. atmosphere statevector elements.
+        We use a numerical approach to approximate datmosphere with a constant surface
         reflectance. This is a reasonable approx. for the multicomponent surface.
 
         When using the glint model however, this does not take into account
         the dependence of the surface reflectance on the atmosphere.
         """
-        # perturb each element of the RT state vector (finite difference)
-        K_RT = []
-        x_RTs_perturb = x_RT + np.eye(len(x_RT)) * eps
-        for x_RT_perturb in list(x_RTs_perturb):
+        # perturb each element of the atmosphere state vector (finite difference)
+        K_atmosphere = []
+        x_atmospheres_perturb = x_atmosphere + np.eye(len(x_atmosphere)) * eps
+        for x_atmosphere_perturb in list(x_atmospheres_perturb):
             (
                 r,
                 L_tot,
@@ -802,11 +763,11 @@ class ForwardModel:
                 L_dif_dir,
                 L_dir_dif,
                 L_dif_dif,
-            ) = self.calc_RT_quantities(x_RT_perturb, geom, rho_dif_dif)
+            ) = self.calc_atmosphere_quantities(x_atmosphere_perturb, geom, rho_dif_dif)
 
             # Surface state is held constant?
             rdne = self.calc_rdn(
-                x_RT_perturb,
+                x_atmosphere_perturb,
                 rho_dir_dir,
                 rho_dif_dir,
                 rho_dir_dif,
@@ -820,14 +781,22 @@ class ForwardModel:
                 r,
                 geom,
             )
-            K_RT.append((rdne - rdn) / eps)
+            K_atmosphere.append((rdne - rdn) / eps)
 
-        K_RT = np.array(K_RT).T
+        K_atmosphere = np.array(K_atmosphere).T
 
-        return K_RT
+        return K_atmosphere
 
-    def drdn_dRTb(
-        self, x_RT, geom, rho_dir_dir, rho_dif_dir, rho_dir_dif, rho_dif_dif, Ls, rdn
+    def drdn_datmosphereb(
+        self,
+        x_atmosphere,
+        geom,
+        rho_dir_dir,
+        rho_dif_dir,
+        rho_dir_dif,
+        rho_dif_dif,
+        Ls,
+        rdn,
     ):
         """Derivative of estimated rdn w.r.t. H2O_ABSCO
 
@@ -837,25 +806,28 @@ class ForwardModel:
         (which is very unlikely though).
         """
         if len(self.bvec) == 0:
-            Kb_RT = np.zeros((0, len(self.wl.shape)))
+            Kb_atmosphere = np.zeros((0, len(self.atmosphere.wl.shape)))
 
         # ToDo: might require modification in case more unknowns are added
         # The following statement captures the case that H2O is not part
-        # of the statevector.
-        # but might need to be modified as soon as we add more unknowns
-        elif len(self.bvec) > 0 and "H2OSTR" not in self.statevec_names:
-            Kb_RT = np.zeros((1, len(self.wl)))
+        # of the statevector, but might need to be modified as soon as we
+        # add more unknowns
+        elif len(self.bvec) > 0 and "H2OSTR" not in self.atmosphere.statevec_names:
+            Kb_atmosphere = np.zeros((1, len(self.atmosphere.wl)))
         else:
             # unknown parameters modeled as random variables per
             # Rodgers et al (2000) K_b matrix.  We calculate these derivatives
             # by finite differences
-            Kb_RT = []
+            Kb_atmosphere = []
             perturb = 1.0 + eps
             for unknown in self.bvec:
-                if unknown == "H2O_ABSCO" and "H2OSTR" in self.statevec_names:
-                    i = self.statevec_names.index("H2OSTR")
-                    x_RT_perturb = x_RT.copy()
-                    x_RT_perturb[i] = x_RT[i] * perturb
+                if (
+                    unknown == "H2O_ABSCO"
+                    and "H2OSTR" in self.atmosphere.statevec_names
+                ):
+                    i = self.atmosphere.statevec_names.index("H2OSTR")
+                    x_atmosphere_perturb = x_atmosphere.copy()
+                    x_atmosphere_perturb[i] = x_atmosphere[i] * perturb
                     (
                         r,
                         L_tot,
@@ -863,10 +835,12 @@ class ForwardModel:
                         L_dif_dir,
                         L_dir_dif,
                         L_dif_dif,
-                    ) = self.calc_RT_quantities(x_RT_perturb, geom, rho_dif_dif)
+                    ) = self.calc_atmosphere_quantities(
+                        x_atmosphere_perturb, geom, rho_dif_dif
+                    )
 
                     rdne = self.calc_rdn(
-                        x_RT_perturb,
+                        x_atmosphere_perturb,
                         rho_dir_dir,
                         rho_dif_dir,
                         rho_dir_dif,
@@ -880,7 +854,62 @@ class ForwardModel:
                         r,
                         geom,
                     )
-                    Kb_RT.append((rdne - rdn) / eps)
+                    Kb_atmosphere.append((rdne - rdn) / eps)
 
-        Kb_RT = np.array(Kb_RT).T
-        return Kb_RT
+        Kb_atmosphere = np.array(Kb_atmosphere).T
+
+        return Kb_atmosphere
+
+    def summarize(self, x, geom):
+        """State vector summary."""
+
+        x_surface, x_atmosphere, x_instrument = self.unpack(x)
+        return (
+            self.surface.summarize(x_surface, geom)
+            + " "
+            + self.atmosphere.summarize(x_atmosphere, geom)
+            + " "
+            + self.instrument.summarize(x_instrument, geom)
+        )
+
+    def calibration(self, x):
+        """Calculate measured wavelengths and fwhm."""
+
+        x_inst = x[self.idx_instrument]
+        return self.instrument.calibration(x_inst)
+
+    def upsample(self, wl, q):
+        """Linear interpolation to atmosphere wavelengths."""
+        # Only interpolate if these aren't close
+        close = len(wl) == len(self.atmosphere.wl) and np.allclose(
+            wl, self.atmosphere.wl
+        )
+
+        # or if any dimension is the wrong size
+        interp = (np.array(q.shape) != len(self.atmosphere.wl)).all()
+
+        if not close or interp:
+            if q.ndim > 1:
+                return np.array(
+                    [
+                        interp1d(wl, qi, fill_value="extrapolate")(self.atmosphere.wl)
+                        for qi in q
+                    ]
+                )
+            else:
+                p = interp1d(wl, q, fill_value="extrapolate")
+                return p(self.atmosphere.wl)
+        return q
+
+    def unpack(self, x):
+        """Unpack the state vector in appropriate index ordering."""
+
+        x_surface = x[self.idx_surface]
+        x_atmosphere = x[self.idx_atmosphere]
+        x_instrument = x[self.idx_instrument]
+        return x_surface, x_atmosphere, x_instrument
+
+    def match_statevector(self, full_statevector):
+        self.full_idx, self.full_miss = match_statevector(
+            full_statevector, self.statevec
+        )

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -47,7 +47,7 @@ class ForwardModel:
 
     State vector elements always go in the following order:
       (1) Surface parameters
-      (2) Radiative Transfer (RT) parameters
+      (2) Atmospheric Radiative Transfer parameters
       (3) Instrument parameters
 
     The parameter bounds, scales, initial values, and names are all
@@ -70,7 +70,7 @@ class ForwardModel:
         self.instrument = Instrument(self.full_config)
         self.n_meas = self.instrument.n_chan
 
-        # Build the radiative transfer model
+        # Build the atmospheric radiative transfer model
         if cache_atmosphere:
             self.atmosphere = cache_atmosphere
         else:
@@ -129,7 +129,7 @@ class ForwardModel:
         # non-reflectance surface parameters
         self.idx_surf_nonrfl = self.idx_surface[len(self.surface.idx_lamb) :]
 
-        # radiative transfer portion
+        # atmospheric radiative transfer portion
         self.idx_atmosphere = np.arange(
             len(self.atmosphere.statevec_names), dtype=int
         ) + len(self.idx_surface)

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -325,10 +325,10 @@ class Inversion:
 
             # Update regions outside retrieval windows to match priors
             if self.config.priors_in_initial_guess:
-                prior_subset_idx = np.arange(len(x0))[self.fm.idx_surf_rfl][
-                    self.outside_ret_windows
-                ]
-                x0[prior_subset_idx] = self.fm.surface.xa(x0, geom)[prior_subset_idx]
+                prior_subset_idx = self.fm.idx_surf_rfl[self.outside_ret_windows]
+                x0[prior_subset_idx] = self.fm.surface.xa(
+                    x0[self.fm.idx_surface], geom
+                )[self.outside_ret_windows]
 
             trajectory.append(x0)
 
@@ -357,7 +357,7 @@ class Inversion:
 
             # Record initializaation state
             geom.x_surf_init = x[self.fm.idx_surface]
-            geom.x_RT_init = x[self.fm.idx_RT]
+            geom.x_atmosphere_init = x[self.fm.idx_atmosphere]
 
             # Seps is the covariance of "observation noise" including both
             # measurement noise from the instrument as well as variability due to

--- a/isofit/inversion/inverse_mcmc.py
+++ b/isofit/inversion/inverse_mcmc.py
@@ -71,7 +71,7 @@ class MCMCInversion(Inversion):
         Seps = self.fm.Seps(x, rdn_meas, geom)
         Seps_win = np.array([Seps[i, self.winidx] for i in self.winidx])
 
-        # Get RT quantities
+        # Get atmsopheric quantities
         rdn_est = self.fm.calc_meas(x=x, geom=geom)
         pm = self.stable_mvnpdf(rdn_est[self.winidx], Seps_win, rdn_meas[self.winidx])
         return pa + pm

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -299,10 +299,6 @@ def invert_analytical(
     # Sample just the wavelengths and states of interest
     L = H[winidx, :][:, iv_idx]
 
-    # Use cached scaling factor from inital normalized inverse (outside of loop).
-    Sa, Sa_inv, Sa_inv_sqrt = fm.Sa(x, geom)
-    Sa_inv = Sa_inv[fm.idx_surface, :][:, fm.idx_surface]
-
     trajectory = np.zeros((num_iter + 1, len(x)))
     trajectory[0, :] = x
     for n in range(num_iter):
@@ -310,7 +306,10 @@ def invert_analytical(
         # Measurement uncertainty
         Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
 
-        # Prior mean
+        # Prior mean and covariance
+        Sa, Sa_inv, Sa_inv_sqrt = fm.Sa(x, geom)
+        Sa_inv = Sa_inv[fm.idx_surface, :][:, fm.idx_surface]
+
         xa_full = fm.xa(x, geom)
         xa_surface = xa_full[fm.idx_surface]
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -97,17 +97,15 @@ def heuristic_atmosphere(
         # atmospheric parameters (such as aerosol, if it is there).
         for h2o in fm.atmosphere.engine.lut_grid[h2oname]:
             # Get Atmospheric terms at high spectral resolution
-            x_atmosphere_2 = x_atmosphere.copy()
-            x_atmosphere_2[ind_sv] = h2o
+            x_atmosphere_guess = x_atmosphere.copy()
+            x_atmosphere_guess[ind_sv] = h2o
 
             # pass in all zeros, as this is ONLY used for Ls, which we will
             # assume is not present
             r, coeffs = invert_algebraic(
-                fm.surface,
-                fm.atmosphere,
-                fm.instrument,
+                fm,
                 x_surface,
-                x_atmosphere_2,
+                x_atmosphere_guess,
                 x_instrument,
                 meas,
                 geom,

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -28,13 +28,14 @@ from scipy.optimize import minimize_scalar as min1d
 
 from isofit.core import units
 from isofit.core.common import emissive_radiance, eps
+from isofit.core.forward import ForwardModel
 from isofit.data import env
 
 
 def heuristic_atmosphere(
     fm: ForwardModel,
     x_surface: np.array,
-    x_RT: np.array,
+    x_atmosphere: np.array,
     x_instrument: np.array,
     meas: np.array,
     geom: Geometry,
@@ -48,7 +49,7 @@ def heuristic_atmosphere(
     Args:
         fm: isofit forward model
         x_surface: surface portion of the state vector
-        x_RT: radiative transfer portion of the state vector
+        x_atmosphere: atmosphere portion of the state vector
         x_instrument: instrument portion of the state vector
         meas: a one-D numpy vector of radiance in uW/nm/sr/cm2
         geom: geometry object corresponding to given measurement
@@ -57,7 +58,7 @@ def heuristic_atmosphere(
         wl_hi: High wavelength to use for the continuum removal H2O fit
 
     Returns:
-        x_new: updated estimate of x_RT
+        x_new: updated estimate of x_atmosphere
     """
 
     # Identify the latest instrument wavelength calibration (possibly
@@ -68,42 +69,45 @@ def heuristic_atmosphere(
     bhi = np.argmin(abs(wl - wl_hi))
 
     offset = 5  # nm
-    if not (any(fm.RT.wl > (wl_lo - offset)) and any(fm.RT.wl < (wl_hi + offset))):
-        return x_RT
+    if not (
+        any(fm.atmosphere.wl > (wl_lo - offset))
+        and any(fm.atmosphere.wl < (wl_hi + offset))
+    ):
+        return x_atmosphere
 
-    x_new = x_RT.copy()
+    x_new = x_atmosphere.copy()
 
     # Band ratio retrieval of H2O.  Depending on the radiative transfer
     # model we are using, this state parameter could go by several names.
     for h2oname in ["H2OSTR", "h2o"]:
-        if h2oname not in fm.RT.statevec_names:
+        if h2oname not in fm.atmosphere.statevec_names:
             continue
 
         # ignore unused names
-        if h2oname not in fm.RT.engine.lut_names:
+        if h2oname not in fm.atmosphere.engine.lut_names:
             continue
 
         # find the index in the lookup table associated with water vapor
-        ind_sv = fm.RT.statevec_names.index(h2oname)
+        ind_sv = fm.atmosphere.statevec_names.index(h2oname)
         h2os, areas = [], []
 
         # We iterate through every possible grid point in the lookup table,
         # calculating the band ratio that we would see if this were the
         # atmospheric H2O content.  It assumes that defaults for all other
         # atmospheric parameters (such as aerosol, if it is there).
-        for h2o in fm.RT.engine.lut_grid[h2oname]:
+        for h2o in fm.atmosphere.engine.lut_grid[h2oname]:
             # Get Atmospheric terms at high spectral resolution
-            x_RT_2 = x_RT.copy()
-            x_RT_2[ind_sv] = h2o
+            x_atmosphere_2 = x_atmosphere.copy()
+            x_atmosphere_2[ind_sv] = h2o
 
             # pass in all zeros, as this is ONLY used for Ls, which we will
             # assume is not present
             r, coeffs = invert_algebraic(
                 fm.surface,
-                fm.RT,
+                fm.atmosphere,
                 fm.instrument,
                 x_surface,
-                x_RT_2,
+                x_atmosphere_2,
                 x_instrument,
                 meas,
                 geom,
@@ -130,11 +134,9 @@ def heuristic_atmosphere(
 
 
 def invert_algebraic(
-    surface: Surface,
-    RT: RadiativeTransfer,
-    instrument: Instrument,
+    fm: ForwardModel,
     x_surface: np.array,
-    x_RT: np.array,
+    x_atmosphere: np.array,
     x_instrument: np.array,
     meas: np.array,
     geom: Geometry,
@@ -145,22 +147,18 @@ def invert_algebraic(
     will be treated as if flat.
 
     Args:
-        surface: surface model
-        RT: radiative transfer model to use
-        instrument: instrument model
+        fm: forward model
         x_surface: surface portion of the state vector
-        x_RT: radiative transfer portion of the state vector
+        x_atmosphere: atmosphere portion of the state vector
         x_instrument: instrument portion of the state vector
         meas: a one-D numpy vector of radiance in uW/nm/sr/cm2
         geom: geometry object corresponding to given measurement
-
 
     Return:
         rfl_est: estimate of the surface reflectance based on the given surface model and specified atmospheric state
         coeffs: atmospheric parameters used for the inversion, returned for convenience
     """
-
-    _, rho_init = surface.calc_rfl(x_surface, geom)
+    _, rho_init = fm.surface.calc_rfl(x_surface, geom)
 
     rho_dif_dif = geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_init
 
@@ -172,33 +170,33 @@ def invert_algebraic(
         L_dif_dir,
         L_dir_dif,
         L_dif_dif,
-    ) = RT.calc_RT_quantities(x_RT, geom, rho_dif_dif=rho_dif_dif)
-    L_atm = RT.get_L_atm(x_RT, geom)
+    ) = fm.calc_atmosphere_quantities(x_atmosphere, geom, rho_dif_dif=rho_dif_dif)
+    L_atm = fm.atmosphere.get_L_atm(x_atmosphere, geom)
     sphalb = rhi["sphalb"]
-    Ls = surface.calc_Ls(x_surface, geom)
-    transup = RT.get_upward_transm(r=rhi, geom=geom)
+    Ls = fm.surface.calc_Ls(x_surface, geom)
+    transup = fm.atmosphere.get_upward_transm(r=rhi, geom=geom)
 
     # Get the wavelengths too - these may also be adjusted
-    wl, fwhm = instrument.calibration(x_instrument)
+    wl, fwhm = fm.instrument.calibration(x_instrument)
 
     # Interpolate L_up linearly if needed.
-    Ls = interp1d(surface.wl, Ls, fill_value="extrapolate")(RT.wl)
+    Ls = interp1d(fm.surface.wl, Ls, fill_value="extrapolate")(fm.atmosphere.wl)
 
     # Now convert to what's scene at the instrument
     L_up = Ls * transup
 
     # Resample the components we need to use
-    L_atm = instrument.sample(x_instrument, RT.wl, L_atm)
-    L_tot = instrument.sample(x_instrument, RT.wl, L_tot)
-    sphalb = instrument.sample(x_instrument, RT.wl, sphalb)
-    L_up = instrument.sample(x_instrument, RT.wl, L_up)
+    L_atm = fm.instrument.sample(x_instrument, fm.atmosphere.wl, L_atm)
+    L_tot = fm.instrument.sample(x_instrument, fm.atmosphere.wl, L_tot)
+    sphalb = fm.instrument.sample(x_instrument, fm.atmosphere.wl, sphalb)
+    L_up = fm.instrument.sample(x_instrument, fm.atmosphere.wl, L_up)
 
     # Now everything should be in hand to do the calculation
     rdn_solrfl = meas - L_up
     rfl = 1.0 / (L_tot / (rdn_solrfl - L_atm) + sphalb)
 
     # explicity handle known nan cases - this doesn't handle nans
-    # that might appear from the RT directly, as we don't want to
+    # that might appear from the atmosphere directly, as we don't want to
     # cover them up
     rfl[rdn_solrfl - L_atm == 0] = 0.0
     rfl[L_tot == 0] = 0.0
@@ -208,7 +206,7 @@ def invert_algebraic(
     rfl[rfl > 1.6] = 1.6
 
     # interpolate the output
-    rfl_est = interp1d(wl, rfl, fill_value="extrapolate")(surface.wl)
+    rfl_est = interp1d(wl, rfl, fill_value="extrapolate")(fm.surface.wl)
 
     # Some downstream code will benefit from our precalculated
     # atmospheric optical parameters
@@ -224,11 +222,8 @@ def invert_analytical(
     x0: np.array,
     sub_state,
     num_iter: int = 1,
-    hash_table: OrderedDict = None,
-    hash_size: int = None,
     diag_uncert: bool = True,
     outside_ret_const: float = -0.01,
-    fill_value: float = -9999.0,
 ):
     """Perform an analytical estimate of the conditional MAP estimate for
     a fixed atmosphere.  Based on the "Inner loop" from Susiluoto et al. (2025).
@@ -241,10 +236,9 @@ def invert_analytical(
         geom: geometry object corresponding to given measurement
         x0: the initialization state including surface from the superpixel
             and the atm from the smoothed atmosphere.
-        num_iter: number of interations to run through
-        hash_table: a hash table to use locally
-        hash_size: max size of given hash table
+        num_iter: number of interactions to run through
         diag_uncert: flag indicating whether to diagonalize the uncertainty
+        outside_ret_const:
 
     Returns:
         x: MAP estimate of the mean
@@ -254,41 +248,36 @@ def invert_analytical(
     from scipy.linalg.lapack import dpotrf, dpotri
 
     x = x0.copy()
-    x_surface, x_RT, x_instrument = fm.unpack(x)
+    x_surface, x_atmosphere, x_instrument = fm.unpack(x)
 
     # Get all the surface quantities for the super pixel
-    sub_surface, sub_RT, sub_instrument = fm.unpack(sub_state)
+    sub_surface, sub_atmosphere, sub_instrument = fm.unpack(sub_state)
 
     # Surface reflectance at the wl resolution of fm.RT
     rho_dir_dir, rho_dif_dir = fm.calc_rfl(sub_surface, geom)
     rho_dir_dir = fm.upsample(fm.surface.wl, rho_dir_dir)
     rho_dif_dir = fm.upsample(fm.surface.wl, rho_dif_dir)
 
-    rho_dir_dif = (
-        fm.upsample(fm.surface.wl, geom.bg_rfl)
-        if isinstance(geom.bg_rfl, np.ndarray)
-        else rho_dir_dir
-    )
     rho_dif_dif = (
         fm.upsample(fm.surface.wl, geom.bg_rfl)
         if isinstance(geom.bg_rfl, np.ndarray)
         else rho_dif_dir
     )
 
-    # Get all the RT quantities
-    (r, L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif) = fm.RT.calc_RT_quantities(
-        x_RT, geom, rho_dif_dif=rho_dif_dif
+    # Get all the atmosphere quantities
+    (r, L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif) = (
+        fm.calc_atmosphere_quantities(x_atmosphere, geom, rho_dif_dif=rho_dif_dif)
     )
 
     # Path radiance and spherical albedo
-    L_atm = fm.RT.get_L_atm(x_RT, geom)
+    L_atm = fm.atmosphere.get_L_atm(x_atmosphere, geom)
     s = r["sphalb"]
 
     # Background conditions equal to the superpixel reflectance
     bg = s * rho_dif_dir
 
     # Get superpixel EOF shift if used
-    eof_offset = fm.eof_offset(sub_surface, sub_RT, sub_instrument)
+    eof_offset = fm.eof_offset(sub_instrument)
 
     # Get the inversion indices; Include glint indices if applicable
     full_idx = np.concatenate((winidx, fm.idx_surf_nonrfl), axis=0)
@@ -313,7 +302,6 @@ def invert_analytical(
     # Use cached scaling factor from inital normalized inverse (outside of loop).
     Sa, Sa_inv, Sa_inv_sqrt = fm.Sa(x, geom)
     Sa_inv = Sa_inv[fm.idx_surface, :][:, fm.idx_surface]
-    Sa_inv_sqrt = Sa_inv_sqrt[fm.idx_surface, :][:, fm.idx_surface]
 
     trajectory = np.zeros((num_iter + 1, len(x)))
     trajectory[0, :] = x
@@ -329,7 +317,7 @@ def invert_analytical(
         # Save the product of the prior covariance and mean
         prprod = Sa_inv @ xa_surface
 
-        x_surface, x_RT, x_instrument = fm.unpack(x)
+        x_surface, x_atmosphere, x_instrument = fm.unpack(x)
 
         C = dpotrf(Seps, 1)[0]
         P = dpotri(C, 1)[0]
@@ -370,12 +358,12 @@ def invert_analytical(
         return trajectory, C_rcond
 
 
-def invert_simple(forward: ForwardModel, meas: np.array, geom: Geometry):
+def invert_simple(fm: ForwardModel, meas: np.array, geom: Geometry):
     """Find an initial guess at the state vector. This currently uses
     traditional (non-iterative, heuristic) atmospheric correction.
 
     Args:
-        forward: isofit forward model
+        fm: isofit forward model
         meas: a one-D numpy vector of radiance in uW/nm/sr/cm2
         geom: geometry object corresponding to given measurement
 
@@ -383,62 +371,62 @@ def invert_simple(forward: ForwardModel, meas: np.array, geom: Geometry):
         x: estimate of the full statevector based on initial conditions, geometry, and a heuristic guess
     """
 
-    surface = forward.surface
-    RT = forward.RT
-    instrument = forward.instrument
+    surface = fm.surface
+    atmosphere = fm.atmosphere
+    instrument = fm.instrument
 
     vswir_present = False
-    if any(forward.surface.wl < 2600):
+    if any(fm.surface.wl < 2600):
         vswir_present = True
 
     tir_present = False
-    if any(forward.surface.wl > 2600):
+    if any(fm.surface.wl > 2600):
         tir_present = True
 
     # First step is to get the atmosphere. We start from the initial state
     # and estimate atmospheric terms using traditional heuristics.
-    x = forward.init.copy()
-    x_surface, x_RT, x_instrument = forward.unpack(x)
+    x = fm.init.copy()
+    x_surface, x_atmosphere, x_instrument = fm.unpack(x)
 
     if vswir_present:
-        x[forward.idx_RT] = heuristic_atmosphere(
-            forward, x_surface, x_RT, x_instrument, meas, geom
+        x[fm.idx_atmosphere] = heuristic_atmosphere(
+            fm, x_surface, x_atmosphere, x_instrument, meas, geom
         )
 
     # Now, with atmosphere fixed, we can invert the radiance algebraically
     # via Lambertian approximations to get reflectance
-    x_surface, x_RT, x_instrument = forward.unpack(x)
+    x_surface, x_atmosphere, x_instrument = fm.unpack(x)
     rfl_est, coeffs = invert_algebraic(
-        surface, RT, instrument, x_surface, x_RT, x_instrument, meas, geom
+        fm, x_surface, x_atmosphere, x_instrument, meas, geom
     )
 
     # Condition thermal part on the VSWIR portion. Only works for
     # Multicomponent surfaces. Finds the cluster nearest the VSWIR heuristic
     # inversion and uses it for the TIR suface initialization.
     if tir_present:
-        tir_idx = np.where(forward.surface.wl > 3000)[0]
+        tir_idx = np.where(fm.surface.wl > 3000)[0]
 
         if vswir_present:
             x_surface_temp = x_surface.copy()
             x_surface_temp[: len(rfl_est)] = rfl_est
-            mu = forward.surface.xa(x_surface_temp, geom)
+            mu = fm.surface.xa(x_surface_temp, geom)
             rfl_est[tir_idx] = mu[tir_idx]
         else:
-            rfl_est = 0.03 * np.ones(len(forward.surface.wl))
+            rfl_est = 0.03 * np.ones(len(fm.surface.wl))
 
     # Now we have an estimated reflectance. Fit the surface parameters.
-    x_surface[forward.idx_surface] = forward.surface.fit_params(rfl_est, geom)
+    x_surface[fm.idx_surface] = fm.surface.fit_params(rfl_est, geom)
 
     # Find temperature of emissive surfaces
     if tir_present:
         # Estimate the total radiance at sensor, leaving out surface emission
         # Radiate transfer calculations could take place at high spectral resolution
         # so we upsample the surface reflectance
-        rfl_hi = forward.upsample(forward.surface.wl, rfl_est)
+        rfl_hi = fm.upsample(fm.surface.wl, rfl_est)
         _, sphalb, _, transup, _ = coeffs
 
-        L_atm = RT.get_L_atm(x_RT, geom)
-        L_tot = RT.calc_RT_quantities(x_RT, geom)[1]
+        L_atm = fm.atmosphere.get_L_atm(x_atmosphere, geom)
+        L_tot = fm.calc_atmosphere_quantities(x_atmosphere, geom)[1]
         L_total_without_surface_emission = L_atm + L_tot * rfl_hi / (
             1.0 - sphalb * rfl_hi
         )
@@ -451,15 +439,15 @@ def invert_simple(forward: ForwardModel, meas: np.array, geom: Geometry):
         # This is fragile if other instruments have different wavelength
         # spacing or range
         clearest_indices = [
-            np.argmin(np.absolute(RT.wl - w)) for w in clearest_wavelengths
+            np.argmin(np.absolute(fm.atmosphere.wl - w)) for w in clearest_wavelengths
         ]
 
         # Error function for nonlinear temperature fit
         def err(z):
             T = z
-            emissivity = forward.surface.emissivity_for_surface_T_init
+            emissivity = fm.surface.emissivity_for_surface_T_init
             Ls_est, d = emissive_radiance(
-                emissivity, T, forward.surface.wl[clearest_indices]
+                emissivity, T, fm.surface.wl[clearest_indices]
             )
             resid = (
                 transup[clearest_indices] * Ls_est
@@ -469,22 +457,27 @@ def invert_simple(forward: ForwardModel, meas: np.array, geom: Geometry):
             return sum(resid**2)
 
         # Fit temperature, set bounds,  and set the initial values
-        idx_T = forward.surface.surf_temp_ind
-        Tinit = np.array([forward.surface.init[idx_T]])
+        idx_T = fm.surface.surf_temp_ind
+        Tinit = np.array([fm.surface.init[idx_T]])
         Tbest = minimize(err, Tinit).x
         T = max(
-            forward.surface.bounds[idx_T][0] + eps,
-            min(Tbest, forward.surface.bounds[idx_T][1] - eps),
+            fm.surface.bounds[idx_T][0] + eps,
+            min(Tbest, fm.surface.bounds[idx_T][1] - eps),
         )
         x_surface[idx_T] = Tbest
-        forward.surface.init[idx_T] = T
+        fm.surface.init[idx_T] = T
 
     # Update the full state vector
-    x[forward.idx_surface] = x_surface
+    x[fm.idx_surface] = x_surface
 
     # If available, get initial guess of surface elevation from location file.
-    if geom.surface_elevation_km and "surface_elevation_km" in RT.statevec_names:
-        ind_sv = forward.idx_RT[RT.statevec_names.index("surface_elevation_km")]
+    if (
+        geom.surface_elevation_km
+        and "surface_elevation_km" in fm.atmosphere.statevec_names
+    ):
+        ind_sv = fm.idx_atmosphere[
+            fm.atmosphere.statevec_names.index("surface_elevation_km")
+        ]
         if geom.surface_elevation_km < 0.0:
             x[ind_sv] = 0.0
         else:
@@ -492,8 +485,8 @@ def invert_simple(forward: ForwardModel, meas: np.array, geom: Geometry):
 
     # We record these initial values in the geometry object - the only
     # "stateful" part of the retrieval
-    geom.x_surf_init = x[forward.idx_surface]
-    geom.x_RT_init = x[forward.idx_RT]
+    geom.x_surf_init = x[fm.idx_surface]
+    geom.x_atmosphere_init = x[fm.idx_atmosphere]
 
     return x
 

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -252,8 +252,7 @@ def invert_analytical(
     sub_surface, sub_atmosphere, sub_instrument = fm.unpack(sub_state)
 
     # Surface reflectance at the wl resolution of fm.RT
-    rho_dir_dir, rho_dif_dir = fm.calc_rfl(sub_surface, geom)
-    rho_dir_dir = fm.upsample(fm.surface.wl, rho_dir_dir)
+    rho_dir_dir, rho_dif_dir = fm.calc_rfl(sub_state, geom)
     rho_dif_dir = fm.upsample(fm.surface.wl, rho_dif_dir)
 
     rho_dif_dif = (


### PR DESCRIPTION
Initial draft of the `forward.py` refactoring. Same as #947, this is work in progress and more updates are to come.

Additional thoughts that came up during editing the code:

- We should think about moving `drdn_dsurface` and `analytical_model` to `forward.py` as well. Currently, those live in the surface object, but take both surface and atmosphere RT quantities as input. Might be challenging though due to the class inherence between our different surface modules.
- `invert_algebraic()` now requires the `ForwardModel` object as input to have access to functions like `calc_atmosphere_quantities()`. This should be fine, but we need to carefully check if this causes issues down the line.