### PR TITLE
Update atmosphere config section

### DIFF
--- a/isofit/configs/configs.py
+++ b/isofit/configs/configs.py
@@ -75,7 +75,7 @@ class Config(BaseConfigSection):
         self._forward_model_type = ForwardModelConfig
         self.forward_model = ForwardModelConfig({})
         """ForwardModelConfig: forward_model config. Holds information about surface models,
-        radiative transfer models, and the instrument.
+        atmosphere radiative transfer models, and the instrument.
         """
 
         self._implementation_type = ImplementationConfig

--- a/isofit/configs/sections/atmosphere_config.py
+++ b/isofit/configs/sections/atmosphere_config.py
@@ -20,7 +20,7 @@
 import logging
 import os
 from collections import OrderedDict
-from typing import Dict, List, Type
+from typing import List
 
 import numpy as np
 
@@ -32,9 +32,9 @@ from isofit.configs.sections.statevector_config import (
 from isofit.data import env
 
 
-class RTStateVectorConfig(StateVectorConfig):
+class AtmosphereStateVectorConfig(StateVectorConfig):
     """
-    RT State vector configuration.
+    Atmosphere state vector configuration.
     """
 
     def __init__(self, sub_configdic: dict = None):
@@ -66,9 +66,9 @@ class RTStateVectorConfig(StateVectorConfig):
         self._set_statevector_config_options(sub_configdic)
 
 
-class RadiativeTransferEngineConfig(BaseConfigSection):
+class AtmosphereEngineConfig(BaseConfigSection):
     """
-    Radiative transfer unknowns configuration.
+    Atmospheric radiative transfer engine unknowns configuration.
     """
 
     def __init__(self, sub_configdic: dict = None, name: str = None):
@@ -79,11 +79,11 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
 
         self._engine_name_type = str
         self.engine_name = None
-        """str: Name of radiative transfer engine to use - options ['modtran', '6s', 'sRTMnet', 'LibRadTran']."""
+        """str: Name of atmospheric radiative transfer engine to use - options ['modtran', '6s', 'sRTMnet', 'LibRadTran']."""
 
         self._engine_base_dir_type = str
         self.engine_base_dir = None
-        """str: base directory of the given radiative transfer engine on user's OS."""
+        """str: base directory of the given atmospheric radiative transfer engine on user's OS."""
 
         self._engine_lut_file_type = str
         self.engine_lut_file = None
@@ -95,7 +95,7 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
 
         self._wavelength_range_type = list()
         self.wavelength_range = None
-        """List: The wavelength range to execute this radiative transfer engine over."""
+        """List: The wavelength range to execute this atmospheric radiative transfer engine over."""
 
         self._environment_type = str
         self.environment = None
@@ -103,15 +103,15 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
 
         self._lut_path_type = str
         self.lut_path = None
-        """str: The path to the look up table directory used by the radiative transfer engine."""
+        """str: The path to the look up table directory used by the atmospheric radiative transfer engine."""
 
         self._sim_path_type = str
         self.sim_path = None
-        """str: Path to the simulation outputs for the radiative transfer engine."""
+        """str: Path to the simulation outputs for the atmospheric radiative transfer engine."""
 
         self._template_file_type = str
         self.template_file = None
-        """str: A template file to be used as the base-configuration for the given radiative transfer engine."""
+        """str: A template file to be used as the base-configuration for the given atmospheric radiative transfer engine."""
 
         self._glint_model_type = bool
         self.glint_model = False
@@ -122,20 +122,20 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
 
         self._rt_mode_type = str
         self.rt_mode = "transm"
-        """str: Radiative transfer mode of LUT simulations.
+        """str: Atmospheric radiative transfer mode of LUT simulations.
         'transm' for transmittances, 'rdn' for reflected radiance."""
 
         self._lut_names_type = dict
         self.lut_names = None
-        """Dictionary: Names of the elements to run this radiative transfer element on.  Must be a subset
-        of the keys in radiative_transfer->lut_grid.  If not specified, uses all keys from
-        radiative_transfer-> lut_grid.  Auto-sorted (alphabetically) below."""
+        """Dictionary: Names of the elements to run this atmospheric radiative transfer element on.  Must be a subset
+        of the keys in atmosphere->lut_grid.  If not specified, uses all keys from
+        atmosphere-> lut_grid.  Auto-sorted (alphabetically) below."""
 
         self._statevector_names_type = list()
         self.statevector_names = None
-        """List: Names of the statevector elements to use with this radiative transfer engine.  Must be a subset
-        of the keys in radiative_transfer->statevector.  If not specified, uses all keys from
-        radiative_transfer->statevector.  Auto-sorted (alphabetically) below."""
+        """List: Names of the statevector elements to use with this atmospheric radiative transfer engine.  Must be a subset
+        of the keys in atmosphere->statevector.  If not specified, uses all keys from
+        atmosphere->statevector.  Auto-sorted (alphabetically) below."""
 
         self._lut_compression_type = str
         self.lut_compression = "zlib"
@@ -260,7 +260,7 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         # MODTRAN, 6S, and libRadtran
         self._rte_configure_and_exit_type = bool
         self.rte_configure_and_exit = False
-        """bool: Indicates that code should terminate as soon as all radiative transfer engine configuration files are
+        """bool: Indicates that code should terminate as soon as all atmospheric radiative transfer engine configuration files are
         written (without running them)"""
 
         # sRTMnet
@@ -282,25 +282,23 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         errors = list()
         warnings = list()
 
-        from isofit.radiative_transfer.engines import Engines
+        from isofit.atmosphere.engines import Engines
 
         if self.engine_name not in Engines:
             errors.append(
-                "radiative_transfer->raditive_transfer_model: {} not in one of the"
+                "atmosphere->engine_name: {} not in one of the"
                 " available models: {}".format(self.engine_name, list(Engines))
             )
 
         valid_rt_modes = ["transm", "rdn"]
         if self.rt_mode not in valid_rt_modes:
             errors.append(
-                "radiative_transfer->raditive_transfer_mode: {} not in one of the"
+                "atmosphere->rt_mode: {} not in one of the"
                 " available modes: {}".format(self.rt_mode, valid_rt_modes)
             )
 
         if not (self.emulator_batch_size > 0):
-            errors.append(
-                "radiative_transfer->emulator_batch_size must be a positive integer."
-            )
+            errors.append("atmosphere->emulator_batch_size must be a positive integer.")
 
         # Only check for missing files when a prebuilt LUT is not provided
         if not os.path.exists(self.lut_path):
@@ -310,7 +308,7 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
                 if value and key[-5:] == "_file" and key != "emulator_file":
                     if os.path.isfile(value) is False:
                         errors.append(
-                            "Config value radiative_transfer->{}: {} not found".format(
+                            "Config value atmosphere->{}: {} not found".format(
                                 key, value
                             )
                         )
@@ -341,7 +339,7 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
                     )
 
                 if self.emulator_file.endswith(".6c"):
-                    from isofit.radiative_transfer.engines.six_s import get_exe
+                    from isofit.atmosphere.engines.six_s import get_exe
 
                     if "co2" not in get_exe(self.engine_base_dir, version=True):
                         errors.append(
@@ -364,7 +362,7 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
             for file in files:
                 if file is not None and not os.path.isfile(file):
                     errors.append(
-                        f"Radiative transfer engine file not found on system: {file}"
+                        f"Atmospheric radiative transfer engine file not found on system: {file}"
                     )
 
         if isinstance(self.lut_complevel, int) and self.lut_complevel < 1:
@@ -373,9 +371,9 @@ class RadiativeTransferEngineConfig(BaseConfigSection):
         return errors, warnings
 
 
-class RadiativeTransferUnknownsConfig(BaseConfigSection):
+class AtmosphereUnknownsConfig(BaseConfigSection):
     """
-    Radiative transfer unknowns configuration.
+    Atmosphere unknowns configuration.
     """
 
     def __init__(self, sub_configdic: dict = None):
@@ -386,20 +384,20 @@ class RadiativeTransferUnknownsConfig(BaseConfigSection):
         self.set_config_options(sub_configdic)
 
 
-class RadiativeTransferConfig(BaseConfigSection):
+class AtmosphereConfig(BaseConfigSection):
     """
-    Forward model configuration.
+    Atmosphere configuration.
     """
 
     def __init__(self, sub_configdic: dict = None):
-        self._statevector_type = RTStateVectorConfig
-        self.statevector: StateVectorConfig = RTStateVectorConfig({})
+        self._statevector_type = AtmosphereStateVectorConfig
+        self.statevector: StateVectorConfig = AtmosphereStateVectorConfig({})
 
         self._lut_grid_type = OrderedDict
         self.lut_grid = None
 
-        self._unknowns_type = RadiativeTransferUnknownsConfig
-        self.unknowns: RadiativeTransferUnknownsConfig = None
+        self._unknowns_type = AtmosphereUnknownsConfig
+        self.unknowns: AtmosphereUnknownsConfig = None
 
         self._interpolator_style_type = str
         self.interpolator_style = "mlg_numba"
@@ -419,21 +417,7 @@ class RadiativeTransferConfig(BaseConfigSection):
         """int: Size of the cache to store interpolation lookups. Defaults to 16 which
         provides the most significant gains. Setting higher may provide marginal gains."""
 
-        self._terrain_style_type = str
-        self.terrain_style = "flat"
-        """
-        Style of terrain to use in the forward model - options are 'flat', 'dem', 'solved'
-        """
-
-        self._max_slope_type = float
-        self.max_slope = 90.0
-        """
-        float: Max slope value used in LUT component calculations to inform minimum cos_i.
-        Only relevant if terrain_style is 'dem' and a 6 component model is used.
-        This can avoid runaway results at low cos_i values where diffuse radiance dominates.
-        """
-
-        self._engine_type = RadiativeTransferEngineConfig
+        self._engine_type = AtmosphereEngineConfig
         self.engine = None
 
         self.set_config_options(sub_configdic)
@@ -454,7 +438,7 @@ class RadiativeTransferConfig(BaseConfigSection):
                     f"Old config detected, taking the first engine available: {key}"
                 )
 
-        self.engine = RadiativeTransferEngineConfig(engine)
+        self.engine = AtmosphereEngineConfig(engine)
 
     def _check_config_validity(self) -> List[str]:
         errors = list()
@@ -494,11 +478,5 @@ class RadiativeTransferConfig(BaseConfigSection):
                     "Invalid degree number. Should be an integer, e.g. nds-3, got"
                     f" {degrees!r} from {self.interpolator_style!r}[4:]"
                 )
