### PR TITLE
Fix workflows/result_close_pr (again)

### DIFF
--- a/.github/workflows/results_close_pr.yml
+++ b/.github/workflows/results_close_pr.yml
@@ -14,5 +14,5 @@ jobs:
           PR_NUM: ${{ github.event.pull_request.number }}
           REPO: isofit/isofit-test-results
         run: |
-          PR_NUMBER=$(gh pr list --repo "$REPO" --search "$PR_NUM" --json number,title --jq '.[] | select(.title == "'"$PR_NUM"'") | .number')
-          gh pr close "$PR_NUM" --repo "$REPO"
+          URL=$(gh pr list --repo "$REPO" --search "$PR_NUM" --json url,title --jq '.[] | select(.title == "'"$PR_NUM"'") | .url')
+          gh pr close "$URL" --repo "$REPO"


### PR DESCRIPTION
Another swing at fixing this very simple workflow that absolutely refuses to work. Switched to using the remote PR's url instead of attempting to retrieve the PR number