### PR TITLE
Algorithm to bound AOE solutions 4.0

### DIFF
--- a/isofit/atmosphere/atmosphere.py
+++ b/isofit/atmosphere/atmosphere.py
@@ -131,6 +131,11 @@ class BaseAtmosphere(Reader):
         self.lut_names = list(self.lut_grid)
         self.statevec_names = self.config.statevector.get_element_names()
 
+        possible_h2o_names = ["H2OSTR", "h2o"]
+        self.h2o_i = [
+            i for i, v in enumerate(possible_h2o_names) if v in self.statevec_names
+        ]
+
         # Configure and exit flag
         self.configure_and_exit = self.config.configure_and_exit
 
@@ -292,9 +297,18 @@ class BaseAtmosphere(Reader):
             Logger.error(error)
             raise AttributeError(error)
 
-    def xa(self):
+    def xa(self, x_atmosphere, geom):
         """Pull the priors from each of the individual RTs."""
-        return self.prior_mean
+        xa = self.prior_mean.copy()
+        if self.h2o_i:
+            if hasattr(geom, "atm_h2o_init"):
+                xa_h2o = geom.atm_h2o_init
+            else:
+                xa_h2o = x_atmosphere[self.h2o_i]
+                geom.atm_h2o_init = xa_h2o
+
+            xa[self.h2o_i] = xa_h2o
+        return xa
 
     def Sa(self):
         """Pull the priors from each of the individual RTs."""

--- a/isofit/atmosphere/atmosphere.py
+++ b/isofit/atmosphere/atmosphere.py
@@ -133,7 +133,7 @@ class BaseAtmosphere(Reader):
 
         possible_h2o_names = ["H2OSTR", "h2o"]
         self.h2o_i = [
-            i for i, v in enumerate(possible_h2o_names) if v in self.statevec_names
+            i for i, v in enumerate(self.statevec_names) if v in possible_h2o_names
         ]
 
         # Configure and exit flag

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -123,6 +123,9 @@ class SurfaceConfig(BaseConfigSection):
         This can avoid runaway results at low cos_i values where diffuse radiance dominates.
         """
 
+        self._refractive_index_path_type = str
+        self.refractive_index_path = ""
+
         self.set_config_options(sub_configdic)
 
     def _check_config_validity(self) -> List[str]:

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -61,7 +61,7 @@ class ForwardModel:
     noise for the purpose of weighting the measurement information
     against the prior."""
 