-
-        terrain_options = ["flat", "dem", "solved"]
-        if self.terrain_style not in terrain_options:
-            errors.append(
-                f"surface->terrain_style is set as {self.terrain_style}, but must be one of: {terrain_options}"
-            )
 
         return errors, warnings

--- a/isofit/configs/sections/forward_model_config.py
+++ b/isofit/configs/sections/forward_model_config.py
@@ -17,12 +17,10 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 
-from typing import Dict, List, Type
-
 from isofit.configs.base_config import BaseConfigSection
-from isofit.configs.sections.instrument_config import InstrumentConfig
-from isofit.configs.sections.radiative_transfer_config import RadiativeTransferConfig
 from isofit.configs.sections.surface_config import SurfaceConfig
+from isofit.configs.sections.atmosphere_config import AtmosphereConfig
+from isofit.configs.sections.instrument_config import InstrumentConfig
 
 
 class ForwardModelConfig(BaseConfigSection):
@@ -33,22 +31,22 @@ class ForwardModelConfig(BaseConfigSection):
     def __init__(self, sub_configdic: dict = None):
         super().__init__()
 
-        self._instrument_type = InstrumentConfig
-        self.instrument: InstrumentConfig = None
-        """
-        Instrument: instrument config section. 
-        """
-
         self._surface_type = SurfaceConfig
         self.surface: SurfaceConfig = None
         """
         Surface: surface config section. 
         """
 
