### PR TITLE
Spectrally dependent fresnel reflectance factor

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -123,6 +123,9 @@ class SurfaceConfig(BaseConfigSection):
         This can avoid runaway results at low cos_i values where diffuse radiance dominates.
         """
 
+        self._refractive_index_path_type = str
+        self.refractive_index_path = ""
+
         self.set_config_options(sub_configdic)
 
     def _check_config_validity(self) -> List[str]:

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -61,7 +61,7 @@ class ForwardModel:
     noise for the purpose of weighting the measurement information
     against the prior."""
 
-    def __init__(self, full_config: Config, cache_atmosphere: Atmosphere = None):
+    def __init__(self, full_config: Config, cache_atmosphere: Atmosphere = False):
         # load in the full config (in case of inter-module dependencies) and
         # then designate the current config
         self.full_config = full_config

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 import numpy as np
 from scipy.linalg import block_diag
 
-from isofit.core.common import eps, svd_inv_sqrt
+from isofit.core.common import eps, resample_spectrum, svd_inv_sqrt
+from isofit.data import env
 from isofit.surface.surface import DefaultState
 from isofit.surface.surface_multicomp import MultiComponentSurface
 
@@ -102,6 +103,30 @@ class GlintModelSurface(MultiComponentSurface):
         self.Sa_inv_glint, self.Sa_inv_sqrt_glint = svd_inv_sqrt(
             Cov / np.mean(np.diag(Cov))
         )
+        # Check for fwhm, if not in surface -> use instrument
+        if not len(self.fwhm):
+            q = np.loadtxt(full_config.forward_model.instrument.wavelength_file)
+
+            # Assume that fwhm is the second dim, and that wl file has multi-dim
+            assert q.shape[1] > 1
+
+            fwhm = q[:, 1]
+            if q[0, 0] < 100:
+                fwhm = units.micron_to_nm(fwhm)
+            self.fwhm = fwhm
+
+        # Refractive index file
+        # [:, 0] - wavelength (nm)
+        # [:, 2] - refractive index
+        real_ref_idx = np.loadtxt(config.refractive_index_path)
+        # Normalize s.t. reference wl has value of 1
+        self.ref_wl = 1050  # Choices 1050 nm, 1640 nm
+        ref_i = np.argmin(np.abs(real_ref_idx[:, 0] - self.ref_wl))
+        real_ref_idx[:, 1] = real_ref_idx[:, 1] / real_ref_idx[ref_i, 1]
+
+        self.real_ref_idx = resample_spectrum(
+            real_ref_idx[:, 1], real_ref_idx[:, 0], self.wl, self.fwhm
+        )
 
     def update_heuristic_prior_means(self, x_surface, geom):
         """Update the sun glint prior to match initial guess (x_surface"""
@@ -163,7 +188,7 @@ class GlintModelSurface(MultiComponentSurface):
             ]
         )
 
-        # hard-coded glint bounds from experience #TODO - get from config
+        # glint_est is calc. in RFL-space. Makes sense that rfl < 1.0
         bounds_glint_est = [
             0,
             5.0,
@@ -178,7 +203,14 @@ class GlintModelSurface(MultiComponentSurface):
         # Get estimate for g_dd and g_dsf parameters
         # Set sky glint to a static number; use prior mean.
         g_dsf_est = self.init[self.sky_glint_ind]
-        g_dd_est = glint_est / self.fresnel_rf(geom.observer_zenith)
+
+        # Reference wavelength
+        g_dd_est = (
+            glint_est
+            / self.fresnel_rf_refractive_index(geom.observer_zenith)[
+                np.argmin(np.abs(self.wl - self.ref_wl))
+            ]
+        )
 
         # Updating self.init will set the prior mean (xa) to this value
         self.init[self.sun_glint_ind] = g_dd_est
@@ -213,7 +245,7 @@ class GlintModelSurface(MultiComponentSurface):
             independently.
         """
         # fresnel reflectance factor (approx. 0.02 for nadir view)
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
 
         # Enforce bounds, also turns -9999. fill into 0.
         # Note if null_value > bounds[1], will return bounds[1]
@@ -259,7 +291,7 @@ class GlintModelSurface(MultiComponentSurface):
 
         drfl = self.dlamb_dsurface(x_surface, geom)
 
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
         # TODO make the indexing better for the surface state elements
         drfl[:, self.sun_glint_ind] = rho_ls
         drfl[:, self.sky_glint_ind] = rho_ls
@@ -335,7 +367,7 @@ class GlintModelSurface(MultiComponentSurface):
         Currently we set the diffuse glint scaling term to constant
         value, which makes the AOE inner loop inversion possible.
         """
-        rho_ls = self.fresnel_rf(geom.observer_zenith)
+        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
 
         # Construct the H matrix from:
         # theta (rho portion)
@@ -379,6 +411,15 @@ class GlintModelSurface(MultiComponentSurface):
             x_surface[self.sun_glint_ind],
             x_surface[self.sky_glint_ind],
         )
