### PR TITLE
Small patch to surface reflectance statevector names.

### DIFF
--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -77,7 +77,10 @@ class MultiComponentSurface(Surface):
 
         # Variables retrieved: each channel maps to a reflectance model parameter
         rmin, rmax = -0.05, 2.0
-        self.statevec_names = ["RFL_%04i" % int(w) for w in self.wl]
+        self.statevec_names = [
+            "RFL_%04i_%f" % (float(w), float(str(v % 1).lstrip("0")))
+            for w, v in zip(self.wl, self.wl)
+        ]
 
         self.idx_surface = np.arange(len(self.statevec_names))
 

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -78,7 +78,7 @@ class MultiComponentSurface(Surface):
         # Variables retrieved: each channel maps to a reflectance model parameter
         rmin, rmax = -0.05, 2.0
         self.statevec_names = [
-            "RFL_%04i_%f" % (float(w), float(str(v % 1).lstrip("0")))
+            "RFL_%04i_%.3f" % (float(w), float(str(v % 1)))
             for w, v in zip(self.wl, self.wl)
         ]
 


### PR DESCRIPTION
Allows distinct statevector names for instrument channels with less than 1 nm difference in center wavelengths.