-        self._radiative_transfer_type = RadiativeTransferConfig
-        self.radiative_transfer: RadiativeTransferConfig = None
+        self._atmosphere_type = AtmosphereConfig
+        self.atmosphere: AtmosphereConfig = None
         """
-        RadiativeTransfer: radiative transfer config section.
+        Atmosphere: atmospheric radiative transfer config section.
+        """
+
+        self._instrument_type = InstrumentConfig
+        self.instrument: InstrumentConfig = None
+        """
+        Instrument: instrument config section. 
         """
 
         self._model_discrepancy_file_type = str

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -17,8 +17,7 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 
-import os
-from typing import Dict, List, Type
+from typing import List
 
 import numpy as np
 from scipy.io import loadmat
@@ -94,10 +93,10 @@ class SurfaceConfig(BaseConfigSection):
         self._wavelength_file_type = str
         self.wavelength_file = None
 
-        """bool: This field, if present and set to true, forces us to use any initialization state and never change.
-        The state is preserved in the geometry object so that this object stays stateless"""
         self._select_on_init_type = bool
         self.select_on_init = True
+        """bool: This field, if present and set to true, forces us to use any initialization state and never change.
+        The state is preserved in the geometry object so that this object stays stateless"""
 
         self._selection_metric_type = str
         self.selection_metric = "Euclidean"
@@ -106,9 +105,23 @@ class SurfaceConfig(BaseConfigSection):
         self.statevector: StateVectorConfig = SurfaceStateVectorConfig({})
 
         # Surface Thermal
-        """ Initial Value recommended by Glynn Hulley."""
         self._emissivity_for_surface_T_init_type = float
         self.emissivity_for_surface_T_init = 0.98
+        """ Initial Value recommended by Glynn Hulley."""
+
+        self._terrain_style_type = str
+        self.terrain_style = "flat"
+        """
+        Style of terrain to use in the forward model - options are 'flat', 'dem', 'solved'
+        """
+
+        self._max_slope_type = float
+        self.max_slope = 90.0
+        """
+        float: Max slope value used in LUT component calculations to inform minimum cos_i.
+        Only relevant if terrain_style is 'dem' and a 6 component model is used.
+        This can avoid runaway results at low cos_i values where diffuse radiance dominates.
+        """
 
         self.set_config_options(sub_configdic)
 