-    def __init__(self, full_config: Config, cache_atmosphere: Atmosphere = None):
+    def __init__(self, full_config: Config, cache_atmosphere: Atmosphere = False):
         # load in the full config (in case of inter-module dependencies) and
         # then designate the current config
         self.full_config = full_config

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -176,9 +176,9 @@ class ForwardModel:
         this is so we can calculate the local prior.
         """
 
-        x_surface = x[self.idx_surface]
+        x_surface, x_atmosphere, x_instrument = self.unpack(x)
         xa_surface = self.surface.xa(x_surface, geom)
-        xa_atmosphere = self.atmosphere.xa()
+        xa_atmosphere = self.atmosphere.xa(x_atmosphere, geom)
         xa_instrument = self.instrument.xa()
         return np.concatenate((xa_surface, xa_atmosphere, xa_instrument), axis=0)
 

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -156,13 +156,6 @@ class Geometry:
                     "coszen is not defined and valid solar zenith not found in OBS data."
                 )
 
-        if self.use_universal_coszen:
-            logging.debug(f"The coszen will be universal:   coszen={coszen}")
-        else:
-            logging.info(
-                f"The coszen is pixel dependent and will based on the OBS data"
-            )
-
         if self.coszen is not None:
 
             # Pretend that the surface is flat, regardless of input geometry

--- a/isofit/inversion/inverse_analytical.py
+++ b/isofit/inversion/inverse_analytical.py
@@ -1,0 +1,277 @@
+#! /usr/bin/env python3
+#
+#  Copyright 2018 California Institute of Technology
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ISOFIT: Imaging Spectrometer Optimal FITting
+# Author: David R Thompson, david.r.thompson@jpl.nasa.gov
+from __future__ import annotations
+
+from typing import OrderedDict
+
+import numpy as np
+from scipy.linalg.blas import dsymv
+from scipy.linalg.lapack import dpotrf, dpotri
+
+from isofit.core.common import eps
+
+
+def map_solve(L, P, prprod, Sa_inv, y, iv_idx):
+    P_tilde = ((L.T @ P) @ L).T
+    P_rcond = Sa_inv[iv_idx, :][:, iv_idx] + P_tilde
+
+    LI_rcond = dpotrf(P_rcond)[0]
+    C_rcond = dpotri(LI_rcond)[0]
+
+    xk = dsymv(
+        1,
+        C_rcond,
+        (L.T @ dsymv(1, P, y) + prprod[iv_idx]),
+    )
+
+    return xk, C_rcond
+
+
+def map_solve_constrained(
+    L: np.ndarray,
+    iv_idx: np.ndarray,
+    Sa_inv: np.ndarray,
+    P: np.ndarray,
+    y: np.ndarray,
+    prprod: np.ndarray,
+    bounds: np.ndarray,
+    n_max_fixed: int,
+    chunk_n: int = -1,
+):
+    """More complex solver that iteratively enforces bounds on AOE solutions.
+    It does this by "freezing" the index of the n-"greatest" bounds violation.
+    It uses a for loop to deal with the covariance constraint between statevector elements.
+    """
+    n = len(iv_idx)
+    fixed_set = np.zeros((n, 2), dtype=bool)
+    free_mask = np.min(~fixed_set, axis=1)
+    y_constrained = y.copy()
+    Py = dsymv(1, P, y_constrained)
+    P_tilde_0 = (L.T @ P) @ L
+    for _ in range(n_max_fixed + 1):
+        iv_free = iv_idx[free_mask]
+        L_free = L[:, free_mask]
+        free_local = np.where(free_mask)[0]
+
+        # Don't need to recompute every iter. Can just slice.
+        P_tilde = P_tilde_0[np.ix_(free_local, free_local)]
+        P_rcond = Sa_inv[np.ix_(iv_free, iv_free)] + P_tilde
+        LI = dpotrf(P_rcond)[0]
+        C_free = dpotri(LI)[0]
+
+        xk_free = dsymv(
+            1,
+            C_free,
+            (L_free.T @ Py + prprod[iv_free]),
+        )
+
+        # Reconstruct full solution
+        xk = np.zeros(n)
+        xk[free_mask] = xk_free
+        xk[~free_mask] = bounds[fixed_set]
+
+        # Bounds check
+        violations = np.zeros((n, 2), dtype=bool)
+        violations[xk < bounds[:, 0], 0] = True
+        violations[xk > bounds[:, 1], 1] = True
+
+        # Found solution
+        if not np.any(violations):
+            break
+
+        # Replace the n-worst offenders
+        violation_magnitudes = violations * np.concatenate(
+            [
+                ((bounds[:, 0] - xk) / (bounds[:, 0] + eps) ** 2)[..., None],
+                ((xk - bounds[:, 1]) / (bounds[:, 1] + eps) ** 2)[..., None],
+            ],
+            axis=1,
+        )
+
+        n_violations = np.sum(violation_magnitudes > 0)
+        if chunk_n == -1 or chunk_n >= n_violations:
+            worst = np.where(violation_magnitudes > 0)
+        else:
+            worst = np.unravel_index(
+                np.argpartition(violation_magnitudes.ravel(), -chunk_n)[-chunk_n:],
+                violations.shape,
+            )
+        fixed_set[worst[0], worst[1]] = True
+        free_mask = ~np.any(fixed_set, axis=1)
+
+        # Subtract active (fixed) variable contributions from y
+        delta = L[:, worst[0]] @ bounds[worst[0], worst[1]]
+        y_constrained -= delta
+        Py = dsymv(1, P, y_constrained)
+
+    C_rcond = np.zeros((n, n))
+    C_rcond[np.ix_(free_mask, free_mask)] = C_free
+    # Set the posterior uncertainty to prior variance in the fixed cases
+    fixed_mask = ~free_mask
+    C_rcond[fixed_mask, fixed_mask] = (
+        1.0 / Sa_inv[iv_idx[fixed_mask], iv_idx[fixed_mask]]
+    )
+
+    return xk, C_rcond, fixed_mask
+
+
+def invert_analytical(
+    fm: ForwardModel,
+    winidx: np.array,
+    meas: np.array,
+    geom: Geometry,
+    x0: np.array,
+    sub_state,
+    num_iter: int = 1,
+    hash_table: OrderedDict = None,
+    hash_size: int = None,
+    diag_uncert: bool = True,
+    outside_ret_const: float = -0.01,
+    fill_value: float = -9999.0,
+    enforce_bounds: bool = True,
+):
+    """Perform an analytical estimate of the conditional MAP estimate for
+    a fixed atmosphere.  Based on the "Inner loop" from Susiluoto et al. (2025).
+    doi: https://doi.org/10.3390/rs17223719
+
+    Args:
+        fm: isofit forward model
+        winidx: indices of surface components of state vector (to be solved)
+        meas: a one-D numpy vector of radiance in uW/nm/sr/cm2
+        geom: geometry object corresponding to given measurement
+        x0: the initialization state including surface from the superpixel
+            and the atm from the smoothed atmosphere.
+        num_iter: number of interations to run through
+        hash_table: a hash table to use locally
+        hash_size: max size of given hash table
+        diag_uncert: flag indicating whether to diagonalize the uncertainty
+
+    Returns:
+        x: MAP estimate of the mean
+        S: diagonal conditional posterior covariance estimate
+    """
+    from scipy.linalg.blas import dsymv
+    from scipy.linalg.lapack import dpotrf, dpotri
+
+    x = x0.copy()
+    x_surface, x_atmosphere, x_instrument = fm.unpack(x)
+
+    # Get all the surface quantities for the super pixel
+    sub_surface, sub_atmosphere, sub_instrument = fm.unpack(sub_state)
+
+    # Surface reflectance at the wl resolution of fm.atmosphere
+    rho_dir_dir, rho_dif_dir = fm.calc_rfl(sub_state, geom)
+    rho_dif_dir = fm.upsample(fm.surface.wl, rho_dif_dir)
+
+    rho_dif_dif = (
+        fm.upsample(fm.surface.wl, geom.bg_rfl)
+        if isinstance(geom.bg_rfl, np.ndarray)
+        else rho_dif_dir
+    )
+
+    # Get all the atmosphere quantities
+    (r, L_tot, L_dir_dir, L_dif_dir, L_dir_dif, L_dif_dif) = (
+        fm.calc_atmosphere_quantities(x_atmosphere, geom, rho_dif_dif=rho_dif_dif)
+    )
+
+    # Path radiance and spherical albedo
+    L_atm = fm.atmosphere.get_L_atm(x_atmosphere, geom)
+    s = r["sphalb"]
+
+    # Background conditions equal to the superpixel reflectance
+    bg = s * rho_dif_dir
+
+    # Get superpixel EOF shift if used
+    eof_offset = fm.eof_offset(sub_instrument)
+
+    # Get the inversion indices; Include glint indices if applicable
+    full_idx = np.concatenate((winidx, fm.idx_surf_nonrfl), axis=0)
+    outside_ret_windows = np.ones(len(fm.idx_surface), dtype=bool)
+    outside_ret_windows[full_idx] = False
+    outside_ret_windows = np.where(outside_ret_windows)[0]
+    iv_idx = fm.surface.analytical_iv_idx
+
+    # The H matrix does not change as a function of x-vector
+    H = fm.surface.analytical_model(
+        bg,
+        L_tot=L_tot,
+        geom=geom,
+        L_dir_dir=L_dir_dir,
+        L_dir_dif=L_dir_dif,
+        L_dif_dir=L_dif_dir,
+        L_dif_dif=L_dif_dif,
+    )
+    # Sample just the wavelengths and states of interest
+    L = H[winidx, :][:, iv_idx]
+
+    trajectory = np.zeros((num_iter + 1, len(x)))
+    trajectory[0, :] = x
+
+    # Bounded
+    bounds = np.array(fm.surface.bounds)
+
+    # Set inversion target
+    y = meas[winidx] - L_atm[winidx] - eof_offset[winidx]
+    for n in range(num_iter):
+        # Measurement uncertainty
+        Seps = fm.Seps(x, meas, geom)[winidx, :][:, winidx]
+
+        # Prior mean and covariance
+        Sa, Sa_inv, Sa_inv_sqrt = fm.Sa(x, geom)
+        Sa_inv = Sa_inv[fm.idx_surface, :][:, fm.idx_surface]
+
+        xa_full = fm.xa(x, geom)
+        xa_surface = xa_full[fm.idx_surface]
+
+        # Save the product of the prior covariance and mean
+        prprod = Sa_inv @ xa_surface
+
+        x_surface, x_atmosphere, x_instrument = fm.unpack(x)
+
+        C = dpotrf(Seps, 1)[0]
+        P = dpotri(C, 1)[0]
+
+        if enforce_bounds:
+            xk, C_rcond, fixed_set = map_solve_constrained(
+                L, iv_idx, Sa_inv, P, y, prprod, bounds, len(iv_idx) - 1, 2
+            )
+        else:
+            xk, C_rcond = map_solve(L, P, prprod, Sa_inv, y, iv_idx)
+
+        # Save trajectory step:
+        x_surface[iv_idx] = xk
+        if outside_ret_const is None:
+            x_surface[outside_ret_windows] = xa_surface[outside_ret_windows]
+        else:
+            x_surface[outside_ret_windows] = outside_ret_const
+
+        x[fm.idx_surface] = x_surface
+        trajectory[n + 1, :] = x
+
+    if diag_uncert:
+        if len(C_rcond):
+            full_unc = np.ones(len(x))
+            full_unc[iv_idx] = np.sqrt(np.diag(C_rcond))
+        else:
+            full_unc = np.ones(len(x))
+            full_unc[iv_idx] = [-9999 for i in x[iv_idx]]
+
+        return trajectory, full_unc
+    else:
+        return trajectory, C_rcond

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -453,7 +453,8 @@ def load(
     if mf:
         xropen = xr.mfopen_dataset
 
-    ds = xropen(path, chunks=chunks, **kwargs)
+    # ds = xropen(path, chunks=chunks, **kwargs)
+    ds = xropen(path, **kwargs)
 
     status = ds.attrs.get("ISOFIT status", "<not set>")
     if status != "success":

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -28,19 +28,19 @@ from isofit.surface.surface import DefaultState
 from isofit.surface.surface_multicomp import MultiComponentSurface
 
 DefaultSkyGlintPrior = DefaultState(
-    bounds=[0.0, 100.0],
+    bounds=[0.0, 0.5],
     scale=1.0,
-    prior_mean=1 / np.pi,
-    prior_sigma=0.001,
+    prior_mean=0.1,
+    prior_sigma=0.1,
     init=1 / np.pi,
 )
 
 DefaultSunGlintPrior = DefaultState(
-    bounds=[0.0, 100.0],
+    bounds=[0.0, 10.0],
     scale=1.0,
     prior_mean=0.02,
-    prior_sigma=0.001,
-    init=0.02,
+    prior_sigma=1.0,
+    init=4.0,
 )
 
 
@@ -187,7 +187,7 @@ class GlintModelSurface(MultiComponentSurface):
         # glint_est is calc. in RFL-space. Makes sense that rfl < 1.0
         bounds_glint_est = [
             0,
-            1.0,
+            20.0,
         ]
         glint_est = max(
             bounds_glint_est[0] + eps,
@@ -208,7 +208,7 @@ class GlintModelSurface(MultiComponentSurface):
         )
 
         # Updating self.init will set the prior mean (xa) to this value
-        self.init[self.sun_glint_ind] = g_dd_est
+        # self.init[self.sun_glint_ind] = g_dd_est
 
         # SKY_GLINT g_dsf
         x[self.sky_glint_ind] = g_dsf_est

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -204,7 +204,7 @@ class GlintModelSurface(MultiComponentSurface):
         ref_wl = 1050  # Choices 1050 nm, 1640 nm
         g_dd_est = (
             glint_est
-            / self.fresnel_rf(geom.observer_zenith)[np.argmin(np.abs(self.wl - ref_wl))]
+            / self.fresnel_rf(geom.solar_zenith)[np.argmin(np.abs(self.wl - ref_wl))]
         )
 
         # Updating self.init will set the prior mean (xa) to this value
@@ -239,7 +239,7 @@ class GlintModelSurface(MultiComponentSurface):
             independently.
         """
         # fresnel reflectance factor (approx. 0.02 for nadir view)
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.solar_zenith)
 
         # Enforce bounds, also turns -9999. fill into 0.
         # Note if null_value > bounds[1], will return bounds[1]
