### PR TITLE
Add NEON AOP HDF5 → ENVI conversion utility (isofit/utils/neon_h5.py)

### DIFF
--- a/isofit/test/test_neon_h5.py
+++ b/isofit/test/test_neon_h5.py
@@ -1,0 +1,290 @@
+"""
+Tests for isofit.utils.neon_h5
+
+A synthetic NEON HDF5 file is constructed in a temporary directory for each
+test so no real data file is required.  The structure mirrors the actual NEON
+L1 radiance product layout.
+"""
+
+import importlib.util
+import struct
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module directly to avoid pulling in the full isofit package,
+# which requires optional heavy dependencies (torch, etc.).
+# ---------------------------------------------------------------------------
+_spec = importlib.util.spec_from_file_location(
+    "neon_h5",
+    Path(__file__).resolve().parents[1] / "utils" / "neon_h5.py",
+)
+neon_h5 = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(neon_h5)
+
+convert_rad = neon_h5.convert_rad
+convert_loc = neon_h5.convert_loc
+convert_obs = neon_h5.convert_obs
+convert_neon_h5 = neon_h5.convert_neon_h5
+LOC_BAND_NAMES = neon_h5.LOC_BAND_NAMES
+OBS_BAND_NAMES = neon_h5.OBS_BAND_NAMES
+_to_decimal_hours = neon_h5._to_decimal_hours
+_get_scale = neon_h5._get_scale
+
+# ---------------------------------------------------------------------------
+# Synthetic H5 fixture
+# ---------------------------------------------------------------------------
+
+SITE = "NEON_TEST"
+N_LINES, N_SAMPLES, N_BANDS = 4, 5, 6
+SCALE = 10_000.0
+
+WAVELENGTHS = np.array([400.0, 420.0, 440.0, 460.0, 480.0, 500.0], dtype=np.float32)
+FWHM = np.full(N_BANDS, 10.0, dtype=np.float32)
+MAP_INFO = "UTM, 1, 1, 480000.0, 4442000.0, 1.0, 1.0, 13, North, WGS-84, units=Meters"
+COORD_SYS = "PROJCS[WGS 84 / UTM zone 13N]"
+
+
+def _make_h5(path: Path) -> Path:
+    """Write a minimal synthetic NEON H5 file to *path* and return it."""
+    rng = np.random.default_rng(0)
+
+    int_part = rng.integers(50, 200, size=(N_LINES, N_SAMPLES, N_BANDS), dtype=np.int16)
+    dec_part = rng.integers(0, 9999, size=(N_LINES, N_SAMPLES, N_BANDS), dtype=np.int16)
+
+    igm = rng.uniform(
+        [480000, 4_442_000, 1600],
+        [480100, 4_442_100, 1700],
+        size=(N_LINES, N_SAMPLES, 3),
+    ).astype(np.float32)
+
+    obs = rng.uniform(0, 1, size=(N_LINES, N_SAMPLES, 10)).astype(np.float32)
+    obs[:, :, 9] = 58_500.0  # seconds since midnight → 16.25 decimal hours
+
+    with h5py.File(path, "w") as f:
+        rad = f.create_group(f"{SITE}/Radiance")
+
+        ds_int = rad.create_dataset("RadianceIntegerPart", data=int_part)
+        ds_int.attrs["Data_Ignore_Value"] = -9999
+
+        ds_dec = rad.create_dataset("RadianceDecimalPart", data=dec_part)
+        ds_dec.attrs["Data_Ignore_Value"] = -9999
+        ds_dec.attrs["Scale_Factor"] = SCALE
+
+        spec = rad.create_group("Metadata/Spectral_Data")
+        spec.create_dataset("Wavelength", data=WAVELENGTHS)
+        spec.create_dataset("FWHM", data=FWHM)
+
+        crs = rad.create_group("Metadata/Coordinate_System")
+        crs.create_dataset("Map_Info", data=MAP_INFO.encode())
+        crs.create_dataset("Coordinate_System_String", data=COORD_SYS.encode())
+
+        anc = rad.create_group("Metadata/Ancillary_Rasters")
+        anc.create_dataset("IGM_Data", data=igm)
+        anc.create_dataset("OBS_Data", data=obs)
+
+    return path
+
+
+@pytest.fixture
+def h5_file(tmp_path):
+    return _make_h5(tmp_path / "test_flight.h5")
+
+
+# ---------------------------------------------------------------------------
+# Helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_to_decimal_hours_passthrough():
+    """Values already in decimal hours should pass through unchanged."""
+    arr = np.array([16.25, 0.0, 23.99], dtype=np.float32)
+    result = _to_decimal_hours(arr)
+    np.testing.assert_allclose(result, arr, rtol=1e-5)
+
+
+def test_to_decimal_hours_from_seconds():
+    """Seconds since midnight should convert to decimal hours."""
+    arr = np.array([58_500.0], dtype=np.float32)  # 16.25 h × 3600
+    result = _to_decimal_hours(arr)
+    np.testing.assert_allclose(result, [16.25], rtol=1e-4)
+
+
+def test_to_decimal_hours_from_hhmmss():
+    """HHMMSS numeric format (e.g. 162500 = 16:25:00) should convert correctly."""
+    arr = np.array([162_500.0], dtype=np.float64)
+    result = _to_decimal_hours(arr)
+    np.testing.assert_allclose(result, [16.0 + 25.0 / 60.0], rtol=1e-4)
+
+
+def test_get_scale_reads_attribute(h5_file):
+    """_get_scale should find Scale_Factor on the decimal-part dataset."""
+    with h5py.File(h5_file, "r") as f:
+        rad = f[SITE]["Radiance"]
+        scale = _get_scale(rad["RadianceDecimalPart"], rad)
+    assert scale == SCALE
+
+
+# ---------------------------------------------------------------------------
+# convert_rad
+# ---------------------------------------------------------------------------
+
+
+def test_convert_rad_files_created(tmp_path, h5_file):
+    base = str(tmp_path / "out")
+    rad_path, hdr_path = convert_rad(str(h5_file), base)
+    assert Path(rad_path).exists()
+    assert Path(hdr_path).exists()
+
+
+def test_convert_rad_file_size(tmp_path, h5_file):
+    """BIL float32: file size = lines × bands × samples × 4 bytes."""
+    base = str(tmp_path / "out")
+    rad_path, _ = convert_rad(str(h5_file), base)
+    expected = N_LINES * N_BANDS * N_SAMPLES * 4
+    assert Path(rad_path).stat().st_size == expected
+
+
+def test_convert_rad_values(tmp_path, h5_file):
+    """Reconstructed radiance should equal integer + decimal / scale."""
+    base = str(tmp_path / "out")
+    convert_rad(str(h5_file), base)
+
+    # Read back the BIL binary manually
+    raw = np.fromfile(base + ".rad", dtype=np.float32)
+    # BIL layout: (lines, bands, samples) → reshape and transpose to (lines, samples, bands)
+    bil = raw.reshape(N_LINES, N_BANDS, N_SAMPLES).transpose(0, 2, 1)
+
+    with h5py.File(h5_file, "r") as f:
+        rad = f[SITE]["Radiance"]
+        int_part = rad["RadianceIntegerPart"][:].astype(np.float32)
+        dec_part = rad["RadianceDecimalPart"][:].astype(np.float32)
+
+    expected = int_part + dec_part / SCALE
+    np.testing.assert_allclose(bil, expected, rtol=1e-5)
+
+
+def test_convert_rad_header_content(tmp_path, h5_file):
+    base = str(tmp_path / "out")
+    _, hdr_path = convert_rad(str(h5_file), base)
+    hdr = Path(hdr_path).read_text()
+    assert "interleave = bil" in hdr
+    assert "data type = 4" in hdr
+    assert "400.000000" in hdr  # first wavelength
+
+
+# ---------------------------------------------------------------------------
+# convert_loc
+# ---------------------------------------------------------------------------
+
+
+def test_convert_loc_files_created(tmp_path, h5_file):
+    base = str(tmp_path / "out")
+    loc_path, hdr_path = convert_loc(str(h5_file), base)
+    assert Path(loc_path).exists()
+    assert Path(hdr_path).exists()
+
+
+def test_convert_loc_file_size(tmp_path, h5_file):
+    """BIL float32: lines × 3 bands × samples × 4 bytes."""
+    base = str(tmp_path / "out")
+    loc_path, _ = convert_loc(str(h5_file), base)
+    expected = N_LINES * 3 * N_SAMPLES * 4
+    assert Path(loc_path).stat().st_size == expected
+
+
+def test_convert_loc_band_names_in_header(tmp_path, h5_file):
+    base = str(tmp_path / "out")
+    _, hdr_path = convert_loc(str(h5_file), base)
+    hdr = Path(hdr_path).read_text()
+    for name in LOC_BAND_NAMES:
+        assert name in hdr
+
+
+def test_convert_loc_values(tmp_path, h5_file):
+    """LOC values should match the IGM_Data stored in the H5 file."""
+    base = str(tmp_path / "out")
+    loc_path, _ = convert_loc(str(h5_file), base)
+
+    raw = np.fromfile(loc_path, dtype=np.float32)
+    bil = raw.reshape(N_LINES, 3, N_SAMPLES).transpose(0, 2, 1)
+
+    with h5py.File(h5_file, "r") as f:
+        igm = f[SITE]["Radiance"]["Metadata"]["Ancillary_Rasters"]["IGM_Data"][:]
+
+    np.testing.assert_allclose(bil, igm, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# convert_obs
+# ---------------------------------------------------------------------------
+
+
+def test_convert_obs_files_created(tmp_path, h5_file):
+    base = str(tmp_path / "out")
+    obs_path, hdr_path = convert_obs(str(h5_file), base)
+    assert Path(obs_path).exists()
+    assert Path(hdr_path).exists()
+
+
+def test_convert_obs_file_size(tmp_path, h5_file):
+    """BIP float32: lines × samples × 10 bands × 4 bytes."""
+    base = str(tmp_path / "out")
+    obs_path, _ = convert_obs(str(h5_file), base)
+    expected = N_LINES * N_SAMPLES * 10 * 4
+    assert Path(obs_path).stat().st_size == expected
+
+
+def test_convert_obs_interleave_is_bip(tmp_path, h5_file):
+    base = str(tmp_path / "out")
+    _, hdr_path = convert_obs(str(h5_file), base)
+    assert "interleave = bip" in Path(hdr_path).read_text()
+
+
+def test_convert_obs_band_names_in_header(tmp_path, h5_file):
+    base = str(tmp_path / "out")
+    _, hdr_path = convert_obs(str(h5_file), base)
+    hdr = Path(hdr_path).read_text()
+    for name in OBS_BAND_NAMES:
+        assert name in hdr
+
+
+def test_convert_obs_time_converted(tmp_path, h5_file):
+    """Band 10 (index 9) should be converted from seconds to decimal hours."""
+    base = str(tmp_path / "out")
+    obs_path, _ = convert_obs(str(h5_file), base)
+
+    # BIP layout: (lines, samples, bands) in C order
+    raw = np.fromfile(obs_path, dtype=np.float32).reshape(N_LINES, N_SAMPLES, 10)
+    time_band = raw[:, :, 9]
+
+    # 58500 seconds → 16.25 hours
+    np.testing.assert_allclose(time_band, 16.25, rtol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# convert_neon_h5 (end-to-end triplet)
+# ---------------------------------------------------------------------------
+
+
+def test_convert_neon_h5_all_files_created(tmp_path, h5_file):
+    paths = convert_neon_h5(str(h5_file), str(tmp_path))
+    for key in ("rad", "rad_hdr", "loc", "loc_hdr", "obs", "obs_hdr"):
+        assert key in paths
+        assert Path(paths[key]).exists(), f"Missing: {key}"
+
+
+def test_convert_neon_h5_subdir(tmp_path, h5_file):
+    """With subdir=True (default) files should land in <out>/<stem>/."""
+    paths = convert_neon_h5(str(h5_file), str(tmp_path))
+    stem = Path(h5_file).stem
+    assert Path(paths["rad"]).parent.name == stem
+
+
+def test_convert_neon_h5_no_subdir(tmp_path, h5_file):
+    """With subdir=False files should land directly in out_root."""
+    paths = convert_neon_h5(str(h5_file), str(tmp_path), subdir=False)
+    assert Path(paths["rad"]).parent == tmp_path

--- a/isofit/utils/neon_h5.py
+++ b/isofit/utils/neon_h5.py
@@ -404,6 +404,10 @@ def convert_loc(h5_path: str, out_basename: str) -> tuple[str, str]:
     return loc_path, hdr_path
 
 
+# --------------------------------
+# Called by: convert_neon_h5
+# Calls:     _to_decimal_hours, _write_envi_header
+# --------------------------------
 def convert_obs(h5_path: str, out_basename: str) -> tuple[str, str]:
     """
     Export NEON OBS_Data (observation geometry) to an ENVI BIP ``.obs`` file.
@@ -467,6 +471,10 @@ def convert_obs(h5_path: str, out_basename: str) -> tuple[str, str]:
     return obs_path, hdr_path
 
 
+# --------------------------------
+# Called by: (user / external callers)
+# Calls:     convert_rad, convert_loc, convert_obs
+# --------------------------------
 def convert_neon_h5(
     h5_path: str, out_root: str, *, subdir: bool = True
 ) -> dict[str, str]:

--- a/isofit/utils/neon_h5.py
+++ b/isofit/utils/neon_h5.py
@@ -1,0 +1,515 @@
+"""
+Convert NEON AOP HDF5 radiance files to ISOFIT-ready ENVI format.
+
+NEON stores at-sensor radiance in a split-integer encoding to save disk space:
+
+    radiance = RadianceIntegerPart + RadianceDecimalPart / Scale_Factor
+
+This module reconstructs float32 radiance and writes three ENVI binary files
+that ISOFIT's apply_oe expects:
+
+- ``.rad``  — at-sensor radiance, Band-Interleaved-by-Line (BIL)
+- ``.loc``  — per-pixel location (easting, northing, elevation), BIL
+- ``.obs``  — per-pixel observation geometry (angles, path length, time), BIP
+
+Call graph
+----------
+::
+
+    convert_neon_h5                         # main entry point
+    ├── convert_rad                         # reconstruct & write radiance
+    │       ├── _get_scale                  # find Scale_Factor in H5 attrs
+    │       │       └── _to_float           # safe attr → float cast
+    │       ├── _to_float                   # safe attr → float cast
+    │       ├── _decode                     # bytes/numpy scalar → str
+    │       └── _write_envi_header          # write .hdr text file
+    ├── convert_loc                         # write location cube
+    │       └── _write_envi_header
+    └── convert_obs                         # write geometry cube
+            ├── _to_decimal_hours           # normalise time band
+            └── _write_envi_header
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import h5py
+import numpy as np
+
+# Band name constants exposed so callers can reference them without magic strings
+LOC_BAND_NAMES = ["easting_utm", "northing_utm", "elevation_m"]
+
+OBS_BAND_NAMES = [
+    "path_length",
+    "sensor_azimuth",
+    "sensor_zenith",
+    "solar_azimuth",
+    "solar_zenith",
+    "toa_azimuth",
+    "toa_zenith",
+    "view_azimuth",
+    "cos_incidence",
+    "time_decimal_hours",
+]
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+# --------------------------------
+# Called by: convert_rad
+# Calls:     _decode (recursive)
+# --------------------------------
+def _decode(x) -> str:
+    """Return a plain string from an H5 scalar that may be bytes or a numpy void."""
+    if isinstance(x, bytes):
+        return x.decode("utf-8", errors="ignore")
+    if hasattr(x, "shape") and x.shape == () and x.dtype.kind in ("S", "O"):
+        return _decode(x[()])
+    return str(x)
+
+
+# --------------------------------
+# Called by: convert_rad, _get_scale
+# Calls:     (none)
+# --------------------------------
+def _to_float(x, default=None) -> float | None:
+    """Safely cast an H5 attribute value to float, returning *default* on failure."""
+    try:
+        if x is None:
+            return default
+        if np.isscalar(x):
+            return float(x)
+        if getattr(x, "shape", ()) == ():
+            return float(x[()])
+        if isinstance(x, (bytes, str)):
+            return float(x)
+    except Exception:
+        pass
+    return default
+
+
+# --------------------------------
+# Called by: convert_rad
+# Calls:     _to_float
+# --------------------------------
+def _get_scale(dec_ds, group) -> Union[float, np.ndarray]:
+    """
+    Return the radiance scale factor from H5 attributes.
+
+    Searches both the decimal-part dataset and the parent group because the
+    attribute name is inconsistent across NEON file versions.  Falls back to
+    1.0 (no scaling) if nothing is found.
+
+    Parameters
+    ----------
+    dec_ds :
+        HDF5 dataset for ``RadianceDecimalPart``.
+    group :
+        HDF5 group containing the radiance datasets.
+
+    Returns
+    -------
+    float or np.ndarray
+        Scalar scale factor, or a 1-D per-band array.
+    """
+    for obj in (dec_ds, group):
+        if obj is None:
+            continue
+        for key in ("Scale_Factor", "Scale", "scale_factor"):
+            if key not in getattr(obj, "attrs", {}):
+                continue
+            val = obj.attrs[key]
+            if np.isscalar(val) or getattr(val, "shape", ()) == ():
+                s = _to_float(val)
+                if s:
+                    return s
+            else:
+                arr = np.asarray(val)
+                if arr.ndim == 1:
+                    return arr.astype(np.float32)
+    return 1.0
+
+
+# --------------------------------
+# Called by: convert_obs
+# Calls:     (none)
+# --------------------------------
+def _to_decimal_hours(arr: np.ndarray) -> np.ndarray:
+    """
+    Normalise a time array to decimal hours.
+
+    NEON OBS_Data band 10 (time) may arrive as decimal hours, seconds since
+    midnight, or HHMMSS numeric format depending on the file version.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Raw time values from OBS_Data.
+
+    Returns
+    -------
+    np.ndarray
+        Time in decimal hours, float32.
+    """
+    x = arr.astype(np.float64)
+    finite = np.isfinite(x)
+    if not np.any(finite):
+        return arr.astype(np.float32)
+    m = np.nanmax(x[finite])
+    if m <= 24.5:
+        return x.astype(np.float32)  # already decimal hours
+    if m < 86_400:
+        return (x / 3600.0).astype(np.float32)  # seconds → hours
+    # HHMMSS numeric → hours
+    h = np.floor(x / 10_000.0)
+    mm = np.floor((x - h * 10_000.0) / 100.0)
+    ss = x - h * 10_000.0 - mm * 100.0
+    return (h + mm / 60.0 + ss / 3600.0).astype(np.float32)
+
+
+# --------------------------------
+# Called by: convert_rad, convert_loc, convert_obs
+# Calls:     (none)
+# --------------------------------
+def _write_envi_header(
+    path: str,
+    *,
+    samples: int,
+    lines: int,
+    bands: int,
+    interleave: str,
+    no_data: float = -9999.0,
+    wavelengths: np.ndarray | None = None,
+    fwhm: np.ndarray | None = None,
+    map_info: str | None = None,
+    coord_sys: str | None = None,
+    band_names: list[str] | None = None,
+    description: str = "NEON HDF5 → ENVI",
+) -> None:
+    """
+    Write a minimal ENVI ``.hdr`` file.
+
+    Parameters
+    ----------
+    path : str
+        Output path for the header (typically ``<data_file>.hdr``).
+    samples, lines, bands : int
+        Spatial and spectral dimensions.
+    interleave : str
+        ``"bil"`` or ``"bip"``.
+    no_data : float
+        Fill value written to the ``data ignore value`` field.
+    wavelengths : np.ndarray, optional
+        Centre wavelengths in nm (written for ``.rad`` files).
+    fwhm : np.ndarray, optional
+        Full-width half-maximum values in nm.
+    map_info : str, optional
+        ENVI map info string.
+    coord_sys : str, optional
+        Coordinate system string.
+    band_names : list[str], optional
+        Per-band labels.
+    description : str
+        Short description written into the header.
+    """
+    rows = [
+        "ENVI",
+        f"description = {{{description}}}",
+        f"samples = {samples}",
+        f"lines   = {lines}",
+        f"bands   = {bands}",
+        "header offset = 0",
+        "file type = ENVI Standard",
+        "data type = 4",  # float32
+        "byte order = 0",  # little-endian
+        f"interleave = {interleave.lower()}",
+        f"data ignore value = {no_data}",
+    ]
+    if wavelengths is not None:
+        rows.append("wavelength = {" + ", ".join(f"{w:.6f}" for w in wavelengths) + "}")
+    if fwhm is not None:
+        rows.append("fwhm = {" + ", ".join(f"{v:.6f}" for v in fwhm) + "}")
+    if map_info is not None:
+        rows.append(f"map info = {{{map_info}}}")
+    if coord_sys is not None:
+        rows.append(f"coordinate system string = {{{coord_sys}}}")
+    if band_names is not None:
+        rows.append("band names = {" + ", ".join(band_names) + "}")
+
+    Path(path).write_text("\n".join(rows) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+# --------------------------------
+# Called by: convert_neon_h5
+# Calls:     _get_scale, _to_float, _decode, _write_envi_header
+# --------------------------------
+def convert_rad(
+    h5_path: str, out_basename: str, chunk_rows: int = 64
+) -> tuple[str, str]:
+    """
+    Convert a NEON HDF5 radiance file to an ENVI BIL ``.rad`` file.
+
+    NEON stores radiance as two integer datasets to reduce file size.  The
+    physical radiance (W m⁻² sr⁻¹ nm⁻¹) is reconstructed as::
+
+        R = RadianceIntegerPart + RadianceDecimalPart / Scale_Factor
+
+    The output is written as float32, Band-Interleaved-by-Line (BIL), which
+    is the format expected by ISOFIT's ``apply_oe``.
+
+    Parameters
+    ----------
+    h5_path : str
+        Path to the NEON L1 radiance HDF5 file.
+    out_basename : str
+        Output path without extension.  A ``.rad`` data file and a ``.hdr``
+        header are written next to each other.
+    chunk_rows : int, default 64
+        Number of image rows processed at once.  Reduce if memory is limited.
+
+    Returns
+    -------
+    rad_path : str
+    hdr_path : str
+    """
+    rad_path = out_basename + ".rad"
+    hdr_path = out_basename + ".rad.hdr"
+
+    with h5py.File(h5_path, "r") as f:
+        site = next(iter(f.keys()))
+        rad_grp = f[site]["Radiance"]
+
+        ds_int = rad_grp["RadianceIntegerPart"]  # (lines, samples, bands)
+        ds_dec = rad_grp["RadianceDecimalPart"]
+        n_lines, n_samples, n_bands = ds_int.shape
+
+        scale = _get_scale(ds_dec, rad_grp)
+        if not (
+            np.isscalar(scale)
+            or (isinstance(scale, np.ndarray) and scale.shape == (n_bands,))
+        ):
+            raise RuntimeError(
+                f"Unexpected scale shape {getattr(scale, 'shape', type(scale))}; "
+                "expected scalar or 1-D per-band array."
+            )
+
+        int_nd = _to_float(ds_int.attrs.get("Data_Ignore_Value"))
+        dec_nd = _to_float(ds_dec.attrs.get("Data_Ignore_Value"))
+
+        meta = rad_grp["Metadata"]
+        wavelengths = meta["Spectral_Data"]["Wavelength"][:]
+        fwhm = meta["Spectral_Data"]["FWHM"][:]
+        map_info = _decode(meta["Coordinate_System"]["Map_Info"][()])
+        try:
+            coord_sys = _decode(
+                meta["Coordinate_System"]["Coordinate_System_String"][()]
+            )
+        except Exception:
+            coord_sys = None
+
+        with open(rad_path, "wb") as out:
+            row = 0
+            while row < n_lines:
+                r1 = min(row + chunk_rows, n_lines)
+                I = ds_int[row:r1].astype(np.float32)
+                D = ds_dec[row:r1].astype(np.float32)
+
+                nodata_mask = np.zeros(I.shape, dtype=bool)
+                if int_nd is not None:
+                    nodata_mask |= I == int_nd
+                if dec_nd is not None:
+                    nodata_mask |= D == dec_nd
+
+                if np.isscalar(scale):
+                    R = I + D / float(scale)
+                else:
+                    R = I + D / scale.reshape(1, 1, -1)
+
+                R = R.astype(np.float32)
+                R[nodata_mask] = -9999.0
+
+                # BIL: each row on disk is (bands, samples) — transpose (samples, bands)
+                for i in range(R.shape[0]):
+                    out.write(R[i].T.tobytes(order="C"))
+                row = r1
+
+    _write_envi_header(
+        hdr_path,
+        samples=n_samples,
+        lines=n_lines,
+        bands=n_bands,
+        interleave="bil",
+        wavelengths=wavelengths,
+        fwhm=fwhm,
+        map_info=map_info,
+        coord_sys=coord_sys,
+        description="NEON HDF5 → ENVI radiance",
+    )
+    return rad_path, hdr_path
+
+
+# --------------------------------
+# Called by: convert_neon_h5
+# Calls:     _write_envi_header
+# --------------------------------
+def convert_loc(h5_path: str, out_basename: str) -> tuple[str, str]:
+    """
+    Export NEON IGM_Data (easting, northing, elevation) to an ENVI BIL ``.loc`` file.
+
+    Parameters
+    ----------
+    h5_path : str
+        Path to the NEON L1 radiance HDF5 file.
+    out_basename : str
+        Output path without extension.
+
+    Returns
+    -------
+    loc_path : str
+    hdr_path : str
+    """
+    with h5py.File(h5_path, "r") as f:
+        site = next(iter(f.keys()))
+        loc = f[site]["Radiance"]["Metadata"]["Ancillary_Rasters"]["IGM_Data"][:]
+
+    loc = loc.astype(np.float32)
+    loc[loc == -9999] = -9999.0
+    n_lines, n_samples, n_bands = loc.shape
+
+    loc_path = out_basename + ".loc"
+    with open(loc_path, "wb") as out:
+        for i in range(n_lines):
+            out.write(loc[i].T.tobytes(order="C"))  # BIL: (bands, samples) per row
+
+    hdr_path = loc_path + ".hdr"
+    _write_envi_header(
+        hdr_path,
+        samples=n_samples,
+        lines=n_lines,
+        bands=n_bands,
+        interleave="bil",
+        band_names=LOC_BAND_NAMES,
+        description="NEON HDF5 → ENVI location (IGM)",
+    )
+    return loc_path, hdr_path
+
+
+def convert_obs(h5_path: str, out_basename: str) -> tuple[str, str]:
+    """
+    Export NEON OBS_Data (observation geometry) to an ENVI BIP ``.obs`` file.
+
+    The ten output bands are:
+
+    1. path_length — slant range in metres
+    2. sensor_azimuth — degrees clockwise from north
+    3. sensor_zenith — degrees from nadir
+    4. solar_azimuth — degrees clockwise from north
+    5. solar_zenith — degrees from zenith
+    6. toa_azimuth
+    7. toa_zenith
+    8. view_azimuth
+    9. cos_incidence — cosine of solar incidence angle on the surface
+    10. time_decimal_hours — UTC acquisition time in decimal hours
+
+    ISOFIT expects observation geometry in BIP (Band-Interleaved-by-Pixel)
+    format, which is why this file uses a different interleave from ``.rad``
+    and ``.loc``.
+
+    Parameters
+    ----------
+    h5_path : str
+        Path to the NEON L1 radiance HDF5 file.
+    out_basename : str
+        Output path without extension.
+
+    Returns
+    -------
+    obs_path : str
+    hdr_path : str
+    """
+    with h5py.File(h5_path, "r") as f:
+        site = next(iter(f.keys()))
+        obs = f[site]["Radiance"]["Metadata"]["Ancillary_Rasters"]["OBS_Data"][
+            :, :, :10
+        ]
+
+    obs = obs.astype(np.float32)
+    obs[:, :, 9] = _to_decimal_hours(obs[:, :, 9])
+    obs[obs == -9999] = -9999.0
+    n_lines, n_samples, n_bands = obs.shape
+
+    obs_path = out_basename + ".obs"
+    with open(obs_path, "wb") as out:
+        for i in range(n_lines):
+            # BIP: each row is (samples, bands) in C order — no transpose needed
+            out.write(obs[i].tobytes(order="C"))
+
+    hdr_path = obs_path + ".hdr"
+    _write_envi_header(
+        hdr_path,
+        samples=n_samples,
+        lines=n_lines,
+        bands=n_bands,
+        interleave="bip",
+        band_names=OBS_BAND_NAMES,
+        description="NEON HDF5 → ENVI observation geometry",
+    )
+    return obs_path, hdr_path
+
+
+def convert_neon_h5(
+    h5_path: str, out_root: str, *, subdir: bool = True
+) -> dict[str, str]:
+    """
+    Convert a NEON HDF5 file to the full ISOFIT input triplet (.rad, .loc, .obs).
+
+    Parameters
+    ----------
+    h5_path : str
+        Path to the NEON L1 radiance HDF5 file.
+    out_root : str
+        Root output directory.  With ``subdir=True`` (default), files are
+        placed in ``<out_root>/<stem>/``; with ``subdir=False`` directly in
+        ``<out_root>/``.
+    subdir : bool, default True
+        Whether to create a per-file subdirectory named after the H5 stem.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping of ``{"rad", "rad_hdr", "loc", "loc_hdr", "obs", "obs_hdr"}``
+        to the written file paths.
+
+    Examples
+    --------
+    >>> paths = convert_neon_h5("flight.h5", "./envi_output")
+    >>> paths["rad"]
+    './envi_output/flight/flight.rad'
+    """
+    h5_path = Path(h5_path)
+    out_dir = Path(out_root) / h5_path.stem if subdir else Path(out_root)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base = str(out_dir / h5_path.stem)
+
+    rad, rad_hdr = convert_rad(str(h5_path), base)
+    loc, loc_hdr = convert_loc(str(h5_path), base)
+    obs, obs_hdr = convert_obs(str(h5_path), base)
+
+    return {
+        "rad": rad,
+        "rad_hdr": rad_hdr,
+        "loc": loc,
+        "loc_hdr": loc_hdr,
+        "obs": obs,
+        "obs_hdr": obs_hdr,
+    }

--- a/isofit/utils/neon_h5.py
+++ b/isofit/utils/neon_h5.py
@@ -26,7 +26,7 @@ Call graph
     ├── convert_loc                         # write location cube
     │       └── _write_envi_header
     └── convert_obs                         # write geometry cube
-            ├── _to_decimal_hours           # normalise time band
+            ├── _to_decimal_hours           # normalize time band
             └── _write_envi_header
 """
 
@@ -414,7 +414,7 @@ def convert_obs(h5_path: str, out_basename: str) -> tuple[str, str]:
 
     The ten output bands are:
 
-    1. path_length — slant range in metres
+    1. path_length — slant range in meters
     2. sensor_azimuth — degrees clockwise from north
     3. sensor_zenith — degrees from nadir
     4. solar_azimuth — degrees clockwise from north


### PR DESCRIPTION
Adds `isofit/utils/neon_h5.py`, a self-contained utility that converts NEON AOP L1 radiance HDF5 files to the three ENVI binary + .hdr files expected by `apply_oe`:

- `.rad` — at-sensor radiance, BIL float32
- `.loc` — per-pixel location (easting/northing/elevation), BIL float32
- `.obs` — observation geometry (angles, path length, time), BIP float32

NEON stores radiance in a split-integer encoding (`RadianceIntegerPart + RadianceDecimalPart / Scale_Factor`); this module handles reconstruction, no-data masking, and the three known time-band formats (decimal hours / seconds since midnight / HHMMSS).

**Public API**

python:

from isofit.utils.neon_h5 import convert_neon_h5

paths = convert_neon_h5("flight.h5", "./envi_output")
returns {"rad", "rad_hdr", "loc", "loc_hdr", "obs", "obs_hdr"}

Individual converters (convert_rad, convert_loc, convert_obs) are also importable for partial workflows.

## Output band descriptions

### `.rad` — at-sensor radiance (BIL)
N bands matching the NEON AOP sensor wavelengths (e.g. 426 bands for the standard NEON imaging spectrometer). Center wavelengths and FWHM values are read from the H5 file and written into the ENVI header (`wavelength` and `fwhm` fields), so the file is self-describing. Units: W m⁻² sr⁻¹ nm⁻¹.

### `.loc` — per-pixel location (BIL)

{
  "1": "easting_utm",
  "2": "northing_utm",
  "3": "elevation_m"
}

### `.obs` — observation geometry (BIP)

{
  "1":  "path_length",
  "2":  "sensor_azimuth",
  "3":  "sensor_zenith",
  "4":  "solar_azimuth",
  "5":  "solar_zenith",
  "6":  "toa_azimuth",
  "7":  "toa_zenith",
  "8":  "view_azimuth",
  "9":  "cos_incidence",
  "10": "time_decimal_hours"
}

Band names are written into each ENVI header so they are visible in tools like ENVI, QGIS, and spectral (Python).

## Tests

isofit/test/test_neon_h5.py — 20 pytest tests using a synthetic H5 fixture built in tmp_path (no real NEON file used for CI). Covers file sizes, pixel values, header content, BIL/BIP interleave, time-format detection, and the end-to-end triplet writer.

## Additional Notes

- This was originally while running ISOFIT/apply_oe via the command line on multiple NEON AOP radiance flightlines and subsets. This is _**not**_ an H5 driver, it is a converter of h5 > ENVI binary. I'm sure there are additional improvements to be made and am happy to continue contributing/iterating/refining/restructuring.

- I put this all together for the purposes of isofit/utils, but I originally had them more broken up in my codebase I use for my experiments. Please let me know if you would prefer a more modular format.