### PR TITLE
Adjacency effects

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -231,3 +231,19 @@ class SurfaceConfig(BaseConfigSection):
             )
 
         return errors, warnings
+
+
+def update_from_subconfig(self, subconfig_dict: dict):
+
+    # Not entirely sure if this is needed/possible, but just to be safe
+    keys_to_ignore = {
+        "multi_surface_flag",
+        "Surfaces",
+        "surface_class_file",
+        "base_surface_class_file",
+        "statevector",
+    }
+
+    for key, value in subconfig_dict.items():
+        if hasattr(self, key) and key not in keys_to_ignore:
+            setattr(self, key, value)

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -232,18 +232,17 @@ class SurfaceConfig(BaseConfigSection):
 
         return errors, warnings
 
+    def update_from_subconfig(self, subconfig_dict: dict):
 
-def update_from_subconfig(self, subconfig_dict: dict):
+        # Not entirely sure if this is needed/possible, but just to be safe
+        keys_to_ignore = {
+            "multi_surface_flag",
+            "Surfaces",
+            "surface_class_file",
+            "base_surface_class_file",
+            "statevector",
+        }
 
-    # Not entirely sure if this is needed/possible, but just to be safe
-    keys_to_ignore = {
-        "multi_surface_flag",
-        "Surfaces",
-        "surface_class_file",
-        "base_surface_class_file",
-        "statevector",
-    }
-
-    for key, value in subconfig_dict.items():
-        if hasattr(self, key) and key not in keys_to_ignore:
-            setattr(self, key, value)
+        for key, value in subconfig_dict.items():
+            if hasattr(self, key) and key not in keys_to_ignore:
+                setattr(self, key, value)

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -75,6 +75,9 @@ class SurfaceConfig(BaseConfigSection):
         self._multi_surface_flag_type = bool
         self.multi_surface_flag = False
 
+        self._use_background_rfl_type = bool
+        self.use_background_rfl = False
+
         self._surface_file_type = str
         self.surface_file = None
 

--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -517,6 +517,12 @@ class IO:
         if "skyview_factor_file" not in data or data["skyview_factor_file"] is None:
             data["skyview_factor_file"] = 1.0
 
+        if (
+            "background_reflectance_file" not in data
+            or data["background_reflectance_file"] is None
+        ):
+            data["background_reflectance_file"] = None
+
         # We build the geometry object for this spectrum.  For files not
         # specified in the input configuration block, the associated entries
         # will be 'None'. The Geometry object will use reasonable defaults.

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -479,10 +479,10 @@ class ForwardModel:
         # NOTE for now, a flat slope is assumed, such that terrain view is,
         # v_t = (1 + cos_slope) / 2 - skyview = (1 + 1)/2  - skyview = 1 - skyview
         t = self.terrain_rereflection(geom)
-        L_dir_dir *= t
-        L_dif_dir *= t
-        L_dir_dif *= t
-        L_dif_dif *= t
+        L_dir_dir *= float(t)
+        L_dif_dir *= float(t)
+        L_dir_dif *= float(t)
+        L_dif_dif *= float(t)
 
         # Apply equation 11
         # If no rho_dif_dif passed eq_11_term -> 1

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -479,10 +479,10 @@ class ForwardModel:
         # NOTE for now, a flat slope is assumed, such that terrain view is,
         # v_t = (1 + cos_slope) / 2 - skyview = (1 + 1)/2  - skyview = 1 - skyview
         t = self.terrain_rereflection(geom)
-        L_dir_dir *= float(t)
-        L_dif_dir *= float(t)
-        L_dir_dif *= float(t)
-        L_dif_dif *= float(t)
+        L_dir_dir *= t
+        L_dif_dir *= t
+        L_dir_dif *= t
+        L_dif_dif *= t
 
         # Apply equation 11
         # If no rho_dif_dif passed eq_11_term -> 1

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -449,6 +449,12 @@ class ForwardModel:
         cos_i_bg = geom.coszen
         skyview_factor_bg = 1.0
 
+        # Used to modulate the terrain view factor for target pixel and background
+        # NOTE for now, this is assumed a flat slope, such that terrain view is,
+        # v_t = (1 + cos_slope) / 2 - skyview   =    (1 + 1)/2  - skyview
+        cos_slope = 1.0
+        cos_slope_bg = 1.0
+
         # Assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle.
         # Downward diffuse components are scaled by viewable sky fraction (i.e., "ungula" of viewable sky in solid geometry terms).
         L_dir_dir = L_coupled[0] / geom.coszen * geom.cos_i * b
@@ -466,6 +472,19 @@ class ForwardModel:
             (t_down_dir * (cos_i_bg / geom.coszen))
             + ((1 - t_down_dir) * skyview_factor_bg)
         )
+
+        # Re-reflection from nearby surface contributing to at surface signal
+        # Assumptions: no atmospheric attenuation, and reflectance is isotropic over the field of view
+        if geom.bg_rfl is not None:
+
+            v_t = (1 + cos_slope) / 2 - geom.skyview_factor
+            v_t_avg = (1 + cos_slope_bg) / 2 - skyview_factor_bg
+            t = 1 + ((geom.bg_rfl * v_t) / (1 - geom.bg_rfl * v_t_avg))
+
+            L_dir_dir *= t
+            L_dif_dir *= t
+            L_dir_dif *= t
+            L_dif_dif *= t
 
         # Apply equation 11
         # If no rho_dif_dif passed eq_11_term -> 1

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -559,6 +559,21 @@ class ForwardModel:
 
         return ret
 
+    def calc_rdn_bg(self, rho_dir_dif, rho_dif_dif, L_dir_dif, L_dif_dif, L_tot, s_alb):
+        """TOA radiance that is a function of the background reflectance (used in AOE)."""
+
+        atm_surface_scattering = s_alb * rho_dif_dif
+        if not isinstance(L_dir_dif, np.ndarray) or len(L_dir_dif) == 1:
+            atm_surface_scattering = 1
+
+        L_bg = (
+            (L_dir_dif * rho_dir_dif)
+            + (L_dif_dif * rho_dif_dif)
+            + (L_tot * atm_surface_scattering * rho_dif_dif) / (1 - s_alb * rho_dif_dif)
+        )
+
+        return L_bg
+
     def calc_Ls(self, x, geom):
         """Calculate the surface emission."""
 

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -478,7 +478,7 @@ class ForwardModel:
         # Assumptions: no atmospheric attenuation, and reflectance is isotropic over the field of view
         # NOTE for now, a flat slope is assumed, such that terrain view is,
         # v_t = (1 + cos_slope) / 2 - skyview = (1 + 1)/2  - skyview = 1 - skyview
-        t = self.terrain_rereflection(geom)
+        t = self.terrain_rereflection(rho_dif_dif=rho_dif_dif, geom=geom)
         L_dir_dir *= t
         L_dif_dir *= t
         L_dir_dif *= t
@@ -593,16 +593,16 @@ class ForwardModel:
         return np.zeros_like(L_tot)
 
     def terrain_rereflection_heterogeneous(
-        self, geom, skyview_factor_bg=1.0, cos_slope=1.0, cos_slope_bg=1.0
+        self, rho_dif_dif, geom, skyview_factor_bg=1.0, cos_slope=1.0, cos_slope_bg=1.0
     ):
         """Isotropic scattering from nearby terrain."""
         v_t = (1 + cos_slope) / 2 - geom.skyview_factor
         v_t_avg = (1 + cos_slope_bg) / 2 - skyview_factor_bg