@@ -285,7 +285,7 @@ class GlintModelSurface(MultiComponentSurface):
 
         drfl = self.dlamb_dsurface(x_surface, geom)
 
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.solar_zenith)
         # TODO make the indexing better for the surface state elements
         drfl[:, self.sun_glint_ind] = rho_ls
         drfl[:, self.sky_glint_ind] = rho_ls
@@ -361,7 +361,7 @@ class GlintModelSurface(MultiComponentSurface):
         Currently we set the diffuse glint scaling term to constant
         value, which makes the AOE inner loop inversion possible.
         """
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.solar_zenith)
 
         # Construct the H matrix from:
         # theta (rho portion)
@@ -406,13 +406,13 @@ class GlintModelSurface(MultiComponentSurface):
             x_surface[self.sky_glint_ind],
         )
 
-    def fresnel_rf(self, vza):
+    def fresnel_rf(self, sza):
         """Calculates reflectance factor of sky radiance based on the
         Fresnel equation for unpolarized light as a function of view zenith angle (vza).
         """
-        if vza > 0.0:
+        if sza > 0.0:
             n_w = 1.33  # refractive index of water
-            theta = np.deg2rad(vza)
+            theta = np.deg2rad(sza)
 
             # calculate angle of refraction using Snell′s law
             theta_i = np.arcsin(np.sin(theta) / self.real_ref_idx)

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -120,11 +120,6 @@ class GlintModelSurface(MultiComponentSurface):
         # [:, 0] - wavelength (nm)
         # [:, 2] - refractive index
         real_ref_idx = np.loadtxt(config.refractive_index_path)
-        # Normalize s.t. reference wl has value of 1
-        self.ref_wl = 1050  # Choices 1050 nm, 1640 nm
-        ref_i = np.argmin(np.abs(real_ref_idx[:, 0] - self.ref_wl))
-        real_ref_idx[:, 1] = real_ref_idx[:, 1] / real_ref_idx[ref_i, 1]
-
         self.real_ref_idx = resample_spectrum(
             real_ref_idx[:, 1], real_ref_idx[:, 0], self.wl, self.fwhm
         )
@@ -206,11 +201,10 @@ class GlintModelSurface(MultiComponentSurface):
         g_dsf_est = self.init[self.sky_glint_ind]
 
         # Reference wavelength
+        ref_wl = 1050  # Choices 1050 nm, 1640 nm
         g_dd_est = (
             glint_est
-            / self.fresnel_rf_refractive_index(geom.observer_zenith)[
-                np.argmin(np.abs(self.wl - self.ref_wl))
-            ]
+            / self.fresnel_rf(geom.observer_zenith)[np.argmin(np.abs(self.wl - ref_wl))]
         )
 
         # Updating self.init will set the prior mean (xa) to this value
@@ -245,7 +239,7 @@ class GlintModelSurface(MultiComponentSurface):
             independently.
         """
         # fresnel reflectance factor (approx. 0.02 for nadir view)
