### PR TITLE
Disable chunks on small LUTs

### DIFF
--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -454,7 +454,7 @@ def load(
         xropen = xr.mfopen_dataset
 
     # Special case that doesn't require defining the entire grid subsetting strategy
-    if subset is None and load:
+    if not subset and load:
         Logger.debug(
             "With no subset defined and load enabled, disabling default chunking for performance"
         )

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -453,6 +453,10 @@ def load(
     if mf:
         xropen = xr.mfopen_dataset
 
+    # Convert dicts of {dim: None, ...} to None
+    if subset and not any(subset.values()):
+        subset = None
+
     # Special case that doesn't require defining the entire grid subsetting strategy
     if subset is None and load:
         Logger.debug(

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -454,13 +454,11 @@ def load(
         xropen = xr.mfopen_dataset
 
     # Special case that doesn't require defining the entire grid subsetting strategy
-    if subset is None:
-        Logger.debug("Subset was None, using entire store")
-        if load:
-            Logger.debug(
-                "With loading enabled, disabled file-defined chunking for performance"
-            )
-            chunks = None
+    if subset is None and load:
+        Logger.debug(
+            "With no subset defined and load enabled, disabling default chunking for performance"
+        )
+        chunks = None
 
     ds = xropen(path, chunks=chunks, **kwargs)
 
@@ -480,7 +478,7 @@ def load(
 
     # Special case that doesn't require defining the entire grid subsetting strategy
     if subset is None:
-        pass
+        Logger.debug("Subset was None, using entire store")
 
     elif isinstance(subset, dict):
         Logger.debug(f"Subsetting with: {subset}")

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -14,7 +14,7 @@ import xarray as xr
 from netCDF4 import Dataset
 
 from isofit import __version__
-from isofit.core import common
+from isofit.core import common, units
 
 Logger = logging.getLogger(__name__)
 
@@ -449,6 +449,8 @@ def load(
     >>> load(path, subset).unstack().dims
     Frozen({'AOT550': 3, 'H2OSTR': 10, 'wl': 285})
     """
+    path = Path(path)
+
     xropen = xr.open_dataset
     if mf:
         xropen = xr.mfopen_dataset
@@ -458,11 +460,18 @@ def load(
         subset = None
 
     # Special case that doesn't require defining the entire grid subsetting strategy
-    if not subset and load:
-        Logger.debug(
-            "With no subset defined and load enabled, disabling default chunking for performance"
-        )
-        chunks = None
+    if load:
+        if not subset:
+            Logger.debug(
+                "With no subset defined and load enabled, disabling default chunking for performance"
+            )
+            chunks = None
+
+        elif path.is_file() and path.stat().st_size < units.byte_string_to_float("4gb"):
+            Logger.debug(
+                "LUT store detected less than 4gb and load enabled, disabling default chunking for performance"
+            )
+            chunks = None
 
     ds = xropen(path, chunks=chunks, **kwargs)
 

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -453,6 +453,15 @@ def load(
     if mf:
         xropen = xr.mfopen_dataset
 
+    # Special case that doesn't require defining the entire grid subsetting strategy
+    if subset is None:
+        Logger.debug("Subset was None, using entire store")
+        if load:
+            Logger.debug(
+                "With loading enabled, disabled file-defined chunking for performance"
+            )
+            chunks = None
+
     ds = xropen(path, chunks=chunks, **kwargs)
 
     status = ds.attrs.get("ISOFIT status", "<not set>")
@@ -471,7 +480,7 @@ def load(
 
     # Special case that doesn't require defining the entire grid subsetting strategy
     if subset is None:
-        Logger.debug("Subset was None, using entire store")
+        pass
 
     elif isinstance(subset, dict):
         Logger.debug(f"Subsetting with: {subset}")


### PR DESCRIPTION
With the 4.0 changes, we switched to enabling file-defined chunking by default. This has a significant impact on small luts that aren't being subsetted and are being fully loaded into memory. (at least for netcdf, did not check for zarrs). The changes here just detect this case and disable chunking, which should restore previous 3.x lut loading speeds.