@@ -204,5 +217,11 @@ class SurfaceConfig(BaseConfigSection):
                 message += f"\n{value}: {key}"
 
             warnings.append(message)
+
+        terrain_options = ["flat", "dem", "solved"]
+        if self.terrain_style not in terrain_options:
+            errors.append(
+                f"surface->terrain_style is set as {self.terrain_style}, but must be one of: {terrain_options}"
+            )
 
         return errors, warnings

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -373,7 +373,7 @@ class IO:
         self.n_rows = 1
         self.n_cols = 1
         self.bbl = "{" + ",".join([str(1) for n in range(len(self.meas_wl))]) + "}"
-        self.engine_name = config.forward_model.radiative_transfer.engine.engine_name
+        self.engine_name = config.forward_model.atmosphere.engine.engine_name
 
         # Use the pre-defined full statevec
         if len(full_statevec):
@@ -811,7 +811,7 @@ class IO:
         )
         wl_names = [("Channel %i" % i) for i in range(len(wl_init))]
         bbl = "{" + ",".join([str(1) for n in range(len(wl_init))]) + "}"
-        engine_name = config.forward_model.radiative_transfer.engine.engine_name
+        engine_name = config.forward_model.atmosphere.engine.engine_name
 
         for element, element_header, element_name in zip(
             *config.output.get_output_files()

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -127,12 +127,12 @@ class Geometry:
         # In the more common case that Isofit config is provided...
         else:
             # Update terrain parameters from config
-            rt_config = full_config.forward_model.radiative_transfer
-            self.max_slope = rt_config.max_slope
-            self.terrain_style = rt_config.terrain_style
+            self.max_slope = full_config.forward_model.surface.max_slope
+            self.terrain_style = full_config.forward_model.surface.terrain_style
+            self.lut_grid = full_config.forward_model.atmosphere.lut_grid
 
             # 1. If user has a lut grid that contains solar_zenith this takes priority
-            if rt_config.lut_grid is not None and "solar_zenith" in rt_config.lut_grid:
+            if self.lut_grid is not None and "solar_zenith" in self.lut_grid:
                 self.coszen = np.cos(np.radians(self.solar_zenith))
                 self.use_universal_coszen = False
 
@@ -147,7 +147,7 @@ class Geometry:
                 )
 
             # 3. In this case, the user does not have solar zenith in the lut grid
-            # and cozen is correctly defined (based on the RT Engine)
+            # and cozen is correctly defined (based on the atmospheric RT Engine)
             elif coszen is not None:
                 self.coszen = coszen
 

--- a/isofit/core/instrument.py
+++ b/isofit/core/instrument.py
@@ -195,7 +195,7 @@ class Instrument:
                 self.bval = np.hstack([self.bval, self.unknowns.stray_srf_uncertainty])
 
         # Determine whether the calibration is fixed.  If it is fixed,
-        # and the wavelengths of radiative transfer modeling and instrument
+        # and the wavelengths of atmospheric radiative transfer modeling and instrument
         # are the same, then we can bypass computationally expensive sampling
         # operations later.
         self.calibration_fixed = True
@@ -224,7 +224,7 @@ class Instrument:
         # First we take care of radiometric uncertainties, which add
         # in quadrature.  We sum their squared values.  Systematic
         # radiometric uncertainties account for differences in sampling
-        # and radiative transfer that manifest predictably as a function
+        # and atmospheric radiative transfer that manifest predictably as a function
         # of wavelength.
         if self.unknowns:
             if self.unknowns.channelized_radiometric_uncertainty_file is not None:

--- a/isofit/core/multistate.py
+++ b/isofit/core/multistate.py
@@ -93,11 +93,11 @@ def construct_full_state(full_config):
     instrument_states = instrument.statevec_names
 
     # Pull the rt names from the config. Seems to be most commonly present.
-    rt_config = full_config.forward_model.radiative_transfer
+    atmosphere_config = full_config.forward_model.atmosphere
 
-    rt_states = vars(rt_config.engine)["statevector_names"]
+    rt_states = vars(atmosphere_config.engine)["statevector_names"]
     if not rt_states:
-        rt_states = sorted(rt_config.engine.lut_names.keys())
+        rt_states = sorted(atmosphere_config.engine.lut_names.keys())
 
     # Check for config type
     if full_config.forward_model.surface.multi_surface_flag:
@@ -281,12 +281,12 @@ def update_config_for_surface(config, surface_class_str, clouds=True):
     # Experimental: added statevector elements
     for key, value in isurface.get("rt_statevector_elements", {}).items():
         # Add the statevector params