-        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.observer_zenith)
 
         # Enforce bounds, also turns -9999. fill into 0.
         # Note if null_value > bounds[1], will return bounds[1]
@@ -291,7 +285,7 @@ class GlintModelSurface(MultiComponentSurface):
 
         drfl = self.dlamb_dsurface(x_surface, geom)
 
-        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.observer_zenith)
         # TODO make the indexing better for the surface state elements
         drfl[:, self.sun_glint_ind] = rho_ls
         drfl[:, self.sky_glint_ind] = rho_ls
@@ -367,7 +361,7 @@ class GlintModelSurface(MultiComponentSurface):
         Currently we set the diffuse glint scaling term to constant
         value, which makes the AOE inner loop inversion possible.
         """
-        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.observer_zenith)
 
         # Construct the H matrix from:
         # theta (rho portion)
@@ -412,17 +406,7 @@ class GlintModelSurface(MultiComponentSurface):
             x_surface[self.sky_glint_ind],
         )
 
-    def fresnel_rf_refractive_index(self, vza):
-        """Calculates the fresnel reflectance spectrum.
-        Can also return value at single wavelength
-
-        Arguments:
-        wl (nm) - float valued wavelength center
-        """
-        return self.fresnel_rf(vza) * self.real_ref_idx
-
-    @staticmethod
-    def fresnel_rf(vza):
+    def fresnel_rf(self, vza):
         """Calculates reflectance factor of sky radiance based on the
         Fresnel equation for unpolarized light as a function of view zenith angle (vza).
         """
@@ -431,7 +415,7 @@ class GlintModelSurface(MultiComponentSurface):
             theta = np.deg2rad(vza)
 
             # calculate angle of refraction using Snell′s law
-            theta_i = np.arcsin(np.sin(theta) / n_w)
+            theta_i = np.arcsin(np.sin(theta) / self.real_ref_idx)
 
             # reflectance factor of sky radiance based on the Fresnel equation for unpolarized light
             rho_ls = 0.5 * np.abs(

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 import numpy as np
 from scipy.linalg import block_diag
 
-from isofit.core.common import eps, svd_inv_sqrt
+from isofit.core.common import eps, resample_spectrum, svd_inv_sqrt
+from isofit.data import env
 from isofit.surface.surface import DefaultState
 from isofit.surface.surface_multicomp import MultiComponentSurface
 
@@ -103,12 +104,44 @@ class GlintModelSurface(MultiComponentSurface):
             Cov / np.mean(np.diag(Cov))
         )
 
+        # Check for fwhm, if not in surface -> use instrument
+        if not len(self.fwhm):
+            q = np.loadtxt(full_config.forward_model.instrument.wavelength_file)
+
+            # Assume that fwhm is the second dim, and that wl file has multi-dim
+            assert q.shape[1] > 1
+
+            fwhm = q[:, 1]
+            if q[0, 0] < 100:
+                fwhm = units.micron_to_nm(fwhm)
+            self.fwhm = fwhm
+
+        # Refractive index file
+        # [:, 0] - wavelength (nm)
+        # [:, 2] - refractive index
+        real_ref_idx = np.loadtxt(config.refractive_index_path)
+        # Normalize s.t. reference wl has value of 1
+        self.ref_wl = 1050  # Choices 1050 nm, 1640 nm
+        ref_i = np.argmin(np.abs(real_ref_idx[:, 0] - self.ref_wl))
+        real_ref_idx[:, 1] = real_ref_idx[:, 1] / real_ref_idx[ref_i, 1]
+
+        self.real_ref_idx = resample_spectrum(
+            real_ref_idx[:, 1], real_ref_idx[:, 0], self.wl, self.fwhm
+        )
+
     def xa(self, x_surface, geom):
         """Mean of prior distribution, calculated at state x."""
 
         mu = MultiComponentSurface.xa(self, x_surface, geom)
         mu[self.sky_glint_ind] = self.sky_glint_mean
-        mu[self.sun_glint_ind] = self.sun_glint_mean
+
+        if hasattr(geom, "sun_glint_init"):
+            sun_glint_mean = geom.sun_glint_init
+        else:
+            sun_glint_mean = x_surface[self.sun_glint_ind]
+            geom.sun_glint_init = sun_glint_mean
+
+        mu[self.sun_glint_ind] = sun_glint_mean
 
         return mu
 
@@ -146,12 +179,14 @@ class GlintModelSurface(MultiComponentSurface):
         blue_band_1 = np.argmin(np.abs(450 - self.wl))
         blue_band_2 = np.argmin(np.abs(500 - self.wl))
 
-        if np.max(self.wl) >= 2300:
-            glint_band_1 = np.argmin(np.abs(2200 - self.wl))
-            glint_band_2 = np.argmin(np.abs(2300 - self.wl))
-        else:
-            glint_band_1 = np.argmin(np.abs(1000 - self.wl))
-            glint_band_2 = np.argmin(np.abs(1020 - self.wl))
+        # if np.max(self.wl) >= 2300:
+        # glint_band_1 = np.argmin(np.abs(2200 - self.wl))
+        # glint_band_2 = np.argmin(np.abs(2300 - self.wl))
+        # else:
+        # glint_band_1 = np.argmin(np.abs(1000 - self.wl))
+        # glint_band_2 = np.argmin(np.abs(1020 - self.wl))
+        glint_band_1 = np.argmin(np.abs(1625 - self.wl))
+        glint_band_2 = np.argmin(np.abs(1675 - self.wl))
 
         glint_est = np.min(
             [
@@ -160,7 +195,7 @@ class GlintModelSurface(MultiComponentSurface):
             ]
         )
 
-        # hard-coded glint bounds from experience #TODO - get from config
+        # glint_est is calc. in RFL-space. Makes sense that rfl < 1.0
         bounds_glint_est = [
             0,
             1.0,
@@ -175,7 +210,15 @@ class GlintModelSurface(MultiComponentSurface):
         # Get estimate for g_dd and g_dsf parameters
         # Set sky glint to a static number; use prior mean.
         g_dsf_est = self.init[self.sky_glint_ind]
-        g_dd_est = glint_est / self.fresnel_rf(geom.observer_zenith)
+
+        # Reference wavelength
+        # g_dd_est = glint_est / self.fresnel_rf(geom.observer_zenith)
+        g_dd_est = (
+            glint_est
+            / self.fresnel_rf_refractive_index(geom.observer_zenith)[
+                np.argmin(np.abs(self.wl - self.ref_wl))
+            ]
+        )
 
         # Updating self.init will set the prior mean (xa) to this value
         self.init[self.sun_glint_ind] = g_dd_est
@@ -209,7 +252,7 @@ class GlintModelSurface(MultiComponentSurface):
             independently.
         """
         # fresnel reflectance factor (approx. 0.02 for nadir view)
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
 
         # Enforce bounds, also turns -9999. fill into 0.
         # Note if null_value > bounds[1], will return bounds[1]
