### PR TITLE
Forward model patch fixes

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -402,18 +402,19 @@ class ForwardModel:
         # Assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle.
         # Downward diffuse components are scaled by viewable sky fraction (i.e., "ungula" of viewable sky in solid geometry terms).
         L_dir_dir = L_coupled[0] / geom.coszen * geom.cos_i * b
-        L_dif_dir = L_coupled[1]
         L_dir_dif = L_coupled[2] / geom.coszen * cos_i_bg
-        L_dif_dif = L_coupled[3]
 
-        # Note - we should really be doing the multiplication upstream before convolution - this is an approximation
+        # Note - we should really be doing the multiplication upstream before convolution - L_dif_dir and L_dif_dif terms are
+        # therefor an approximation
         # Correct downward diffuse term for topographic assuming Hay's model (Hay 1979; Richter 1998; Guanter et al., 2009)
         t_down_dir = r["transm_down_dir"]
-        L_dif_dir *= (b * t_down_dir * (geom.cos_i / geom.coszen)) + (
-            (1 - b * t_down_dir) * geom.skyview_factor
+        L_dif_dir = L_coupled[1] * (
+            (b * t_down_dir * (geom.cos_i / geom.coszen))
+            + ((1 - b * t_down_dir) * geom.skyview_factor)
         )
-        L_dif_dif *= (t_down_dir * (cos_i_bg / geom.coszen)) + (
-            (1 - t_down_dir) * skyview_factor_bg
+        L_dif_dif = L_coupled[3] * (
+            (t_down_dir * (cos_i_bg / geom.coszen))
+            + ((1 - t_down_dir) * skyview_factor_bg)
         )
 
         # Apply equation 11

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -420,9 +420,11 @@ class ForwardModel:
         # If no rho_dif_dif passed eq_11_term -> 1
         eq_11_term = 1 - (r["sphalb"] * rho_dif_dif)
 
+        # This seems like it's out of order, but it's not.  calc_rdn needs L_tot to *not* have
+        # the eq_11_term adjustment in play to avoid double counting
+        L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
         L_dif_dir /= eq_11_term
         L_dif_dif /= eq_11_term
-        L_tot = L_dir_dir + L_dif_dir + L_dir_dif + L_dif_dif
 
         return L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif
 


### PR DESCRIPTION
Trying to resolve some discrepancies between 3.7.7 and 4.0.0-alpha.  Currently, presolve solution give consistent RTMs, but different converged solutions.  Fixes are:

1) L_tot needs to not have eq_11 terms applied to it, or we double count
2) the cache from reader.py was getting polluted from the get_L_coupled call, as the stored dictionary was mutable.  To fix, the logic inside get_L_coupled was modified to create new variables during the inline multiplication, rather than write over.