-        t = 1 + ((geom.bg_rfl * v_t) / (1 - geom.bg_rfl * v_t_avg))
+        t = 1 + ((rho_dif_dif * v_t) / (1 - rho_dif_dif * v_t_avg))
         return t
 
     def terrain_rereflection_homogeneous(
-        self, geom, skyview_factor_bg=1.0, cos_slope=1.0, cos_slope_bg=1.0
+        self, rho_dif_dif, geom, skyview_factor_bg=1.0, cos_slope=1.0, cos_slope_bg=1.0
     ):
         """Terrain scattering is ignored in the case dir_dir=dir_dif=dif_dir=dif_dif."""
         return 1.0

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -158,6 +158,13 @@ class ForwardModel:
         else:
             self.model_discrepancy = None
 
+        if self.surface.use_background_rfl:
+            self.calc_rdn_bgrfl = self.calc_rdn_bgrfl_heterogeneous
+            self.terrain_rereflection = self.terrain_rereflection_heterogeneous
+        else:
+            self.calc_rdn_bgrfl = self.calc_rdn_bgrfl_homogeneous
+            self.terrain_rereflection = self.terrain_rereflection_homogeneous
+
         if full_config.implementation.per_pixel_heuristic_prior:
             self.xa = self.xa_heuristic
         else:
@@ -449,12 +456,6 @@ class ForwardModel:
         cos_i_bg = geom.coszen
         skyview_factor_bg = 1.0
 
-        # Used to modulate the terrain view factor for target pixel and background
-        # NOTE for now, this is assumed a flat slope, such that terrain view is,
-        # v_t = (1 + cos_slope) / 2 - skyview   =    (1 + 1)/2  - skyview
-        cos_slope = 1.0
-        cos_slope_bg = 1.0
-
         # Assigning coupled terms, unscaling and rescaling downward direct radiance by local solar zenith angle.
         # Downward diffuse components are scaled by viewable sky fraction (i.e., "ungula" of viewable sky in solid geometry terms).
         L_dir_dir = L_coupled[0] / geom.coszen * geom.cos_i * b
@@ -475,16 +476,13 @@ class ForwardModel:
 
         # Re-reflection from nearby surface contributing to at surface signal
         # Assumptions: no atmospheric attenuation, and reflectance is isotropic over the field of view
-        if geom.bg_rfl is not None:
-
-            v_t = (1 + cos_slope) / 2 - geom.skyview_factor
-            v_t_avg = (1 + cos_slope_bg) / 2 - skyview_factor_bg
-            t = 1 + ((geom.bg_rfl * v_t) / (1 - geom.bg_rfl * v_t_avg))
-
-            L_dir_dir *= t
-            L_dif_dir *= t
-            L_dir_dif *= t
-            L_dif_dif *= t
+        # NOTE for now, a flat slope is assumed, such that terrain view is,
+        # v_t = (1 + cos_slope) / 2 - skyview = (1 + 1)/2  - skyview = 1 - skyview
+        t = self.terrain_rereflection(geom)
+        L_dir_dir *= t
+        L_dif_dir *= t
+        L_dir_dif *= t
+        L_dif_dif *= t
 
         # Apply equation 11
         # If no rho_dif_dif passed eq_11_term -> 1
@@ -578,20 +576,36 @@ class ForwardModel:
 
         return ret
 