+
+    def fresnel_rf_refractive_index(self, vza):
+        """Calculates the fresnel reflectance spectrum.
+        Can also return value at single wavelength
+
+        Arguments:
+        wl (nm) - float valued wavelength center
+        """
+        return self.fresnel_rf(vza) * self.real_ref_idx
 
     @staticmethod
     def fresnel_rf(vza):

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -119,11 +119,6 @@ class GlintModelSurface(MultiComponentSurface):
         # [:, 0] - wavelength (nm)
         # [:, 2] - refractive index
         real_ref_idx = np.loadtxt(config.refractive_index_path)
-        # Normalize s.t. reference wl has value of 1
-        self.ref_wl = 1050  # Choices 1050 nm, 1640 nm
-        ref_i = np.argmin(np.abs(real_ref_idx[:, 0] - self.ref_wl))
-        real_ref_idx[:, 1] = real_ref_idx[:, 1] / real_ref_idx[ref_i, 1]
-
         self.real_ref_idx = resample_spectrum(
             real_ref_idx[:, 1], real_ref_idx[:, 0], self.wl, self.fwhm
         )
@@ -205,11 +200,10 @@ class GlintModelSurface(MultiComponentSurface):
         g_dsf_est = self.init[self.sky_glint_ind]
 
         # Reference wavelength
+        ref_wl = 1050  # Choices 1050 nm, 1640 nm
         g_dd_est = (
             glint_est
-            / self.fresnel_rf_refractive_index(geom.observer_zenith)[
-                np.argmin(np.abs(self.wl - self.ref_wl))
-            ]
+            / self.fresnel_rf(geom.observer_zenith)[np.argmin(np.abs(self.wl - ref_wl))]
         )
 
         # Updating self.init will set the prior mean (xa) to this value
@@ -245,7 +239,7 @@ class GlintModelSurface(MultiComponentSurface):
             independently.
         """
         # fresnel reflectance factor (approx. 0.02 for nadir view)
-        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.observer_zenith)
 
         # Enforce bounds, also turns -9999. fill into 0.
         # Note if null_value > bounds[1], will return bounds[1]
@@ -291,7 +285,7 @@ class GlintModelSurface(MultiComponentSurface):
 
         drfl = self.dlamb_dsurface(x_surface, geom)
 
-        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.observer_zenith)
         # TODO make the indexing better for the surface state elements
         drfl[:, self.sun_glint_ind] = rho_ls
         drfl[:, self.sky_glint_ind] = rho_ls
@@ -367,7 +361,7 @@ class GlintModelSurface(MultiComponentSurface):
         Currently we set the diffuse glint scaling term to constant
         value, which makes the AOE inner loop inversion possible.
         """
-        rho_ls = self.fresnel_rf_refractive_index(geom.observer_zenith)
+        rho_ls = self.fresnel_rf(geom.observer_zenith)
 
         # Construct the H matrix from:
         # theta (rho portion)
@@ -412,17 +406,7 @@ class GlintModelSurface(MultiComponentSurface):
             x_surface[self.sky_glint_ind],
         )
 
-    def fresnel_rf_refractive_index(self, vza):
-        """Calculates the fresnel reflectance spectrum.
-        Can also return value at single wavelength
-
-        Arguments:
-        wl (nm) - float valued wavelength center
-        """
-        return self.fresnel_rf(vza) * self.real_ref_idx
-
-    @staticmethod
-    def fresnel_rf(vza):
+    def fresnel_rf(self, vza):
         """Calculates reflectance factor of sky radiance based on the
         Fresnel equation for unpolarized light as a function of view zenith angle (vza).
         """
@@ -431,7 +415,7 @@ class GlintModelSurface(MultiComponentSurface):
             theta = np.deg2rad(vza)
 
             # calculate angle of refraction using Snell′s law