-        config.forward_model.radiative_transfer.statevector.surface_elevation_km = (
+        config.forward_model.atmosphere.statevector.surface_elevation_km = (
             StateVectorElementConfig(value)
         )
 
         # Add the statevector names
-        config.forward_model.radiative_transfer.engine.statevector_names.append(key)
+        config.forward_model.atmosphere.engine.statevector_names.append(key)
 
     return config
 

--- a/isofit/test/test_examples.py
+++ b/isofit/test/test_examples.py
@@ -61,9 +61,7 @@ def test_pasadena_modtran(args, monkeypatch):
 
 
 @pytest.mark.examples
-@mock.patch(
-    "isofit.radiative_transfer.engines.modtran.ModtranRT.makeSim", new=lambda *_: ...
-)
+@mock.patch("isofit.atmosphere.engines.modtran.ModtranRT.makeSim", new=lambda *_: ...)
 def test_pasadena_topoflux(monkeypatch):
     """Run Pasadena topoflux example dataset."""
 

--- a/isofit/test/test_geometry.py
+++ b/isofit/test/test_geometry.py
@@ -95,10 +95,11 @@ def test_config_terrain_settings(input_obs):
     """Test that max_slope and terrain_style are pulled from full_config"""
 
     full_config = MagicMock()
-    rt = full_config.forward_model.radiative_transfer
-    rt.max_slope = 20.0
-    rt.terrain_style = "dem"
-    rt.lut_grid = None
+    atmosphere = full_config.forward_model.atmosphere
+    surface = full_config.forward_model.surface
+    surface.max_slope = 20.0
+    surface.terrain_style = "dem"
+    atmosphere.lut_grid = None
 
     geom = Geometry(obs=input_obs, full_config=full_config)
 
@@ -109,10 +110,11 @@ def test_config_terrain_settings(input_obs):
 def test_coszen_priority(input_obs):
     """Tests how we expect coszen to be defined based on defined priorities in Geometry"""
     full_config = MagicMock()
-    rt = full_config.forward_model.radiative_transfer
-    rt.lut_grid = {"solar_zenith": [10, 20]}
-    rt.max_slope = 20.0
-    rt.terrain_style = "flat"
+    atmosphere = full_config.forward_model.atmosphere
+    surface = full_config.forward_model.surface
+    atmosphere.lut_grid = {"solar_zenith": [10, 20]}
+    surface.max_slope = 20.0
+    surface.terrain_style = "flat"
 
     # If user has a lut grid that contains solar_zenith this takes priority
     user_coszen = 0.9
@@ -122,7 +124,7 @@ def test_coszen_priority(input_obs):
     assert geom.use_universal_coszen is False
 
     # And test the other case, where no lut grid is given, it should fall back to coszen
-    rt.lut_grid = None
+    atmosphere.lut_grid = None
     geom = Geometry(obs=input_obs, coszen=user_coszen, full_config=full_config)
 
     assert geom.coszen == user_coszen

--- a/isofit/test/test_lut.py
+++ b/isofit/test/test_lut.py
@@ -23,7 +23,7 @@
 import pytest
 
 from isofit.configs import configs
-from isofit.radiative_transfer.engines import ModtranRT
+from isofit.atmosphere.engines import ModtranRT
 
 
 @pytest.mark.xfail
@@ -34,23 +34,11 @@ def test_combined(monkeypatch):
 
     print("Loading config file from the Pasadena example.")
     config_file = "configs/ang20171108t184227_beckmanlawn-multimodtran-topoflux.json"
-    config = configs.create_new_config(config_file)
-    config.get_config_errors()
-    engine_config = config.forward_model.radiative_transfer.radiative_transfer_engines[
-        0
-    ]
+    full_config = configs.create_new_config(config_file)
 
     print("Initialize radiative transfer engine without prebuilt LUT file.")
-    lut_grid = config.forward_model.radiative_transfer.lut_grid
-    rt_engine = ModtranRT(
-        engine_config=engine_config, interpolator_style="mlg", lut_grid=lut_grid
-    )
+    engine = ModtranRT(full_config=full_config)
 
-    # First, we don't provide a prebuilt LUT and run simulations based on a given LUT grid
     print("Run radiative transfer simulations.")
-    rt_engine.runSimulations()
-    del rt_engine
-
-    # Second, we use the just built LUT file and initialize the engine class again
-    print("Initialize radiative transfer engine with prebuilt LUT file.")
-    ModtranRT(engine_config=engine_config, interpolator_style="mlg")
+    engine.runSimulations()
+    del engine

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -197,7 +197,7 @@ def analytical_line(
     ]
     bbl = "{" + ",".join([f"{x}" for x in outside_ret_windows]) + "}"
     num_bands = len(full_idx_surf_rfl)
-    engine_name = config.forward_model.radiative_transfer.engine.engine_name
+    engine_name = config.forward_model.atmosphere.engine.engine_name
     isofit_version = config.implementation.isofit_version
     rfl_output = initialize_output(
         output_metadata,

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -20,7 +20,7 @@ import isofit.utils.template_construction as tmpl
 from isofit.core import isofit, units
 from isofit.core.common import envi_header
 from isofit.debug.resource_tracker import FileResources
-from isofit.radiative_transfer.engines.modtran import ModtranRT
+from isofit.atmosphere.engines.modtran import ModtranRT
 from isofit.utils import analytical_line as ALAlg
 from isofit.utils import empirical_line as ELAlg
 from isofit.utils import (
@@ -113,7 +113,7 @@ def apply_oe(
     terrain_style="dem",
 ):
     """
-    Applies OE over a flightline using a radiative transfer engine. This executes
+    Applies OE over a flightline using an atmospheric radiative transfer engine. This executes
     ISOFIT in a generalized way, accounting for the types of variation that might be
     considered typical.
 
@@ -158,7 +158,7 @@ def apply_oe(
     atmosphere_type : str, default="ATM_MIDLAT_SUMMER"
         Atmospheric profile to be used for MODTRAN and libRadtran simulations only.
         However, if presolve mode enabled this is used to inform max water
-        column vapor for any radiative transfer model. Valid options include:
+        column vapor for any atmospheric radiative transfer model. Valid options include:
         ATM_MIDLAT_SUMMER, ATM_TROPICAL, ATM_MIDLAT_WINTER,
         ATM_SUBARC_SUMMER, ATM_SUBARC_WINTER, or ATM_US_STANDARD_1976.
     channelized_uncertainty_path : str, default=None

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -488,7 +488,7 @@ def empirical_line(
     output_metadata["interleave"] = "bil"
     output_metadata["wavelength_unts"] = "Nanometers"
     isofit_version = iconfig.implementation.isofit_version
-    engine_name = iconfig.forward_model.radiative_transfer.engine.engine_name
+    engine_name = iconfig.forward_model.atmosphere.engine.engine_name
     output_metadata["description"] = (
         f"L2A empirical line per-pixel surface retrieval (segmentation_size={segmentation_size}, engine={engine_name}, isofit_version={isofit_version})"
     )

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -25,7 +25,7 @@ from isofit.core.common import (
 )
 from isofit.core.multistate import SurfaceMapping
 from isofit.data import env
-from isofit.radiative_transfer.engines.modtran import ModtranRT
+from isofit.atmosphere.engines.modtran import ModtranRT
 from isofit.utils.surface_model import surface_model
 
 
@@ -784,50 +784,54 @@ def build_config(
     config = {
         "forward_model": {
             "instrument": make_instrument_config(
-                paths.wavelength_path,
-                paths.input_channelized_uncertainty_path,
-                paths.channelized_uncertainty_working_path,
-                paths.eof_path,
-                paths.eof_working_path,
-                paths.noise_path,
-                segmentation_size,
-                use_superpixels,
-                uncorrelated_radiometric_uncertainty,
-                paths.dn_uncertainty_file,
+                wavelength_path=paths.wavelength_path,
+                input_channelized_uncertainty_path=paths.input_channelized_uncertainty_path,
+                channelized_uncertainty_working_path=paths.channelized_uncertainty_working_path,
+                eof_path=paths.eof_path,
+                eof_working_path=paths.eof_working_path,
+                noise_path=paths.noise_path,
+                segmentation_size=segmentation_size,
+                use_superpixels=use_superpixels,
+                uncorrelated_radiometric_uncertainty=uncorrelated_radiometric_uncertainty,
+                dn_uncertainty_file=paths.dn_uncertainty_file,
             ),
-            "radiative_transfer": make_rt_config(
-                paths.lut_h2o_directory if presolve else paths.full_lut_directory,
-                paths.h2o_template_path if presolve else paths.modtran_template_path,
-                paths.aerosol_tpl_path,
-                paths.earth_sun_distance_path,
-                paths.irradiance_file,
-                paths.sixs_path,
-                paths.modtran_path,
-                h2o_lut_grid,
-                aerosol_lut_grid,
-                aerosol_model_file,
-                aerosol_state_vector,
-                co2_lut_grid,
-                elevation_lut_grid,
-                emulator_base,
-                multipart_transmittance,
-                prebuilt_lut_path,
-                presolve,
-                pressure_elevation,
-                retrieve_co2,
-                relative_azimuth_lut_grid,
-                to_sensor_zenith_lut_grid,
-                to_sun_zenith_lut_grid,
-                terrain_style,
-                max_slope,
+            "atmosphere": make_atmosphere_config(
+                lut_directory=(
+                    paths.lut_h2o_directory if presolve else paths.full_lut_directory
+                ),
+                modtran_template_path=(
+                    paths.h2o_template_path if presolve else paths.modtran_template_path
+                ),
+                aerosol_tpl_path=paths.aerosol_tpl_path,
+                earth_sun_distance_path=paths.earth_sun_distance_path,
+                irradiance_file=paths.irradiance_file,
+                sixs_path=paths.sixs_path,
+                modtran_path=paths.modtran_path,
+                h2o_lut_grid=h2o_lut_grid,
+                aerosol_lut_grid=aerosol_lut_grid,
+                aerosol_model_file=aerosol_model_file,
+                aerosol_state_vector=aerosol_state_vector,
+                co2_lut_grid=co2_lut_grid,
+                elevation_lut_grid=elevation_lut_grid,
+                emulator_base=emulator_base,
+                multipart_transmittance=multipart_transmittance,
+                prebuilt_lut_path=prebuilt_lut_path,
+                presolve=presolve,
+                pressure_elevation=pressure_elevation,
+                retrieve_co2=retrieve_co2,
+                relative_azimuth_lut_grid=relative_azimuth_lut_grid,
+                to_sensor_zenith_lut_grid=to_sensor_zenith_lut_grid,
+                to_sun_zenith_lut_grid=to_sun_zenith_lut_grid,
             ),
             "surface": make_surface_config(
-                paths.surface_class_working_path,
-                paths.surface_class_subs_path,
-                paths.surface_working_paths,
-                surface_category,
-                pressure_elevation,
-                use_superpixels,
+                surface_class_working_path=paths.surface_class_working_path,
+                surface_class_subs_path=paths.surface_class_subs_path,
+                surface_working_paths=paths.surface_working_paths,
+                surface_category=surface_category,
+                pressure_elevation=pressure_elevation,
+                use_superpixels=use_superpixels,
+                terrain_style=terrain_style,
+                max_slope=max_slope,
             ),
         },
         "implementation": make_implementation_config(
@@ -1424,7 +1428,7 @@ def write_wavelength_file(filename, wl, fwhm):
     np.savetxt(filename, wl_data, delimiter=" ")
 
 
-def make_rt_config(
+def make_atmosphere_config(
     lut_directory: str,
     modtran_template_path: str,
     aerosol_tpl_path: str = None,
@@ -1447,8 +1451,6 @@ def make_rt_config(
     relative_azimuth_lut_grid: np.array = None,
     to_sensor_zenith_lut_grid: np.array = None,
     to_sun_zenith_lut_grid: np.array = None,
-    terrain_style: str = "flat",
-    max_slope: float = 20.0,
 ):
     avc = np.sum(
         [
@@ -1476,7 +1478,7 @@ def make_rt_config(
     else:
         engine_name = "sRTMnet"
 
-    radiative_transfer_config = {
+    atmosphere_config = {
         "engine": {
             "engine_name": engine_name,
             "multipart_transmittance": multipart_transmittance,
@@ -1488,28 +1490,26 @@ def make_rt_config(
         "statevector": {},
         "lut_grid": {},
         "unknowns": {"H2O_ABSCO": 0.0},
-        "terrain_style": terrain_style,
-        "max_slope": max_slope,
     }
 
-    rte = {}
+    atmosphere_rte = {}
     if emulator_base is not None:
-        rte["emulator_file"] = abspath(emulator_base)
-        rte["earth_sun_distance_file"] = earth_sun_distance_path
-        rte["irradiance_file"] = irradiance_file
-        rte["engine_base_dir"] = sixs_path
+        atmosphere_rte["emulator_file"] = abspath(emulator_base)
+        atmosphere_rte["earth_sun_distance_file"] = earth_sun_distance_path
+        atmosphere_rte["irradiance_file"] = irradiance_file
+        atmosphere_rte["engine_base_dir"] = sixs_path
         if multipart_transmittance:
-            rte["emulator_aux_file"] = abspath(emulator_base)
+            atmosphere_rte["emulator_aux_file"] = abspath(emulator_base)
         else:
-            rte["emulator_aux_file"] = abspath(
+            atmosphere_rte["emulator_aux_file"] = abspath(
                 os.path.splitext(emulator_base)[0] + "_aux.npz"
             )
     else:
-        rte["engine_base_dir"] = modtran_path
-    radiative_transfer_config["engine"].update(rte)
+        atmosphere_rte["engine_base_dir"] = modtran_path
+    atmosphere_config["engine"].update(atmosphere_rte)
 
     if aerosol_model_file is None:
-        radiative_transfer_config["engine"]["aerosol_model_file"] = aerosol_model_file
+        atmosphere_config["engine"]["aerosol_model_file"] = aerosol_model_file
 
     # First, build the general lut grid
     lut_grid = {
@@ -1531,7 +1531,7 @@ def make_rt_config(
             lut_grid[gn] = np.array(gc).tolist()
 
     if emulator_base is not None and os.path.splitext(emulator_base)[1] == ".jld2":
-        from isofit.radiative_transfer.engines.kernel_flows import bounds_check
+        from isofit.atmosphere.engines.kernel_flows import bounds_check
 
         # Should only modify H2OSTR and surface_elevation_km
         bounds_check(lut_grid, emulator_base, modify=True)
@@ -1551,10 +1551,8 @@ def make_rt_config(
     for tr in np.unique(to_remove):
         lut_grid.pop(tr)
 
-    radiative_transfer_config["lut_grid"].update(lut_grid)
-    radiative_transfer_config["engine"]["lut_names"] = {
-        key: None for key in lut_grid.keys()
-    }
+    atmosphere_config["lut_grid"].update(lut_grid)
+    atmosphere_config["engine"]["lut_names"] = {key: None for key in lut_grid.keys()}
 
     # Now do statevector
     statekeys = ["H2OSTR"]
@@ -1576,7 +1574,7 @@ def make_rt_config(
                 if isinstance(lut_grid[key], list)
                 else list(lut_grid[key].values())
             )
-            radiative_transfer_config["statevector"][key] = {
+            atmosphere_config["statevector"][key] = {
                 "bounds": [grid[0], grid[-1]],
                 "scale": scale,
                 "init": (grid[0] + grid[-1]) / 2.0,
@@ -1585,25 +1583,26 @@ def make_rt_config(
             }
 
     if aerosol_state_vector is not None and presolve is False:
-        radiative_transfer_config["statevector"].update(aerosol_state_vector)
+        atmosphere_config["statevector"].update(aerosol_state_vector)
 
-    # RTE should know about our whole LUT grid and all of our statevectors, so copy them in
-    radiative_transfer_config["engine"]["statevector_names"] = list(
-        radiative_transfer_config["statevector"].keys()
+    # Atmosphere RT engine should know about our whole LUT grid and all of our statevectors, so copy them in
+    atmosphere_config["engine"]["statevector_names"] = list(
+        atmosphere_config["statevector"].keys()
     )
 
-    return radiative_transfer_config
+    return atmosphere_config
 
 
 def make_surface_config(
-    surface_class_working_path=None,
-    surface_class_subs_path=None,
+    surface_class_working_path: str = None,
+    surface_class_subs_path: str = None,
     surface_working_paths: dict = None,
-    surface_category="multicomponent_surface",
-    pressure_elevation=False,
-    use_superpixels=False,
+    surface_category: str = "multicomponent_surface",
+    pressure_elevation: bool = False,
+    use_superpixels: bool = False,
+    terrain_style: str = "flat",
+    max_slope: float = 20.0,
 ):
-
     # Initialize config dict
     surface_config_dict = {
         "multi_surface_flag": False,
@@ -1641,12 +1640,16 @@ def make_surface_config(
                 "surface_int": int(i),
                 "surface_file": surface_path,
                 "surface_category": surface_category,
+                "terrain_style": terrain_style,
+                "max_slope": max_slope,
             }
 
     # Single surface run
     else:
         surface_config_dict["surface_file"] = surface_working_paths[surface_category]
         surface_config_dict["surface_category"] = surface_category
+        surface_config_dict["terrain_style"] = terrain_style
+        surface_config_dict["max_slope"] = max_slope
 
     # Accumulate statevector
     for category, path in surface_working_paths.items():

--- a/isofit/utils/wavelength_cal.py
+++ b/isofit/utils/wavelength_cal.py
@@ -39,7 +39,7 @@ def add_wavelength_elements(config_path, state_type="shift", spline_indices=[]):
     n = np.ones(len(x))
     D = np.c_[n, x, w]
     np.savetxt(hi_res_wavlengths, D, fmt="%8.6f")
-    config["forward_model"]["radiative_transfer"]["engine"][
+    config["forward_model"]["atmosphere"]["engine"][
         "wavelength_file"
     ] = hi_res_wavlengths
 


### PR DESCRIPTION
- Touched up all instances to be atmosphere config instead of rt config (reason why 15 files changed)
- Moved `max_slope` and `terrain_style` to surface config

For now, I retained both classes in the old radiative_transfer_config.py. They are now named 
- `AtmosphereEngineConfig`
- `AtmosphereConfig`

Where the first is the old `RadiativeTransferEngineConfig`, and holds all of the information related to running the sims. At first I was going to try and combine them, but figured this simpler approach would be a good place to start?