@@ -255,7 +298,7 @@ class GlintModelSurface(MultiComponentSurface):
 
         drfl = self.dlamb_dsurface(x_surface, geom)
 
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
         # TODO make the indexing better for the surface state elements
         drfl[:, self.sun_glint_ind] = rho_ls
         drfl[:, self.sky_glint_ind] = rho_ls
@@ -331,7 +374,7 @@ class GlintModelSurface(MultiComponentSurface):
         Currently we set the diffuse glint scaling term to constant
         value, which makes the AOE inner loop inversion possible.
         """
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
 
         # Construct the H matrix from:
         # theta (rho portion)
@@ -375,6 +418,15 @@ class GlintModelSurface(MultiComponentSurface):
             x_surface[self.sun_glint_ind],
             x_surface[self.sky_glint_ind],
         )
+
+    def fresnel_rf_refractive_index(self, vza):
+        """Calculates the fresnel reflectance spectrum.
+        Can also return value at single wavelength
+
+        Arguments:
+        wl (nm) - float valued wavelength center
+        """
+        return self.fresnel_rf(vza) * self.real_ref_idx
 
     @staticmethod
     def fresnel_rf(vza):

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -179,14 +179,8 @@ class GlintModelSurface(MultiComponentSurface):
         blue_band_1 = np.argmin(np.abs(450 - self.wl))
         blue_band_2 = np.argmin(np.abs(500 - self.wl))
 
-        # if np.max(self.wl) >= 2300:
-        # glint_band_1 = np.argmin(np.abs(2200 - self.wl))
-        # glint_band_2 = np.argmin(np.abs(2300 - self.wl))
-        # else:
-        # glint_band_1 = np.argmin(np.abs(1000 - self.wl))
-        # glint_band_2 = np.argmin(np.abs(1020 - self.wl))
-        glint_band_1 = np.argmin(np.abs(1625 - self.wl))
-        glint_band_2 = np.argmin(np.abs(1675 - self.wl))
+        glint_band_1 = np.argmin(np.abs(1060 - self.wl))
+        glint_band_2 = np.argmin(np.abs(1030 - self.wl))
 
         glint_est = np.min(
             [

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -179,8 +179,8 @@ class GlintModelSurface(MultiComponentSurface):
         blue_band_1 = np.argmin(np.abs(450 - self.wl))
         blue_band_2 = np.argmin(np.abs(500 - self.wl))
 
-        glint_band_1 = np.argmin(np.abs(1060 - self.wl))
-        glint_band_2 = np.argmin(np.abs(1030 - self.wl))
+        glint_band_1 = np.argmin(np.abs(1030 - self.wl))
+        glint_band_2 = np.argmin(np.abs(1060 - self.wl))
 
         glint_est = np.min(
             [
@@ -206,7 +206,6 @@ class GlintModelSurface(MultiComponentSurface):
         g_dsf_est = self.init[self.sky_glint_ind]
 
         # Reference wavelength
-        # g_dd_est = glint_est / self.fresnel_rf(geom.observer_zenith)
         g_dd_est = (
             glint_est
             / self.fresnel_rf_refractive_index(geom.observer_zenith)[

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -50,6 +50,9 @@ class MultiComponentSurface(Surface):
 
         self.n_comp = len(self.component_means)
         self.wl = self.model_dict["wl"][0]
+        self.fwhm = (
+            self.model_dict["fwhm"][0] if len(self.model_dict.get("fwhm", [])) else []
+        )
         self.n_wl = len(self.wl)
 
         # Set up normalization method

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -42,11 +42,8 @@ from isofit.core.multistate import (
     index_spectra_by_surface,
     update_config_for_surface,
 )
-from isofit.inversion.inverse_simple import (
-    invert_algebraic,
-    invert_analytical,
-    invert_simple,
-)
+from isofit.inversion.inverse_analytical import invert_analytical
+from isofit.inversion.inverse_simple import invert_algebraic, invert_simple
 from isofit.utils.atm_interpolation import atm_interpolation
 
 

--- a/isofit/utils/multicomponent_classification.py
+++ b/isofit/utils/multicomponent_classification.py
@@ -15,7 +15,7 @@ from spectral import envi
 
 import isofit.utils.template_construction as tmpl
 from isofit import ray
-from isofit.core.common import envi_header, resample_spectrum, svd_inv
+from isofit.core.common import envi_header, load_esd, resample_spectrum, svd_inv
 from isofit.core.fileio import IO, initialize_output, write_bil_chunk
 from isofit.core.geometry import Geometry
 from isofit.core.multistate import SurfaceMapping
@@ -106,7 +106,7 @@ class Worker(object):
         )
 
         self.component = Component(model_dict)
-        self.esd = IO.load_esd()
+        self.esd = load_esd()
         self.dayofyear = dayofyear
 
         self.wl = wl

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -143,17 +143,27 @@ def surface_model(
     selection_metric = config.get("selection_metric", "Euclidean")
 
     # load wavelengths file, and change units to nm if needed
+    fwhm = []
     if os.path.splitext(wavelength_file)[-1] == ".hdr":
         ds = envi.open(wavelength_file)
         wl = np.array([float(x) for x in ds.metadata["wavelength"]])
+        fwhm = np.array(ds.metadata.get("fwhm")).astype(float)
     else:
+        # Assumes
+        # [:, 0] - Wavelength
+        # [:, 1] - fwhm
         q = np.loadtxt(wavelength_file)
         if q.shape[1] > 2:
             q = q[:, 1:]
         wl = q[:, 0]
+        if q.shape[1] > 1:
+            fwhm = q[:, 1]
 
     if wl[0] < 100:
         wl = units.micron_to_nm(wl)
+        if len(fwhm):
+            fwhm = units.micron_to_nm(fwhm)
+
     nchan = len(wl)
 
     # build global reference windows
@@ -169,6 +179,7 @@ def surface_model(
         "normalize": normalize,
         "selection_metric": selection_metric,
         "wl": wl,
+        "fwhm": fwhm,
         "means": [],
         "covs": [],
         "attribute_means": [],

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -17,15 +17,11 @@ from scipy.io import loadmat
 from spectral.io import envi
 
 from isofit import __version__
+from isofit.atmosphere.engines.modtran import ModtranRT
 from isofit.core import units
-from isofit.core.common import (
-    envi_header,
-    expand_path,
-    json_load_ascii,
-)
+from isofit.core.common import envi_header, expand_path, json_load_ascii
 from isofit.core.multistate import SurfaceMapping
 from isofit.data import env
-from isofit.atmosphere.engines.modtran import ModtranRT
 from isofit.utils.surface_model import surface_model
 
 
@@ -828,7 +824,6 @@ def build_config(
                 surface_class_subs_path=paths.surface_class_subs_path,
                 surface_working_paths=paths.surface_working_paths,
                 surface_category=surface_category,
-                pressure_elevation=pressure_elevation,
                 use_superpixels=use_superpixels,
                 terrain_style=terrain_style,
                 max_slope=max_slope,
@@ -1598,10 +1593,10 @@ def make_surface_config(
     surface_class_subs_path: str = None,
     surface_working_paths: dict = None,
     surface_category: str = "multicomponent_surface",
-    pressure_elevation: bool = False,
     use_superpixels: bool = False,
     terrain_style: str = "flat",
     max_slope: float = 20.0,
+    surface_refractive_index_path: str = None,
 ):
     # Initialize config dict
     surface_config_dict = {
@@ -1667,6 +1662,17 @@ def make_surface_config(
                     "prior_sigma": surface_mat["prior_sigma"][0][i],
                     "scale": surface_mat["scale"][0][i],
                 }
+
+    # Add refractive index path if specified
+    if surface_refractive_index_path:
+        surface_config_dict["refractive_index_path"] = surface_refractive_index_path
+
+    elif (surface_category == "glint_model_surface") or (
+        "glint_model_surface" in list(surface_config_dict.get("Surfaces", {}).keys())
+    ):
+        surface_config_dict["refractive_index_path"] = str(
+            env.path("data", "h2o_real_refractive_index.txt")
+        )
 
     return surface_config_dict
 

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1031,7 +1031,7 @@ def load_climatology(
             aerosol_state_vector["AERFRAC_{}".format(_a)] = {
                 "bounds": [float(alr[0]), float(alr[1])],
                 "scale": 1,
-                "init": float((alr[1] - alr[0]) / 10.0 + alr[0]),
+                "init": 0.2,
                 "prior_sigma": 10.0,
                 "prior_mean": float((alr[1] - alr[0]) / 10.0 + alr[0]),
             }
@@ -1551,7 +1551,7 @@ def make_atmosphere_config(
 
     # Now do statevector
     statekeys = ["H2OSTR"]
-    statesigmas = [100.0]
+    statesigmas = [0.1]
     statescale = [1]
     if pressure_elevation and presolve is False:
         statekeys.append("surface_elevation_km")


### PR DESCRIPTION
**Problem:**

The analytical MAP solution we use in AOE is unbounded. For retrievals with complex surface statevectors, i.e. the glint model presently, unconstrained priors can lead to poor solutions where reflectance and glint quantities lie in unphysical state spaces.

**The fix:**

On the per-pixel basis, perform multiple passes of the AOE solve. After the first solve, check for state-elements that lie above or below the fixed bounds, and for elements that fall outside the bounds, fix them to the upper or lower bound, respectively. Then compute the MAP solution again with the fixed elements. The algorithm allows you to fix `n` number of state elements at a time. Prior covariance constraints can mean that fixing one surface-state vector element changes the solution on other elements. It's important to note that fixing all bounds-exceeding state elements can lead to over-constraint. Iteratively solving for the MAP solution is necessary to produce a final vector that has no bounds violations.  

**The downside:**

This increases the computation time for the AOE algorithm. If one statevector element exceeds the bounds, and a single re-solve is necessary, MAP calculation time increases by 2x. 

If the number of states = n, If you fix one element at a time and at maximum allow for `n - 1` to be fixed, the maximum increase in computation time is a factor of `n`. In practice, however,  you can get away with fixing all bounds violations at once, so the practical slowdown in the invert_analtyical call should be `2x-3x`.


See https://github.com/isofit/isofit/pull/932