-            theta_i = np.arcsin(np.sin(theta) / n_w)
+            theta_i = np.arcsin(np.sin(theta) / self.real_ref_idx)
 
             # reflectance factor of sky radiance based on the Fresnel equation for unpolarized light
             rho_ls = 0.5 * np.abs(

--- a/isofit/surface/surface_glint_model.py
+++ b/isofit/surface/surface_glint_model.py
@@ -409,6 +409,12 @@ class GlintModelSurface(MultiComponentSurface):
     def fresnel_rf(self, vza):
         """Calculates reflectance factor of sky radiance based on the
         Fresnel equation for unpolarized light as a function of view zenith angle (vza).
+
+        There is some discussion to whether the vza or sza is the appropriate angle to use here.
+        We follow Gege WASI-2D (2014) implementation. Following Gege's suggestion: when working
+        within radiance units, view zenith is the relevant angle. Gao and Li (2021) are working
+        in irradiance units, where their implementation is integrating across observation
+        angles, and the sza is the relevant angle for averaged reflectances.
         """
         if vza > 0.0:
             n_w = 1.33  # refractive index of water

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -50,6 +50,9 @@ class MultiComponentSurface(Surface):
 
         self.n_comp = len(self.component_means)
         self.wl = self.model_dict["wl"][0]
+        self.fwhm = (
+            self.model_dict["fwhm"][0] if len(self.model_dict.get("fwhm", [])) else []
+        )
         self.n_wl = len(self.wl)
 
         # Set up normalization method

--- a/isofit/utils/surface_model.py
+++ b/isofit/utils/surface_model.py
@@ -143,17 +143,27 @@ def surface_model(
     selection_metric = config.get("selection_metric", "Euclidean")
 
     # load wavelengths file, and change units to nm if needed
+    fwhm = []
     if os.path.splitext(wavelength_file)[-1] == ".hdr":
         ds = envi.open(wavelength_file)
         wl = np.array([float(x) for x in ds.metadata["wavelength"]])
+        fwhm = np.array(ds.metadata.get("fwhm")).astype(float)
     else:
+        # Assumes
+        # [:, 0] - Wavelength
+        # [:, 1] - fwhm
         q = np.loadtxt(wavelength_file)
         if q.shape[1] > 2:
             q = q[:, 1:]
         wl = q[:, 0]
+        if q.shape[1] > 1:
+            fwhm = q[:, 1]
 
     if wl[0] < 100:
         wl = units.micron_to_nm(wl)
+        if len(fwhm):
+            fwhm = units.micron_to_nm(fwhm)
+
     nchan = len(wl)
 
     # build global reference windows
@@ -169,6 +179,7 @@ def surface_model(
         "normalize": normalize,
         "selection_metric": selection_metric,
         "wl": wl,
+        "fwhm": fwhm,
         "means": [],
         "covs": [],
         "attribute_means": [],

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -828,7 +828,6 @@ def build_config(
                 surface_class_subs_path=paths.surface_class_subs_path,
                 surface_working_paths=paths.surface_working_paths,
                 surface_category=surface_category,
-                pressure_elevation=pressure_elevation,
                 use_superpixels=use_superpixels,
                 terrain_style=terrain_style,
                 max_slope=max_slope,
@@ -1775,10 +1774,10 @@ def make_surface_config(
     surface_class_subs_path: str = None,
     surface_working_paths: dict = None,
     surface_category: str = "multicomponent_surface",
-    pressure_elevation: bool = False,
     use_superpixels: bool = False,
     terrain_style: str = "flat",
     max_slope: float = 20.0,
+    surface_refractive_index_path: str = None,
 ):
     # Initialize config dict
     surface_config_dict = {
@@ -1844,6 +1843,17 @@ def make_surface_config(
                     "prior_sigma": surface_mat["prior_sigma"][0][i],
                     "scale": surface_mat["scale"][0][i],
                 }
+
+    # Add refractive index path if specified
+    if surface_refractive_index_path:
+        surface_config_dict["refractive_index_path"] = surface_refractive_index_path
+
+    elif (surface_category == "glint_model_surface") or (
+        "glint_model_surface" in list(surface_config_dict.get("Surfaces", {}).keys())
+    ):
+        surface_config_dict["refractive_index_path"] = str(
+            env.path("data", "h2o_real_refractive_index.txt")
+        )
 
     return surface_config_dict
 


### PR DESCRIPTION
Follows Gao and Li, 2021 to calculate a spectrally dependent fresenel reflectance factor.

<img width="598" height="315" alt="Screenshot 2026-06-17 at 3 01 36 PM" src="https://github.com/user-attachments/assets/0525c942-0e1e-465c-bba1-5d29cc78cbaa" />

<img width="1381" height="368" alt="Screenshot 2026-06-18 at 11 47 09 AM" src="https://github.com/user-attachments/assets/833c812b-9a69-40d6-9db2-0af844b00aea" />

This results in slightly different magnitude radiance contributions for the same glint level:

<img width="1464" height="508" alt="Screenshot 2026-06-18 at 11 45 34 AM" src="https://github.com/user-attachments/assets/702a224c-c524-4be3-a0a2-75c79da811dc" />

Example spectrum:

<img width="1677" height="585" alt="Screenshot 2026-06-18 at 11 48 15 AM" src="https://github.com/user-attachments/assets/9066a06e-d350-4ea1-ad95-56226c850286" />

TODO: Image-wide tests