-    def calc_rdn_bg(self, rho_dir_dif, rho_dif_dif, L_dir_dif, L_dif_dif, L_tot, s_alb):
-        """TOA radiance that is a function of the background reflectance (used in AOE)."""
-
-        atm_surface_scattering = s_alb * rho_dif_dif
-        if not isinstance(L_dir_dif, np.ndarray) or len(L_dir_dif) == 1:
-            atm_surface_scattering = 1
-
-        L_bg = (
+    def calc_rdn_bgrfl_heterogeneous(
+        self, rho_dir_dif, rho_dif_dif, L_dir_dif, L_dif_dif, L_tot, s_alb
+    ):
+        """TOA radiance that is a function of the heterogeneous background reflectance (used in AOE)."""
+        return (
             (L_dir_dif * rho_dir_dif)
             + (L_dif_dif * rho_dif_dif)
-            + (L_tot * atm_surface_scattering * rho_dif_dif) / (1 - s_alb * rho_dif_dif)
+            + (L_tot * (s_alb * rho_dif_dif) * rho_dif_dif) / (1 - s_alb * rho_dif_dif)
         )
 
-        return L_bg
+    def calc_rdn_bgrfl_homogeneous(
+        self, rho_dir_dif, rho_dif_dif, L_dir_dif, L_dif_dif, L_tot, s_alb
+    ):
+        """TOA radiance that is a function of the background reflectance in homogenous case (used in AOE)."""
+        return np.zeros_like(L_tot)
+
+    def terrain_rereflection_heterogeneous(
+        self, geom, skyview_factor_bg=1.0, cos_slope=1.0, cos_slope_bg=1.0
+    ):
+        """Isotropic scattering from nearby terrain."""
+        v_t = (1 + cos_slope) / 2 - geom.skyview_factor
+        v_t_avg = (1 + cos_slope_bg) / 2 - skyview_factor_bg
+        t = 1 + ((geom.bg_rfl * v_t) / (1 - geom.bg_rfl * v_t_avg))
+        return t
+
+    def terrain_rereflection_homogeneous(
+        self, geom, skyview_factor_bg=1.0, cos_slope=1.0, cos_slope_bg=1.0
+    ):
+        """Terrain scattering is ignored in the case dir_dir=dir_dif=dif_dir=dif_dif."""
+        return 1.0
 
     def calc_Ls(self, x, geom):
         """Calculate the surface emission."""

--- a/isofit/core/multistate.py
+++ b/isofit/core/multistate.py
@@ -271,13 +271,8 @@ def update_config_for_surface(config, surface_class_str, clouds=True):
     if not isurface:
         raise KeyError("Multi-surface flag used, but no valid multi-surface config")
 
-    surface_category = isurface.get("surface_category")
-    surface_file = isurface.get("surface_file")
-    glint_model = isurface.get("glint_model")
-
-    config.forward_model.surface.surface_category = surface_category
-    config.forward_model.surface.surface_file = surface_file
-    config.forward_model.surface.glint_model = glint_model
+    # Iterate through the kwargs in the Surfaces sub dict
+    config.forward_model.surface.update_from_subconfig(isurface)
 
     # Experimental: added statevector elements
     for key, value in isurface.get("rt_statevector_elements", {}).items():

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -269,10 +269,17 @@ def invert_analytical(
 
     # Path radiance and spherical albedo
     L_atm = fm.atmosphere.get_L_atm(x_atmosphere, geom)
-    s = r["sphalb"]
+    s_alb = r["sphalb"]
 
-    # Background conditions equal to the superpixel reflectance
-    bg = s * rho_dif_dir
+    # Estimation of background radiance (background terms assumed rho_dir_dif ~= rho_dif_dif)
+    L_bg = fm.calc_rdn_bg(
+        rho_dir_dif=rho_dif_dif,
+        rho_dif_dif=rho_dif_dif,
+        L_dir_dif=L_dir_dif,
+        L_dif_dif=L_dif_dif,
+        L_tot=L_tot,
+        s_alb=s_alb,
+    )
 
     # Get superpixel EOF shift if used
     eof_offset = fm.eof_offset(sub_instrument)
@@ -286,7 +293,6 @@ def invert_analytical(
 
     # The H matrix does not change as a function of x-vector
     H = fm.surface.analytical_model(
-        bg,
         L_tot=L_tot,
         geom=geom,
         L_dir_dir=L_dir_dir,
@@ -325,7 +331,7 @@ def invert_analytical(
         LI_rcond = dpotrf(P_rcond)[0]
         C_rcond = dpotri(LI_rcond)[0]
 
-        y = meas[winidx] - L_atm[winidx] - eof_offset[winidx]
+        y = meas[winidx] - L_atm[winidx] - eof_offset[winidx] - L_bg[winidx]
         xk = dsymv(
             1,
             C_rcond,

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -261,6 +261,7 @@ def invert_analytical(
         if isinstance(geom.bg_rfl, np.ndarray)
         else rho_dif_dir
     )
+    geom.bg_rfl = rho_dif_dif
 
     # Get all the atmosphere quantities
     r, L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = (
@@ -272,7 +273,7 @@ def invert_analytical(
     s_alb = r["sphalb"]
 
     # Estimation of background radiance (background terms assumed rho_dir_dif ~= rho_dif_dif)
-    L_bg = fm.calc_rdn_bg(
+    L_bg = fm.calc_rdn_bgrfl(
         rho_dir_dif=rho_dif_dif,
         rho_dif_dif=rho_dif_dif,
         L_dir_dif=L_dir_dif,
@@ -295,6 +296,7 @@ def invert_analytical(
     H = fm.surface.analytical_model(
         L_tot=L_tot,
         geom=geom,
+        s_alb=s_alb,
         L_dir_dir=L_dir_dir,
         L_dir_dif=L_dir_dif,
         L_dif_dir=L_dif_dir,

--- a/isofit/surface/surface.py
+++ b/isofit/surface/surface.py
@@ -81,6 +81,8 @@ class Surface:
         if self.wl is not None:
             self.n_wl = len(self.wl)
 
+        self.use_background_rfl = config.use_background_rfl
+
     def resample_reflectance(self):
         """Make sure model wavelengths align with the wavelength file."""
 

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -356,6 +356,7 @@ class GlintModelSurface(MultiComponentSurface):
         self,
         L_tot,
         geom,
+        s_alb=None,
         L_dir_dir=None,
         L_dir_dif=None,
         L_dif_dir=None,
@@ -377,6 +378,7 @@ class GlintModelSurface(MultiComponentSurface):
         H = super().analytical_model(
             L_tot,
             geom,
+            s_alb,
             L_dir_dir,
             L_dir_dif,
             L_dif_dir,

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -318,7 +318,15 @@ class GlintModelSurface(MultiComponentSurface):
         # Dimensions should be (len(RT.wl), len(x_surface))
         # which is correctly handled by the instrument resampling
         drdn_dsurface = np.zeros(drfl_dsurface.shape)
-        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
+        drdn_drfl = self.drdn_drfl(
+            L_tot,
+            s_alb,
+            rho_dif_dir,
+            L_dir_dir=L_dir_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dir=L_dif_dir,
+            L_dif_dif=L_dif_dif,
+        )
         drdn_dsurface[:, : self.n_wl] = np.multiply(
             drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
         )
@@ -346,7 +354,6 @@ class GlintModelSurface(MultiComponentSurface):
 
     def analytical_model(
         self,
-        background,
         L_tot,
         geom,
         L_dir_dir=None,
@@ -368,7 +375,6 @@ class GlintModelSurface(MultiComponentSurface):
         # gam (sun glint portion)
         # ep (sky glint portion)
         H = super().analytical_model(
-            background,
             L_tot,
             geom,
             L_dir_dir,
@@ -381,16 +387,14 @@ class GlintModelSurface(MultiComponentSurface):
         # It must match the alphabeitcal order of the glint terms
 
         # Diffuse portion
-        ep = (
-            (L_dif_dir + L_dif_dif) + ((L_tot * background) / (1 - background))
-        ) * rho_ls
+        ep = L_dif_dir * rho_ls
         # If you ignore multi-scattering
         # ep = (L_dif_dir + L_dif_dif) * rho_ls
         ep = np.reshape(ep, (len(ep), 1))
         H = np.append(H, ep, axis=1)
 
         # Direct portion
-        gam = (L_dir_dir + L_dir_dif) * rho_ls
+        gam = L_dir_dir * rho_ls
         gam = np.reshape(gam, (len(gam), 1))
         H = np.append(H, gam, axis=1)
 

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -88,9 +88,17 @@ class LUTSurface(Surface):
         # Change this if you don't want to analytical solve for all the full statevector elements.
         self.analytical_iv_idx = np.arange(len(self.statevec_names))
 
+        if self.use_background_rfl:
+            self.drdn_drfl = self.drdn_drfl_heterogeneous_bkg
+        else:
+            self.drdn_drfl = self.drdn_drfl_homogeneous_bkg
+
+
     def update_heuristic_prior_means(self, x_surface, geom):
         """Don't update any of the priors. Return xa"""
         return self.xa(x_surface, geom)
+
+
 
     def xa(self, x_surface, geom):
         """Mean of prior distribution."""
@@ -191,10 +199,18 @@ class LUTSurface(Surface):
 
         return dlamb
 
-    def drdn_drfl(self, L_tot, s_alb, rho_dif_dir):
+    def drdn_drfl_heterogeneous_bkg(
+        self, L_tot, s_alb, rho_dif_dir, L_dir_dir, L_dir_dif, L_dif_dir, L_dif_dif
+    ):
         """Partial derivative of radiance with respect to
-        surface reflectance"""
+        surface reflectance, treating dir-dif and dif-dif as constants."""
+        return L_dir_dir + (L_dif_dir / (1.0 - s_alb * rho_dif_dir))
 
+    def drdn_drfl_homogeneous_bkg(
+        self, L_tot, s_alb, rho_dif_dir, L_dir_dir, L_dir_dif, L_dif_dir, L_dif_dif
+    ):
+        """Partial derivative of radiance with respect to
+        surface reflectance (dir-dir = dif-dir = dir-dif = dif-dif)."""
         return L_tot / ((1.0 - s_alb * rho_dif_dir) ** 2)
 
     def calc_Ls(self, x_surface, geom):
@@ -235,7 +251,15 @@ class LUTSurface(Surface):
         drdn_dLs = t_total_up
 
         drdn_dsurface = np.zeros(drfl_dsurface.shape)
-        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
+        drdn_drfl = self.drdn_drfl(
+            L_tot,
+            s_alb,
+            rho_dif_dir,
+            L_dir_dir=L_dir_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dir=L_dif_dir,
+            L_dif_dif=L_dif_dif,
+        )
 
         # Construct the output matrix:
         # Dimensions should be (len(RT.wl), len(x_surface))
@@ -251,9 +275,9 @@ class LUTSurface(Surface):
 
     def analytical_model(
         self,
-        background,
         L_tot,
         geom,
+        s_alb=None,
         L_dir_dir=None,
         L_dir_dif=None,
         L_dif_dir=None,

--- a/isofit/surface/surface_lut.py
+++ b/isofit/surface/surface_lut.py
@@ -93,12 +93,9 @@ class LUTSurface(Surface):
         else:
             self.drdn_drfl = self.drdn_drfl_homogeneous_bkg
 
-
     def update_heuristic_prior_means(self, x_surface, geom):
         """Don't update any of the priors. Return xa"""
         return self.xa(x_surface, geom)
-
-
 
     def xa(self, x_surface, geom):
         """Mean of prior distribution."""

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -119,6 +119,14 @@ class MultiComponentSurface(Surface):
             self.Sa_inv_normalized.append(Cinv_normalized)
             self.Sa_inv_sqrt_normalized.append(Cinv_sqrt_normalized)
 
+        # Determine surface derivatives depending on definitions for reflectance used
+        if self.use_background_rfl:
+            self.drdn_drfl = self.drdn_drfl_heterogeneous_bgrfl
+            self.evaluate_theta = self.evaluate_theta_heterogeneous_bgrfl
+        else:
+            self.drdn_drfl = self.drdn_drfl_homogeneous_bgrfl
+            self.evaluate_theta = self.evaluate_theta_homogeneous_bgrfl
+
     def component(self, x, geom):
         """We pick a surface model component using a distance metric.
 
@@ -275,15 +283,19 @@ class MultiComponentSurface(Surface):
 
         return np.concatenate((prefix, dlamb, suffix), axis=1)
 
-    def drdn_drfl(
+    def drdn_drfl_heterogeneous_bgrfl(
         self, L_tot, s_alb, rho_dif_dir, L_dir_dir, L_dir_dif, L_dif_dir, L_dif_dif
     ):
         """Partial derivative of radiance with respect to
-        surface reflectance"""
-        if self.use_background_rfl:
-            return L_dir_dir + (L_dif_dir / (1.0 - s_alb * rho_dif_dir))
-        else:
-            return L_tot / ((1.0 - s_alb * rho_dif_dir) ** 2)
+        surface reflectance, treating dir-dif and dif-dif as constants."""
+        return L_dir_dir + (L_dif_dir / (1.0 - s_alb * rho_dif_dir))
+
+    def drdn_drfl_homogeneous_bgrfl(
+        self, L_tot, s_alb, rho_dif_dir, L_dir_dir, L_dir_dif, L_dif_dir, L_dif_dif
+    ):
+        """Partial derivative of radiance with respect to
+        surface reflectance (dir_dir=dir_dif=dif_dir=dif_dif)."""
+        return L_tot / ((1.0 - s_alb * rho_dif_dir) ** 2)
 
     def calc_Ls(self, x_surface, geom):
         """Emission of surface, as a radiance."""
@@ -351,6 +363,7 @@ class MultiComponentSurface(Surface):
         self,
         L_tot,
         geom,
+        s_alb=None,
         L_dir_dir=None,
         L_dir_dif=None,
         L_dif_dir=None,
@@ -360,15 +373,40 @@ class MultiComponentSurface(Surface):
         Linearization of the surface reflectance terms to use in the
         AOE inner loop (see Susiluoto, 2025).
         """
-        if type(L_dir_dir) != np.ndarray or len(L_dir_dir) == 1:
-            theta = L_tot
-        else:
-            theta = L_dir_dir + L_dif_dir
+
+        theta = self.evaluate_theta(
+            s_alb, geom, L_tot, L_dir_dir, L_dir_dif, L_dif_dir, L_dif_dif
+        )
 
         H = np.eye(self.n_wl, self.n_wl)
         H = theta[:, np.newaxis] * H
 
         return H
+
+    def evaluate_theta_homogeneous_bgrfl(
+        self,
+        s_alb,
+        geom,
+        L_tot,
+        L_dir_dir,
+        L_dir_dif,
+        L_dif_dir,
+        L_dif_dif,
+    ):
+        return L_tot + (L_tot * (geom.bg_rfl * s_alb) / (1 - (geom.bg_rfl * s_alb)))
+
+    def evaluate_theta_heterogeneous_bgrfl(
+        self,
+        s_alb,
+        geom,
+        L_tot,
+        L_dir_dir,
+        L_dir_dif,
+        L_dif_dir,
+        L_dif_dif,
+    ):
+
+        return L_dir_dir + L_dif_dir
 
     def summarize(self, x_surface, geom):
         """Summary of state vector."""

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -275,11 +275,15 @@ class MultiComponentSurface(Surface):
 
         return np.concatenate((prefix, dlamb, suffix), axis=1)
 
-    def drdn_drfl(self, L_tot, s_alb, rho_dif_dir):
+    def drdn_drfl(
+        self, L_tot, s_alb, rho_dif_dir, L_dir_dir, L_dir_dif, L_dif_dir, L_dif_dif
+    ):
         """Partial derivative of radiance with respect to
         surface reflectance"""
-
-        return L_tot / ((1.0 - s_alb * rho_dif_dir) ** 2)
+        if self.use_background_rfl:
+            return L_dir_dir + (L_dif_dir / (1.0 - s_alb * rho_dif_dir))
+        else:
+            return L_tot / ((1.0 - s_alb * rho_dif_dir) ** 2)
 
     def calc_Ls(self, x_surface, geom):
         """Emission of surface, as a radiance."""
@@ -324,7 +328,15 @@ class MultiComponentSurface(Surface):
         # Dimensions should be (len(RT.wl), len(x_surface))
         # which is correctly handled by the instrument resampling
         drdn_dsurface = np.zeros(drfl_dsurface.shape)
-        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
+        drdn_drfl = self.drdn_drfl(
+            L_tot,
+            s_alb,
+            rho_dif_dir,
+            L_dir_dir=L_dir_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dir=L_dif_dir,
+            L_dif_dif=L_dif_dif,
+        )
 
         drdn_dsurface[:, : self.n_wl] = np.multiply(
             drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]
@@ -337,7 +349,6 @@ class MultiComponentSurface(Surface):
 
     def analytical_model(
         self,
-        background,
         L_tot,
         geom,
         L_dir_dir=None,
@@ -347,14 +358,12 @@ class MultiComponentSurface(Surface):
     ):
         """
         Linearization of the surface reflectance terms to use in the
-        AOE inner loop (see Susiluoto, 2025). We set the quadratic
-        spherical albedo term to a constant background, which
-        simplifies the linearization
-        background = s * rho_bg
+        AOE inner loop (see Susiluoto, 2025).
         """
-        # If you ignore multi-scattering
-        theta = L_tot + (L_tot * background / (1 - background))
-        # theta = L_tot
+        if type(L_dir_dir) != np.ndarray or len(L_dir_dir) == 1:
+            theta = L_tot
+        else:
+            theta = L_dir_dir + L_dif_dir
 
         H = np.eye(self.n_wl, self.n_wl)
         H = theta[:, np.newaxis] * H

--- a/isofit/surface/surface_thermal.py
+++ b/isofit/surface/surface_thermal.py
@@ -168,7 +168,15 @@ class ThermalSurface(MultiComponentSurface):
         # Dimensions should be (len(RT.wl), len(x_surface))
         # which is correctly handled by the instrument resampling
         drdn_dsurface = np.zeros(drfl_dsurface.shape)
-        drdn_drfl = self.drdn_drfl(L_tot, s_alb, rho_dif_dir)
+        drdn_drfl = self.drdn_drfl(
+            L_tot,
+            s_alb,
+            rho_dif_dir,
+            L_dir_dir=L_dir_dir,
+            L_dir_dif=L_dir_dif,
+            L_dif_dir=L_dif_dir,
+            L_dif_dif=L_dif_dif,
+        )
 
         drdn_dsurface[:, : self.n_wl] = np.multiply(
             drdn_drfl[:, np.newaxis], drfl_dsurface[:, : self.n_wl]

--- a/isofit/test/test_forward.py
+++ b/isofit/test/test_forward.py
@@ -185,6 +185,7 @@ def test_get_L_coupled_nadir_sum():
     geom.cos_i = 1.0
     geom.skyview_factor = 1.0
     geom.bg_rfl = None
+    fm.terrain_rereflection = MagicMock(return_value=1.0)
 
     L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = ForwardModel.get_L_coupled(
         fm, r, geom, rho_dif_dif=0
@@ -210,6 +211,7 @@ def test_get_L_coupled_cos_i_scaling():
     geom.cos_i = 0.5
     geom.skyview_factor = 1.0
     geom.bg_rfl = None
+    fm.terrain_rereflection = MagicMock(return_value=1.0)
 
     L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = ForwardModel.get_L_coupled(
         fm, r, geom, rho_dif_dif=0

--- a/isofit/test/test_forward.py
+++ b/isofit/test/test_forward.py
@@ -184,6 +184,7 @@ def test_get_L_coupled_nadir_sum():
     geom.coszen = 1.0
     geom.cos_i = 1.0
     geom.skyview_factor = 1.0
+    geom.bg_rfl = None
 
     L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = ForwardModel.get_L_coupled(
         fm, r, geom, rho_dif_dif=0
@@ -208,6 +209,7 @@ def test_get_L_coupled_cos_i_scaling():
     geom.coszen = 1.0
     geom.cos_i = 0.5
     geom.skyview_factor = 1.0
+    geom.bg_rfl = None
 
     L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif = ForwardModel.get_L_coupled(
         fm, r, geom, rho_dif_dif=0

--- a/isofit/utils/adjacency.py
+++ b/isofit/utils/adjacency.py
@@ -1,0 +1,213 @@
+#! /usr/bin/env python3
+#
+#  Copyright 2019 California Institute of Technology
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ISOFIT: Imaging Spectrometer Optimal FITting
+# Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
+#
+import logging
+import numpy as np
+from spectral.io import envi
+from scipy.ndimage import uniform_filter
+
+from isofit.core.common import envi_header
+from isofit.utils.algebraic_line import algebraic_line
+from isofit.core.forward import ForwardModel
+from isofit.core.units import m_to_km, km_to_m
+from isofit.configs import configs
+from isofit.core.multistate import update_config_for_surface
+from isofit.core.fileio import initialize_output
+from isofit.utils import extractions, reducers
+
+
+def approx_pixel_size(loc, nodata_value=-9999):
+    """Average, approximate pixel size assuming planar locally (units in m)."""
+    R = 6371000.0
+
+    valid_pixels = np.logical_not(np.any(loc == nodata_value, axis=2))
+
+    # determine if lat/lon or N/E
+    sample_coords = loc[np.where(np.all(loc != nodata_value, axis=-1))]
+    is_lat_lon = np.nanmax(np.abs(sample_coords[0, :2])) <= 180
+
+    if is_lat_lon:
+        lon = np.radians(loc[..., 0])
+        lat = np.radians(loc[..., 1])
+
+        dx = R * np.sqrt(
+            (lat[:, 1:] - lat[:, :-1]) ** 2
+            + (np.cos(lat[:, :-1]) * (lon[:, 1:] - lon[:, :-1])) ** 2
+        )
+        dy = R * np.sqrt(
+            (lat[1:, :] - lat[:-1, :]) ** 2
+            + (np.cos(lat[:-1, :]) * (lon[1:, :] - lon[:-1, :])) ** 2
+        )
+    else:
+        dx = np.sqrt(np.sum(np.diff(loc[..., :2], axis=1) ** 2, axis=-1))
+        dy = np.sqrt(np.sum(np.diff(loc[..., :2], axis=0) ** 2, axis=-1))
+
+    pix_size = 0.5 * (
+        np.nanmean(dx[valid_pixels[:, 1:]]) + np.nanmean(dy[valid_pixels[1:, :]])
+    )
+
+    return pix_size
+
+
+def get_adjacency_range(sensor_alt_asl, ground_alt_asl, R_sat=1.0, min_range=0.2):
+    """Estimate adjacency range based on Richter et al. (2011)."""
+    # for satellite case
+    if sensor_alt_asl > 95.0:
+        r = R_sat
+    # for airborne case
+    else:
+        z_rel = sensor_alt_asl - ground_alt_asl
+        R1 = R_sat * (1 - np.exp(-z_rel / 8))
+        R2 = R_sat * (1 - np.exp(-ground_alt_asl / 8))
+        r = R1 - R2
+
+    if r < min_range:
+        r = min_range
+
+    if r > R_sat:
+        r = R_sat
+
+    return r
+
+
+def background_reflectance(
+    input_radiance,
+    input_loc,
+    input_obs,
+    paths,
+    mean_altitude_km,
+    mean_elevation_km,
+    smoothing_sigma,
+    n_cores,
+    logging_level,
+    log_file,
+    chunksize,
+    use_slic_rfls=True,
+    use_superpixels=True,
+    nodata_value=-9999,
+):
+    """Aggregates background reflectance term from the presolve."""
+    R_SAT = 1.0  # assumed adjacency range of satellite [km]
+    MIN_RANGE = 0.2  # assumed min range [km]
+
+    conf = configs.create_new_config(paths.h2o_config_path)
+
+    # If using multisurface, we grab the first surface from the list
+    # TODO this is the only instance of this, but perhaps a config method
+    # could help catch this for other future cases.
+    if not conf.forward_model.surface.surface_category:
+        conf = update_config_for_surface(
+            conf, list(conf.forward_model.surface.Surfaces.keys())[0]
+        )
+
+    fm = ForwardModel(conf)
+    wl = fm.surface.wl
+
+    # Estimate pixel size and adjacency range in km (pixel size is approx. based on loc file)
+    loc = envi.open(envi_header(input_loc), input_loc).open_memmap()
+    rows, cols, _ = loc.shape
+    pixel_size = m_to_km(approx_pixel_size(loc=loc, nodata_value=nodata_value))
+    adj_range = get_adjacency_range(
+        sensor_alt_asl=mean_altitude_km,
+        ground_alt_asl=mean_elevation_km,
+        R_sat=R_SAT,
+        min_range=MIN_RANGE,
+    )
+    logging.info(
+        f"For background reflectance assuming pixel size of {km_to_m(pixel_size):.2f} m "
+        f"and adjacency range of {adj_range:.2f} km."
+    )
+
+    # Calls algebraic line using presolve config
+    if not use_slic_rfls:
+        algebraic_line(
+            rdn_file=input_radiance,
+            loc_file=input_loc,
+            obs_file=input_obs,
+            isofit_config=paths.h2o_config_path,
+            segmentation_file=paths.lbl_working_path,
+            isofit_dir=None,
+            atm_file=paths.atm_presolve,
+            atm_sigma=smoothing_sigma,
+            output_rfl_file=paths.bgrfl_working_path,
+            n_cores=n_cores,
+            logging_level=logging_level,
+            log_file=log_file,
+        )
+        bg_rfl = envi.open(
+            envi_header(paths.bgrfl_working_path), paths.bgrfl_working_path
+        ).open_memmap(interleave="bip", writable=True)
+
+    # else, falls back to weighting the superpixel rfl directly
+    else:
+        rfl_output = initialize_output(
+            output_metadata={
+                "data type": 4,
+                "file type": "ENVI Standard",
+                "byte order": 0,
+                "no data value": nodata_value,
+                "wavelength units": "Nanometers",
+                "wavelength": wl,
+                "lines": rows,
+                "samples": cols,
+                "interleave": "bip",
+            },
+            outpath=paths.bgrfl_working_path,
+            out_shape=(rows, cols, len(wl)),
+            bands=f"{len(wl)}",
+            description="Background reflectance for each pixel used in OE inversion",
+        )
+        labels = (
+            envi.open(envi_header(paths.lbl_working_path), paths.lbl_working_path)
+            .load()
+            .squeeze()
+            .astype(int)
+        )
+        subs_state = envi.open(
+            envi_header(paths.h2o_subs_path), paths.h2o_subs_path
+        ).load()
+        bg_rfl = envi.open(envi_header(rfl_output), rfl_output).open_memmap(
+            interleave="bip", writable=True
+        )
+        rfl_samples = subs_state[:, 0, fm.idx_surf_rfl]
+        bg_rfl[:, :, :] = np.squeeze(rfl_samples[labels, :])
+
+    # For now, this applies a uniform window average based on adjacency range.
+    kernel_diameter = int(np.ceil(2 * np.max(adj_range) / pixel_size + 1))
+    bg_rfl[:, :, :] = uniform_filter(
+        bg_rfl, size=(kernel_diameter, kernel_diameter, 1), mode="nearest"
+    )
+
+    del bg_rfl, loc
+
+    # if using superpixels, we aggregate the bg rfl before OE
+    if use_superpixels:
+        extractions(
+            inputfile=paths.bgrfl_working_path,
+            labels=paths.lbl_working_path,
+            output=paths.bgrfl_subs_path,
+            chunksize=chunksize,
+            flag=nodata_value,
+            reducer=reducers.band_mean,
+            n_cores=n_cores,
+            loglevel=logging_level,
+            logfile=log_file,
+        )
+
+    return

--- a/isofit/utils/adjacency.py
+++ b/isofit/utils/adjacency.py
@@ -58,9 +58,11 @@ def approx_pixel_size(loc, nodata_value=-9999):
         dx = np.sqrt(np.sum(np.diff(loc[..., :2], axis=1) ** 2, axis=-1))
         dy = np.sqrt(np.sum(np.diff(loc[..., :2], axis=0) ** 2, axis=-1))
 
-    pix_size = 0.5 * (
-        np.nanmean(dx[valid_pixels[:, 1:]]) + np.nanmean(dy[valid_pixels[1:, :]])
-    )
+    # Mask pixels before taking nanmean
+    dx[~valid_pixels[:, 1:] | ~valid_pixels[:, :-1]] = np.nan
+    dy[~valid_pixels[1:, :] | ~valid_pixels[:-1, :]] = np.nan
+
+    pix_size = 0.5 * (np.nanmean(dx) + np.nanmean(dy))
 
     return pix_size
 

--- a/isofit/utils/adjacency.py
+++ b/isofit/utils/adjacency.py
@@ -105,8 +105,17 @@ def background_reflectance(
     nodata_value=-9999,
 ):
     """Aggregates background reflectance term from the presolve."""
-    R_SAT = 1.0  # assumed adjacency range of satellite [km]
-    MIN_RANGE = 0.2  # assumed min range [km]
+
+    # Assumed adjacency range of satellite [km]
+    R_SAT = 1.0
+
+    # Assumed min adjacency range [km]
+    MIN_RANGE = 0.2
+
+    # Option for scipy.ndimage.uniform_filter. This matters the most for scene edges.
+    # Setting this to 'nearest' is most likely saftest option for now...
+    # We could also think of more custom weighting treatments for borders in future.
+    UNIFORM_FILTER_MODE = "nearest"
 
     conf = configs.create_new_config(paths.h2o_config_path)
 
@@ -193,7 +202,7 @@ def background_reflectance(
     # For now, this applies a uniform window average based on adjacency range.
     kernel_diameter = int(np.ceil(2 * np.max(adj_range) / pixel_size + 1))
     bg_rfl[:, :, :] = uniform_filter(
-        bg_rfl, size=(kernel_diameter, kernel_diameter, 1), mode="nearest"
+        bg_rfl, size=(kernel_diameter, kernel_diameter, 1), mode=UNIFORM_FILTER_MODE
     )
 
     del bg_rfl, loc

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -77,6 +77,7 @@ def analytical_line(
     output_unc_file: str = None,
     atm_file: str = None,
     skyview_factor_file: str = None,
+    bgrfl_file: str = None,
     loglevel: str = "INFO",
     logfile: str = None,
     initializer: str = "algebraic",
@@ -309,6 +310,7 @@ def analytical_line(
             logfile,
             initializer,
             skyview_factor_file,
+            bgrfl_file,
         ]
         workers = ray.util.ActorPool([Worker.remote(*wargs) for _ in range(n_workers)])
 
@@ -371,6 +373,7 @@ class Worker(object):
         logfile: str,
         initializer: str,
         skyview_factor_file: str,
+        bgrfl_file: str,
     ):
         """
         Worker class to help run a subset of spectra.
@@ -425,6 +428,14 @@ class Worker(object):
             )
         else:
             self.svf = []
+
+        # Open background rfl file
+        if bgrfl_file:
+            self.bg_rfl = envi.open(envi_header(bgrfl_file)).open_memmap(
+                interleave="bip"
+            )
+        else:
+            self.bg_rfl = []
 
         # Lines and samples
         self.n_lines = self.rdn.shape[0]
@@ -523,6 +534,7 @@ class Worker(object):
                 loc=self.loc[r, c, :],
                 esd=self.esd,
                 svf=self.svf[r, c] if len(self.svf) else 1,
+                bg_rfl=self.bg_rfl[r, c, :] if len(self.bg_rfl) else None,
                 coszen=self.coszen,
                 full_config=self.config,
             )
@@ -680,6 +692,7 @@ class Worker(object):
 @click.option("--output_rfl_file", help="TODO", type=str, default=None)
 @click.option("--output_unc_file", help="TODO", type=str, default=None)
 @click.option("--skyview_factor_file", help="TODO", type=str, default=None)
+@click.option("--bgrfl_file", help="TODO", type=str, default=None)
 @click.option("--atm_file", help="TODO", type=str, default=None)
 @click.option("--loglevel", help="TODO", type=str, default="INFO")
 @click.option("--logfile", help="TODO", type=str, default=None)

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -867,6 +867,7 @@ def apply_oe(
         if presolve and use_background_rfl:
             # Only create background reflectance if it doesn't already exist in /data
             # NOTE this may be useful for our single pixel pytests
+            remove_bgrfl_file = False
             if not exists(paths.bgrfl_working_path) or (
                 use_superpixels and not exists(paths.bgrfl_subs_path)
             ):
@@ -887,6 +888,7 @@ def apply_oe(
                     log_file=log_file,
                     n_cores=n_cores,
                 )
+                remove_bgrfl_file = True
 
         if config_only:
             logging.info("`config_only` enabled, exiting early")
@@ -951,6 +953,19 @@ def apply_oe(
                 smoothing_sigma=atm_sigma,
                 segmentation_size=segmentation_size,
             )
+    # Remove any other large temporary files created during ApplyOE
+    if remove_bgrfl_file:
+        bgrfl_files_to_remove = [
+            paths.bgrfl_working_path,
+            envi_header(paths.bgrfl_working_path),
+        ]
+        if use_superpixels:
+            bgrfl_files_to_remove.extend(
+                [paths.bgrfl_subs_path, envi_header(paths.bgrfl_subs_path)]
+            )
+        for f in bgrfl_files_to_remove:
+            if os.path.exists(f):
+                os.remove(f)
 
     logging.info("Done.")
     ray.shutdown()

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -314,6 +314,11 @@ def apply_oe(
                 "If num_neighbors has multiple elements, only --analytical_line is valid"
             )
 
+    if use_background_rfl and not multipart_transmittance:
+        raise ValueError(
+            "ApplyOE must use multi-part transmittance to enable heterogeneous background reflectance."
+        )
+
     # Load in water column upper bound polynomials
     modtran_polynomials_dict = modtran_water_upperbound_polynomials()
     if atmosphere_type not in modtran_polynomials_dict:

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -314,11 +314,6 @@ def apply_oe(
                 "If num_neighbors has multiple elements, only --analytical_line is valid"
             )
 
-    if use_background_rfl and not presolve:
-        raise ValueError(
-            "Background reflectance can only be used if presolve is turned on."
-        )
-
     # Load in water column upper bound polynomials
     modtran_polynomials_dict = modtran_water_upperbound_polynomials()
     if atmosphere_type not in modtran_polynomials_dict:
@@ -449,6 +444,12 @@ def apply_oe(
     paths.make_directories()
     paths.stage_files()
     logging.info("...file/directory setup complete")
+
+    remove_bgrfl_file = False
+    if use_background_rfl and not presolve and not exists(paths.bgrfl_working_path):
+        raise ValueError(
+            "Background reflectance can only be computed if presolve is turned on."
+        )
 
     # Based on the sensor type, get appropriate year/month/day info from initial condition.
     # We'll adjust for line length and UTC day overrun later
@@ -858,6 +859,7 @@ def apply_oe(
         # This is here to allow presolve and bg_rfl to use superpixel speed up.
         if not (analytical_line or empirical_line):
             config_params["use_superpixels"] = False
+            use_superpixels = False
 
         tmpl.build_config(
             h2o_lut_grid=h2o_lut_grid,
@@ -867,7 +869,6 @@ def apply_oe(
         if presolve and use_background_rfl:
             # Only create background reflectance if it doesn't already exist in /data
             # NOTE this may be useful for our single pixel pytests
-            remove_bgrfl_file = False
             if not exists(paths.bgrfl_working_path) or (
                 use_superpixels and not exists(paths.bgrfl_subs_path)
             ):

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -31,6 +31,7 @@ from isofit.utils import (
     segment,
 )
 from isofit.utils.skyview import skyview
+from isofit.utils.adjacency import background_reflectance
 
 EPS = 1e-6
 CHUNKSIZE = 256
@@ -110,6 +111,7 @@ def apply_oe(
     skyview_factor=None,
     resources=False,
     retrieve_co2=False,
+    use_background_rfl=False,
     eof_path=None,
     terrain_style="dem",
     per_pixel_heuristic_prior=False,
@@ -253,6 +255,8 @@ def apply_oe(
         Enables the system resource tracker. Must also have the log_file set.
     retrieve_co2 : bool, default=False
         Flag to retrieve CO2 in the state vector. Only available with emulator at the moment.
+    use_background_rfl : bool, default=False
+        Flag to calculate background reflectance based on presolve. Presolve must also be turned on.
     eof_path : str, default=None
         Add 1 or 2 Empirical Orthogonal Functions to the state vector.  File is a 1-2 column text file
         with one number per instrument channel.
@@ -271,7 +275,7 @@ def apply_oe(
     N. Carmon, and R.O. Green. Generalized radiative transfer emulation for imaging spectroscopy reflectance
     retrievals. Remote Sensing of Environment, 261:112476, 2021.doi: 10.1016/j.rse.2021.112476.
     """
-    use_superpixels = empirical_line or analytical_line
+    use_superpixels = empirical_line or analytical_line or use_background_rfl
     use_multisurface = True if classify_multisurface or surface_class_file else False
 
     # Determine if we run in multipart-transmittance (4c) mode
@@ -309,6 +313,11 @@ def apply_oe(
             raise ValueError(
                 "If num_neighbors has multiple elements, only --analytical_line is valid"
             )
+
+    if use_background_rfl and not presolve:
+        raise ValueError(
+            "Background reflectance can only be used if presolve is turned on."
+        )
 
     # Load in water column upper bound polynomials
     modtran_polynomials_dict = modtran_water_upperbound_polynomials()
@@ -433,6 +442,7 @@ def apply_oe(
         skyview_factor=skyview_factor,
         subs=True if analytical_line or empirical_line else False,
         classify_multisurface=classify_multisurface,
+        use_background_rfl=use_background_rfl,
         dn_uncertainty_file=dn_uncertainty_file,
         eof_path=eof_path,
     )
@@ -672,6 +682,7 @@ def apply_oe(
         "segmentation_size": segmentation_size,
         "terrain_style": terrain_style,
         "per_pixel_heuristic_prior": per_pixel_heuristic_prior,
+        "use_background_rfl": use_background_rfl,
     }
     if presolve:
         # write modtran presolve template
@@ -843,10 +854,39 @@ def apply_oe(
             config_params["co2_lut_grid"] = lut_params.co2_range
             config_params["retrieve_co2"] = True
 
+        # Super pixels set to False now after presolve if not using AOE
+        # This is here to allow presolve and bg_rfl to use superpixel speed up.
+        if not (analytical_line or empirical_line):
+            config_params["use_superpixels"] = False
+
         tmpl.build_config(
             h2o_lut_grid=h2o_lut_grid,
             **config_params,
         )
+
+        if presolve and use_background_rfl:
+            # Only create background reflectance if it doesn't already exist in /data
+            # NOTE this may be useful for our single pixel pytests
+            if not exists(paths.bgrfl_working_path) or (
+                use_superpixels and not exists(paths.bgrfl_subs_path)
+            ):
+                logging.info("Preparing background reflectance...")
+                background_reflectance(
+                    input_radiance=input_radiance,
+                    input_loc=input_loc,
+                    input_obs=input_obs,
+                    paths=paths,
+                    mean_altitude_km=mean_altitude_km,
+                    mean_elevation_km=mean_elevation_km,
+                    smoothing_sigma=atm_sigma,
+                    use_slic_rfls=True,
+                    use_superpixels=use_superpixels,
+                    nodata_value=-9999,
+                    chunksize=CHUNKSIZE,
+                    logging_level=logging_level,
+                    log_file=log_file,
+                    n_cores=n_cores,
+                )
 
         if config_only:
             logging.info("`config_only` enabled, exiting early")
@@ -903,6 +943,7 @@ def apply_oe(
                 output_rfl_file=paths.rfl_working_path,
                 output_unc_file=paths.uncert_working_path,
                 skyview_factor_file=paths.svf_working_path,
+                bgrfl_file=paths.bgrfl_working_path,
                 loglevel=logging_level,
                 logfile=log_file,
                 n_atm_neighbors=nneighbors,
@@ -962,6 +1003,7 @@ def apply_oe(
 @click.option("--skyview_factor", type=str, default=None)
 @click.option("-r", "--resources", is_flag=True, default=False)
 @click.option("--retrieve_co2", is_flag=True, default=False)
+@click.option("--use_background_rfl", is_flag=True, default=False)
 @click.option("--eof_path", default=None)
 @click.option("--terrain_style", default="dem", type=click.Choice(["dem", "flat"]))
 @click.option("--per_pixel_heuristic_prior", is_flag=True, default=False)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -55,7 +55,7 @@ class Pathnames:
         skyview_factor=None,
         subs: bool = False,
         classify_multisurface: bool = False,
-        use_background_rfl: bool = True,
+        use_background_rfl: bool = False,
         dn_uncertainty_file: str = None,
         eof_path=None,
     ):

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -55,6 +55,7 @@ class Pathnames:
         skyview_factor=None,
         subs: bool = False,
         classify_multisurface: bool = False,
+        use_background_rfl: bool = True,
         dn_uncertainty_file: str = None,
         eof_path=None,
     ):
@@ -130,6 +131,17 @@ class Pathnames:
 
         self.surface_template_path = abspath(join(self.data_directory, "surface.mat"))
         self.surface_working_paths = {}
+
+        if use_background_rfl:
+            self.bgrfl_working_path = abspath(
+                join(self.data_directory, rdn_fname.replace("_rdn", "_bgrfl"))
+            )
+            self.atm_presolve = abspath(
+                join(self.output_directory, rdn_fname.replace("_rdn", "_atm_presolve"))
+            )
+        else:
+            self.bgrfl_working_path = None
+            self.atm_presolve = None
 
         if copy_input_files is True:
             self.radiance_working_path = abspath(
@@ -217,6 +229,13 @@ class Pathnames:
         else:
             self.svf_working_path = None
             self.svf_subs_path = None
+
+        if use_background_rfl:
+            self.bgrfl_subs_path = abspath(
+                join(self.input_data_directory, self.fid + "_subs_bgrfl")
+            )
+        else:
+            self.bgrfl_subs_path = None
 
         self.rdn_subs_path = abspath(
             join(self.input_data_directory, self.fid + "_subs_rdn")
@@ -702,6 +721,7 @@ def build_config(
     terrain_style: str = "flat",
     max_slope: float = 20.0,
     per_pixel_heuristic_prior: bool = False,
+    use_background_rfl: bool = False,
 ) -> None:
     """Write an isofit config file for the main solve, using the specified pathnames and all given info
 
@@ -734,6 +754,7 @@ def build_config(
         presolve:                             set this up as a presolve configuration
         terrain_style:                        style of terrain to use in the forward model - options are 'flat', 'dem', 'solved'
         max_slope:                            maximum terrain slope, used to inform minimum cos_i if terrain_style is not flat
+        use_background_rfl:                   flag to determine which surface derivatives to use in OE
     """
 
     if use_superpixels:
@@ -746,11 +767,13 @@ def build_config(
             state_output_path = paths.h2o_subs_path
             posterior_output_path = None
             rfl_output_path = None
+            bgrfl_input_path = None
 
         else:
             state_output_path = paths.state_subs_path
             posterior_output_path = paths.uncert_subs_path
             rfl_output_path = paths.rfl_subs_path
+            bgrfl_input_path = paths.bgrfl_subs_path
 
     else:
         rdn_input_path = paths.radiance_working_path
@@ -762,22 +785,25 @@ def build_config(
             state_output_path = paths.h2o_working_path
             posterior_output_path = None
             rfl_output_path = None
+            bgrfl_input_path = None
         else:
             state_output_path = paths.state_working_path
             posterior_output_path = paths.uncert_working_path
             rfl_output_path = paths.rfl_working_path
+            bgrfl_input_path = paths.bgrfl_working_path
 
     input_config = make_input_config(
-        rdn_input_path,
-        loc_input_path,
-        obs_input_path,
-        svf_input_path,
-        paths.rdn_factors_path,
+        rdn_input_path=rdn_input_path,
+        loc_input_path=loc_input_path,
+        obs_input_path=obs_input_path,
+        svf_input_path=svf_input_path,
+        rdn_factors_path=paths.rdn_factors_path,
+        bgrfl_path=bgrfl_input_path,
     )
     output_config = make_output_config(
-        state_output_path,
-        posterior_output_path,
-        rfl_output_path,
+        state_output_path=state_output_path,
+        posterior_output_path=posterior_output_path,
+        rfl_output_path=rfl_output_path,
     )
 
     config = {
@@ -831,6 +857,7 @@ def build_config(
                 use_superpixels=use_superpixels,
                 terrain_style=terrain_style,
                 max_slope=max_slope,
+                use_background_rfl=use_background_rfl,
             ),
         },
         "implementation": make_implementation_config(
@@ -1778,6 +1805,7 @@ def make_surface_config(
     terrain_style: str = "flat",
     max_slope: float = 20.0,
     surface_refractive_index_path: str = None,
+    use_background_rfl=False,
 ):
     # Initialize config dict
     surface_config_dict = {
@@ -1818,6 +1846,7 @@ def make_surface_config(
                 "surface_category": surface_category,
                 "terrain_style": terrain_style,
                 "max_slope": max_slope,
+                "use_background_rfl": use_background_rfl,
             }
 
     # Single surface run
@@ -1826,6 +1855,7 @@ def make_surface_config(
         surface_config_dict["surface_category"] = surface_category
         surface_config_dict["terrain_style"] = terrain_style
         surface_config_dict["max_slope"] = max_slope
+        surface_config_dict["use_background_rfl"] = use_background_rfl
 
     # Accumulate statevector
     for category, path in surface_working_paths.items():
@@ -1935,6 +1965,7 @@ def make_input_config(
     obs_input_path: str,
     svf_input_path: str = None,
     rdn_factors_path: str = None,
+    bgrfl_path: str = None,
 ):
     input_config = {}
     input_config["measured_radiance_file"] = rdn_input_path
@@ -1944,6 +1975,8 @@ def make_input_config(
         input_config["skyview_factor_file"] = svf_input_path
     if rdn_factors_path:
         input_config["radiometry_correction_file"] = rdn_factors_path
+    if bgrfl_path:
+        input_config["background_reflectance_file"] = bgrfl_path
 
     return input_config
 


### PR DESCRIPTION
## Overview

- This is similar to #815 , but has been worked into the new 4.0 framework. This is producing very similar results for me compared to previous runs on the old branch. 

   - I have also included the improved physical representation of trapped photons from terrain via #846 . 
      - Many approaches use two different spatial scales for the effect from terrain versus background. For instance, EnMAP uses 1.0 km for background, and 0.5 km for terrain ; [see page 41](https://www.enmap.org/data/doc/EN-PCV-TN-6007_Level_2A_Processor_Atmospheric_Correction_Land.pdf)). Right now, one adjacency scale is assumed, but is something we can update in the future. 

- Another change, is the filename `isofit/utils/adjacency.py` (instead of background_reflectance.py). Because  technically this same adjancecy-based smoothing could apply for terms other than reflectance. For instance, [`cos_i_bg`](https://github.com/isofit/isofit/blob/dev/isofit/core/forward.py#L398-L400) (which for now we assume to be coszen, but does not have to be) or the terrain reflectance could be other potential products. 

- Evan and others, we had looked at the surface derivatives a while back. And I think this is what we came up with, but this could certainly use a closer look. 
   - [`drdn_drfl`](https://github.com/brentwilder/isofit/blob/bgrfl40/isofit/surface/surface_multicomp.py#L275-L283)

   - [glint AOE derivatives ](https://github.com/brentwilder/isofit/blob/bgrfl40/isofit/surface/surface_glint_model.py#L359-L371)

- Another thing that has been bugging me is the resulting files remain in the working directory (e.g.,  `/output/data/emit20250327_bgrfl.hdr`). But these are large files and likely not needed by the user.

   - And so, I've added a check here that removes bgrfl files after ApplyOE (if created during the run). In other words, if we built a test that had the bgrfl files already present (or was ran with `config_only`), this check to delete file would be bypassed. 

- I have included a slight modification to the [Lake Mary default args](https://github.com/isofit/isofit-tutorials/pull/54) , so that way this is always tested for this specific example on the github workflows. Niklas and I have shown in many figures adjacency effects were prevalent in this example and so adding this as the default I think will be valuable, especially if/once the 6C tests begin to run on workflows. 



## Lake Mary test

### Single pixel
<img width="1139" height="949" alt="Screenshot 2026-06-15 at 10 48 30" src="https://github.com/user-attachments/assets/e73ccc72-2ab5-4b56-8492-ed18f0e64878" />

#### **RMSE for wavelengths less than 1200 nm:**
- dev: 0.077
- L2A V001: 0.082
- bg_rfl = 0.072
- bg_rfl + dozier terrain trapping = 0.055 (**This PR)**
- 
- DISORT snow model = 0.038
- DISORT snow model (w/out accounting for adjacency) = 0.066


This PR, is essentially the same physics as the DISORT snow model we have been testing, minus a few small differences that could explain the different RMSE:
1. MODTRAN RT was used for DISORT ... vs 6c-emulator for the PR
2. Used 0.5 km adjacency scale for terrain in snow model
3. Used a weighted average in snow model instead of equally weighted average (see below... TLDR; closer pixels to target pixel are weighted more heavily):

```python
  # weights based on example in Richter 1998, `Correction of satellite imagery over mountainous terrain`
  radii_frac = [0.0, 0.45, 0.65, 0.80, 0.90, 1.0] # distance to target pixel in kilometers
  weights = [0.24, 0.24, 0.22, 0.15, 0.15] # weight assigned to the aggregation
```

Interestingly, the relative gain from this PR is similar between snow model runs (0.066-0.038=0.028) and the more typical multicomponent surface Isofit runs (0.077-0.055=0.022). 



