### PR TITLE
Prebuilt lut

### DIFF
--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -40,12 +40,17 @@ def inspect_lut_dimensions(lut_path: str) -> dict[str, np.ndarray]:
     lut_path = Path(lut_path)
 
     # Detect format based on file extension or directory structure
-    if lut_path.suffix == ".nc" or (lut_path.is_file() and not lut_path.is_dir()):
-        # NetCDF format
+    if lut_path.suffix == ".zarr" or (
+        lut_path.is_dir() and not lut_path.suffix == ".nc"
+    ):
+        return _inspect_zarr_dimensions(lut_path)
+    elif lut_path.suffix == ".nc" or lut_path.is_file():
         return _inspect_netcdf_dimensions(lut_path)
     else:
-        # Assume zarr format (directory-based store)
-        return _inspect_zarr_dimensions(lut_path)
+        raise ValueError(
+            f"Cannot determine LUT format for: {lut_path}. "
+            f"Expected .nc file (NetCDF) or .zarr directory (Zarr)."
+        )
 
 
 def _inspect_netcdf_dimensions(lut_path: Path) -> dict[str, np.ndarray]:

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -19,6 +19,84 @@ from isofit.core import common
 Logger = logging.getLogger(__name__)
 
 
+def inspect_lut_dimensions(lut_path: str) -> dict[str, np.ndarray]:
+    """Inspect a prebuilt LUT file to determine available dimensions and their grid points.
+
+    Supports both NetCDF (.nc) and Zarr formats.
+
+    Args:
+        lut_path: Path to the prebuilt LUT file (NetCDF or Zarr store)
+
+    Returns:
+        dict: Mapping dimension names to numpy arrays of grid points
+
+    Examples:
+        >>> dims = inspect_lut_dimensions("lut.nc")
+        >>> dims.keys()
+        dict_keys(['H2OSTR', 'AOT550', 'observer_zenith', 'wl'])
+        >>> dims['H2OSTR']
+        array([0.5, 1.0, 1.5, 2.0, 2.5])
+    """
+    lut_path = Path(lut_path)
+
+    # Detect format based on file extension or directory structure
+    if lut_path.suffix == ".nc" or (lut_path.is_file() and not lut_path.is_dir()):
+        # NetCDF format
+        return _inspect_netcdf_dimensions(lut_path)
+    else:
+        # Assume zarr format (directory-based store)
+        return _inspect_zarr_dimensions(lut_path)
+
+
+def _inspect_netcdf_dimensions(lut_path: Path) -> dict[str, np.ndarray]:
+    """Inspect NetCDF LUT dimensions.
+
+    Args:
+        lut_path: Path to the NetCDF LUT file
+
+    Returns:
+        dict: Mapping dimension names to numpy arrays of grid points
+    """
+    lut_dimensions = {}
+
+    with Dataset(lut_path, "r") as ncds:
+        # Iterate through all variables that could be LUT dimensions
+        # These are typically 1-D coordinate variables
+        for var_name in ncds.variables:
+            var = ncds.variables[var_name]
+
+            # Check if this is a coordinate/dimension variable (1-D)
+            if len(var.dimensions) == 1 and var.dimensions[0] == var_name:
+                # This is a dimension variable - store the actual grid points
+                data = var[:]
+                if len(data) > 0:
+                    lut_dimensions[var_name] = np.array(data)
+
+    return lut_dimensions
+
+
+def _inspect_zarr_dimensions(lut_path: Path) -> dict[str, np.ndarray]:
+    """Inspect Zarr LUT dimensions using xarray.
+
+    Args:
+        lut_path: Path to the Zarr LUT store
+
+    Returns:
+        dict: Mapping dimension names to numpy arrays of grid points
+    """
+    lut_dimensions = {}
+
+    # Open zarr store with xarray (don't load data, just inspect)
+    with xr.open_dataset(lut_path, engine="zarr", chunks=None) as ds:
+        # Extract all coordinate dimensions
+        for coord_name in ds.coords:
+            coord_data = ds[coord_name].values
+            if len(coord_data) > 0:
+                lut_dimensions[coord_name] = np.array(coord_data)
+
+    return lut_dimensions
+
+
 def findSlice(dim, val):
     """
     Creates a slice for selecting along a dimension such that a value is encompassed by

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1569,6 +1569,32 @@ def make_atmosphere_config(
     if prebuilt_lut_path is not None:
         prebuilt_dimensions = inspect_lut_dimensions(prebuilt_lut_path)
 
+        # Read MODTRAN template to get scene-wise mean values for interpolation
+        template_means = {}
+        if modtran_template_path is not None and os.path.exists(modtran_template_path):
+            with open(modtran_template_path, "r") as f:
+                template = json.load(f)
+                # Extract geometry parameters from first case
+                if "cases" in template and len(template["cases"]) > 0:
+                    geom = template["cases"][0]["MODTRAN"][0].get("GEOMETRY", {})
+                    surf = template["cases"][0]["MODTRAN"][0].get("SURFACE", {})
+                    atm = template["cases"][0]["MODTRAN"][0].get("ATMOSPHERE", {})
+
+                    # Map MODTRAN parameters to isofit dimension names
+                    template_means["solar_zenith"] = geom.get("PARM2")
+                    template_means["observer_zenith"] = (
+                        180 - geom.get("OBSZEN")
+                        if geom.get("OBSZEN") is not None
+                        else None
+                    )  # Convert from MODTRAN convention
+                    template_means["relative_azimuth"] = geom.get("PARM1")
+                    template_means["surface_elevation_km"] = surf.get("GNDALT")
+                    template_means["CO2"] = atm.get("CO2MX")
+
+                    logging.debug(
+                        f"Extracted scene means from template: {template_means}"
+                    )
+
         # Check for variables in heuristic but not in LUT (fatal error)
         for dim_name, dim_val in lut_grid.items():
             if dim_val is not None and len(dim_val) > 1:
@@ -1588,14 +1614,20 @@ def make_atmosphere_config(
 
             if dim_name not in lut_grid or lut_grid[dim_name] is None:
                 # Dimension in LUT but not in heuristic === interpolate
-                if dim_name.startswith("AOT") or dim_name.startswith("AERFRAC"):
+                # Use scene mean from template if available, otherwise fall back to LUT mean or aerosol formula
+                if dim_name in template_means and template_means[dim_name] is not None:
+                    interp_value = template_means[dim_name]
+                    source = "scene mean from template"
+                elif dim_name.startswith("AOT") or dim_name.startswith("AERFRAC"):
                     interp_value = get_aerosol_initial_value(vmin, vmax)
+                    source = "aerosol initial value formula"
                 else:
                     interp_value = (vmin + vmax) / 2.0
+                    source = "LUT midpoint"
 
                 logging.info(
                     f"Variable '{dim_name}' is present in prebuilt LUT but not "
-                    f"in heuristic. Will interpolate to {interp_value:.4f}"
+                    f"in heuristic. Will interpolate to {interp_value:.4f} ({source})"
                 )
                 lut_names[dim_name] = {"interp": interp_value}
 
@@ -1657,6 +1689,17 @@ def make_atmosphere_config(
                         "lte": constrained_max,
                         "encompass": True,
                     }
+                else:
+                    # Single value or no valid range - should interpolate
+                    logging.warning(
+                        f"Dimension '{dim_name}' in both LUT and heuristic but heuristic has "
+                        f"invalid value: {heuristic_val}. Treating as interpolation."
+                    )
+                    if dim_name.startswith("AOT") or dim_name.startswith("AERFRAC"):
+                        interp_value = get_aerosol_initial_value(vmin, vmax)
+                    else:
+                        interp_value = (vmin + vmax) / 2.0
+                    lut_names[dim_name] = {"interp": interp_value}
 
     for tr in np.unique(to_remove):
         lut_grid.pop(tr)
@@ -1666,6 +1709,8 @@ def make_atmosphere_config(
     # Set up lut_names for subsetting
     if prebuilt_lut_path is not None:
         # lut_names was already built during reconciliation above
+        logging.info(f"Final lut_names keys: {list(lut_names.keys())}")
+        logging.info(f"Final lut_names content: {lut_names}")
         atmosphere_config["engine"]["lut_names"] = lut_names
     else:
         # For new LUTs being built, lut_names should be None (use all points)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1559,6 +1559,11 @@ def make_atmosphere_config(
         else:
             lut_grid[gn] = np.array(gc).tolist()
 
+    # Remove single-value/None dimensions BEFORE reconciliation so
+    # to prevent entry in the heuristic (IE, we need to interpolate)
+    for tr in np.unique(to_remove):
+        lut_grid.pop(tr)
+
     if emulator_base is not None and os.path.splitext(emulator_base)[1] == ".jld2":
         from isofit.atmosphere.engines.kernel_flows import bounds_check
 
@@ -1586,17 +1591,13 @@ def make_atmosphere_config(
                 # Map MODTRAN parameters to isofit dimension names
                 template_means["solar_zenith"] = geom.get("PARM2")
                 template_means["observer_zenith"] = (
-                    180 - geom.get("OBSZEN")
-                    if geom.get("OBSZEN") is not None
-                    else None
+                    180 - geom.get("OBSZEN") if geom.get("OBSZEN") is not None else None
                 )  # Convert from MODTRAN convention
                 template_means["relative_azimuth"] = geom.get("PARM1")
                 template_means["surface_elevation_km"] = surf.get("GNDALT")
                 template_means["CO2"] = atm.get("CO2MX")
 
-                logging.debug(
-                    f"Extracted scene means from template: {template_means}"
-                )
+                logging.debug(f"Extracted scene means from template: {template_means}")
 
         # Check for variables in heuristic but not in LUT (fatal error)
         for dim_name, dim_val in lut_grid.items():
@@ -1703,9 +1704,6 @@ def make_atmosphere_config(
                     else:
                         interp_value = (vmin + vmax) / 2.0
                     lut_names[dim_name] = {"interp": interp_value}
-
-    for tr in np.unique(to_remove):
-        lut_grid.pop(tr)
 
     atmosphere_config["lut_grid"].update(lut_grid)
 

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1680,20 +1680,42 @@ def make_atmosphere_config(
 
                         logging.warning(
                             f"Variable '{dim_name}' heuristic range [{heuristic_min:.4f}, {heuristic_max:.4f}] "
-                            f"adjusted to use prebuilt LUT points that encompass this range: "
-                            f"[{lower_bound:.4f}, {upper_bound:.4f}] ({len(subset_lut_points)} points)"
+                            f"constrained to LUT range [{lut_min:.4f}, {lut_max:.4f}]. "
+                            f"Reader will use LUT points that encompass [{max(heuristic_min, lut_min):.4f}, "
+                            f"{min(heuristic_max, lut_max):.4f}]"
                         )
+                        # Store all LUT grid points that encompass the heuristic range
                         lut_grid[dim_name] = subset_lut_points.tolist()
 
-                # Apply the subset mechanism (existing logic)
-                if not isinstance(lut_grid[dim_name], dict):
-                    lut_grid[dim_name] = get_lut_subset(lut_grid[dim_name])
+                # Don't convert to dict here - we'll do that separately for lut_names
 
     for tr in np.unique(to_remove):
         lut_grid.pop(tr)
 
     atmosphere_config["lut_grid"].update(lut_grid)
-    atmosphere_config["engine"]["lut_names"] = {key: None for key in lut_grid.keys()}
+
+    # Set up lut_names for subsetting
+    # For prebuilt LUTs, convert grid definitions to subset strategies
+    # For new LUTs, lut_names should be None (use all points)
+    if prebuilt_lut_path is not None:
+        # lut_names controls how to subset the prebuilt LUT
+        # Convert lut_grid values to subset strategies (gte/lte dicts or interp dicts)
+        lut_names = {}
+        for key, val in lut_grid.items():
+            if isinstance(val, dict):
+                # Already a strategy (interp dict)
+                lut_names[key] = val
+            else:
+                # Convert list/array to gte/lte strategy
+                # Reader's sel() with encompass=True will find actual LUT grid points
+                lut_names[key] = get_lut_subset(val)
+
+        atmosphere_config["engine"]["lut_names"] = lut_names
+    else:
+        # For new LUTs being built, lut_names should be None (use all points)
+        atmosphere_config["engine"]["lut_names"] = {
+            key: None for key in lut_grid.keys()
+        }
 
     # Now do statevector
     statekeys = ["H2OSTR"]

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -864,12 +864,54 @@ def build_config(
     return config
 
 
+def inspect_prebuilt_lut_dimensions(prebuilt_lut_path: str, ncds: nc.Dataset = None):
+    """Inspect a prebuilt LUT NetCDF file to determine available dimensions and their ranges.
+
+    Args:
+        prebuilt_lut_path: path to the prebuilt LUT NetCDF file
+        ncds: optional already-opened NetCDF dataset (to avoid reopening)
+
+    Returns:
+        dict mapping dimension names to (min, max) tuples
+    """
+    close_after = False
+    if ncds is None:
+        ncds = nc.Dataset(prebuilt_lut_path, "r")
+        close_after = True
+
+    lut_dimensions = {}
+
+    # Iterate through all variables that could be LUT dimensions
+    # These are typically 1-D coordinate variables
+    for var_name in ncds.variables:
+        var = ncds.variables[var_name]
+
+        # Check if this is a coordinate/dimension variable (1-D)
+        if len(var.dimensions) == 1 and var.dimensions[0] == var_name:
+            # This is a dimension variable
+            data = var[:]
+            if len(data) > 0:
+                lut_dimensions[var_name] = (float(np.min(data)), float(np.max(data)))
+
+    if close_after:
+        ncds.close()
+
+    return lut_dimensions
+
+
 def get_lut_subset(vals):
     """Populate lut_names for the appropriate style of subsetting
 
     Args:
-        vals: the values to use for subsetting
+        vals: the values to use for subsetting (list, array, or dict)
+
+    Returns:
+        dict with either {"interp": value} for single values or
+        {"gte": min, "lte": max} for ranges, or None
     """
+    if isinstance(vals, dict):
+        # Already formatted, return as-is
+        return vals
 
     if vals is not None and len(vals) == 1:
         return {"interp": vals[0]}
@@ -1543,14 +1585,78 @@ def make_atmosphere_config(
     ncds = None
     if prebuilt_lut_path is not None:
         ncds = nc.Dataset(prebuilt_lut_path, "r")
-        for gn, gc in lut_grid.items():
-            if gn not in ncds.variables:
-                logging.warning(
-                    f"Key {gn} not found in prebuilt LUT, removing it from LUT."
+        lut_dimensions = inspect_prebuilt_lut_dimensions(prebuilt_lut_path, ncds)
+
+        # Check for variables in heuristic but not in LUT (fatal error)
+        for dim_name, dim_val in lut_grid.items():
+            if dim_val is not None and len(dim_val) > 1:
+                if dim_name not in lut_dimensions:
+                    raise ValueError(
+                        f"Variable '{dim_name}' is required by the template heuristic but is not "
+                        f"present in the prebuilt LUT at {prebuilt_lut_path}. "
+                        f"Available dimensions in LUT: {list(lut_dimensions.keys())}"
+                    )
+
+        # Check for variables in LUT but not in heuristic (interpolate to fixed value)
+        for lut_dim_name, lut_range in lut_dimensions.items():
+            if lut_dim_name not in lut_grid or lut_grid[lut_dim_name] is None:
+                # Determine the interpolation point
+                if lut_dim_name.startswith("AOT") or lut_dim_name.startswith("AERFRAC"):
+                    # For AOD, use the same initial guess as statevector
+                    # This matches load_climatology logic
+                    interp_value = (lut_range[1] - lut_range[0]) / 10.0 + lut_range[0]
+                else:
+                    # For other variables, use mean value
+                    interp_value = (lut_range[0] + lut_range[1]) / 2.0
+
+                logging.info(
+                    f"Variable '{lut_dim_name}' is present in prebuilt LUT but not "
+                    f"in heuristic. Will interpolate to {interp_value}"
                 )
-                to_remove.append(gn)
-            else:
-                lut_grid[gn] = get_lut_subset(gc)
+                lut_grid[lut_dim_name] = {"interp": interp_value}
+
+        # Check for range mismatches (subset if heuristic range exceeds LUT range)
+        for dim_name, dim_val in lut_grid.items():
+            if dim_name in lut_dimensions and dim_val is not None:
+                lut_min, lut_max = lut_dimensions[dim_name]
+
+                # Handle dict case (already formatted)
+                if isinstance(dim_val, dict):
+                    heuristic_values = None
+                else:
+                    heuristic_values = (
+                        dim_val if isinstance(dim_val, (list, np.ndarray)) else None
+                    )
+
+                if heuristic_values is not None and len(heuristic_values) > 1:
+                    heuristic_min, heuristic_max = min(heuristic_values), max(
+                        heuristic_values
+                    )
+
+                    # Check if heuristic exceeds LUT range
+                    if heuristic_min < lut_min or heuristic_max > lut_max:
+                        # Subset the heuristic to LUT range
+                        subset_values = [
+                            v for v in heuristic_values if lut_min <= v <= lut_max
+                        ]
+
+                        if len(subset_values) == 0:
+                            # No overlap - use closest LUT boundary
+                            if heuristic_min > lut_max:
+                                subset_values = [lut_max]
+                            else:
+                                subset_values = [lut_min]
+
+                        logging.warning(
+                            f"Variable '{dim_name}' heuristic range [{heuristic_min}, {heuristic_max}] "
+                            f"exceeds prebuilt LUT range [{lut_min}, {lut_max}]. "
+                            f"Subsetting to {subset_values}"
+                        )
+                        lut_grid[dim_name] = subset_values
+
+                # Apply the subset mechanism (existing logic)
+                if not isinstance(lut_grid[dim_name], dict):
+                    lut_grid[dim_name] = get_lut_subset(lut_grid[dim_name])
 
     for tr in np.unique(to_remove):
         lut_grid.pop(tr)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1641,7 +1641,9 @@ def make_atmosphere_config(
 
                 # Skip if already formatted as a dict
                 if isinstance(heuristic_val, dict):
-                    lut_names[dim_name] = heuristic_val
+                    lut_names[dim_name] = (
+                        heuristic_val.copy()
+                    )  # Copy to avoid shared references
                     continue
 
                 # Get heuristic range
@@ -1688,9 +1690,18 @@ def make_atmosphere_config(
                     # Store all encompassing LUT points in lut_grid
                     lut_grid[dim_name] = subset_points.tolist()
                     # Set gte and lte to the actual LUT grid boundaries (first and last point)
+                    logging.info(
+                        f"  {dim_name}: Setting lut_grid to {len(subset_points)} LUT points: "
+                        f"[{subset_points[0]:.4f}, ..., {subset_points[-1]:.4f}]"
+                    )
+
+                    # Convert to Python native floats to avoid numpy reference issues
+                    gte_val = float(subset_points[0])
+                    lte_val = float(subset_points[-1])
+
                     lut_names[dim_name] = {
-                        "gte": subset_points[0],
-                        "lte": subset_points[-1],
+                        "gte": gte_val,
+                        "lte": lte_val,
                         "encompass": True,
                     }
                 else:
@@ -1710,8 +1721,6 @@ def make_atmosphere_config(
     # Set up lut_names for subsetting
     if prebuilt_lut_path is not None:
         # lut_names was already built during reconciliation above
-        logging.info(f"Final lut_names keys: {list(lut_names.keys())}")
-        logging.info(f"Final lut_names content: {lut_names}")
         atmosphere_config["engine"]["lut_names"] = lut_names
     else:
         # For new LUTs being built, lut_names should be None (use all points)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1640,10 +1640,10 @@ def make_atmosphere_config(
                         & (lut_grid_points <= upper_bound)
                     ]
 
-                    # Heuristic bounds exceed LUT bounds, raise an error
-                    # May choose to relax this to just a warning later.
+                    # We hit this for AOD lower bound all the time,
+                    # so leaving as a warning for now
                     if heur_min < vmin or heur_max > vmax:
-                        raise ValueError(
+                        logging.warning(
                             f"Variable '{dim_name}' heuristic range [{heur_min:.4f}, {heur_max:.4f}] "
                             f"constrained to LUT range [{vmin:.4f}, {vmax:.4f}]. "
                             f"Reader will use LUT points that encompass [{constrained_min:.4f}, {constrained_max:.4f}]"

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -880,14 +880,14 @@ def get_aerosol_initial_value(range_min: float, range_max: float) -> float:
 
 
 def inspect_prebuilt_lut_dimensions(prebuilt_lut_path: str, ncds: nc.Dataset = None):
-    """Inspect a prebuilt LUT NetCDF file to determine available dimensions and their ranges.
+    """Inspect a prebuilt LUT NetCDF file to determine available dimensions and their grid points.
 
     Args:
         prebuilt_lut_path: path to the prebuilt LUT NetCDF file
         ncds: optional already-opened NetCDF dataset (to avoid reopening)
 
     Returns:
-        dict mapping dimension names to (min, max) tuples
+        dict mapping dimension names to numpy arrays of grid points
     """
     close_after = False
     if ncds is None:
@@ -903,10 +903,10 @@ def inspect_prebuilt_lut_dimensions(prebuilt_lut_path: str, ncds: nc.Dataset = N
 
         # Check if this is a coordinate/dimension variable (1-D)
         if len(var.dimensions) == 1 and var.dimensions[0] == var_name:
-            # This is a dimension variable
+            # This is a dimension variable - store the actual grid points
             data = var[:]
             if len(data) > 0:
-                lut_dimensions[var_name] = (float(np.min(data)), float(np.max(data)))
+                lut_dimensions[var_name] = np.array(data)
 
     if close_after:
         ncds.close()
@@ -1615,15 +1615,16 @@ def make_atmosphere_config(
                     )
 
         # Check for variables in LUT but not in heuristic (interpolate to fixed value)
-        for lut_dim_name, lut_range in lut_dimensions.items():
+        for lut_dim_name, lut_grid_points in lut_dimensions.items():
             if lut_dim_name not in lut_grid or lut_grid[lut_dim_name] is None:
                 # Determine the interpolation point
+                lut_min, lut_max = lut_grid_points.min(), lut_grid_points.max()
                 if lut_dim_name.startswith("AOT") or lut_dim_name.startswith("AERFRAC"):
                     # For AOD, use the same initial guess as statevector
-                    interp_value = get_aerosol_initial_value(lut_range[0], lut_range[1])
+                    interp_value = get_aerosol_initial_value(lut_min, lut_max)
                 else:
                     # For other variables, use mean value
-                    interp_value = (lut_range[0] + lut_range[1]) / 2.0
+                    interp_value = (lut_min + lut_max) / 2.0
 
                 logging.info(
                     f"Variable '{lut_dim_name}' is present in prebuilt LUT but not "
@@ -1631,44 +1632,58 @@ def make_atmosphere_config(
                 )
                 lut_grid[lut_dim_name] = {"interp": interp_value}
 
-        # Check for range mismatches (subset if heuristic range exceeds LUT range)
+        # Check for range mismatches - use LUT grid points that encompass heuristic range
         for dim_name, dim_val in lut_grid.items():
             if dim_name in lut_dimensions and dim_val is not None:
-                lut_min, lut_max = lut_dimensions[dim_name]
+                lut_grid_points = lut_dimensions[dim_name]
 
-                # Handle dict case (already formatted)
+                # Handle dict case (already formatted - skip subsetting)
                 if isinstance(dim_val, dict):
-                    heuristic_values = None
-                else:
-                    heuristic_values = (
-                        dim_val if isinstance(dim_val, (list, np.ndarray)) else None
-                    )
+                    continue
+
+                heuristic_values = (
+                    dim_val if isinstance(dim_val, (list, np.ndarray)) else None
+                )
 
                 if heuristic_values is not None and len(heuristic_values) > 1:
                     heuristic_min, heuristic_max = min(heuristic_values), max(
                         heuristic_values
                     )
+                    lut_min, lut_max = lut_grid_points.min(), lut_grid_points.max()
 
-                    # Check if heuristic exceeds LUT range
+                    # Check if we need to subset to LUT range
                     if heuristic_min < lut_min or heuristic_max > lut_max:
-                        # Subset the heuristic to LUT range
-                        subset_values = [
-                            v for v in heuristic_values if lut_min <= v <= lut_max
+                        # Find LUT grid points that fully encompass the heuristic range
+                        # Get the largest LUT point <= heuristic_min (or smallest LUT point if none)
+                        lower_candidates = lut_grid_points[
+                            lut_grid_points <= heuristic_min
+                        ]
+                        if len(lower_candidates) > 0:
+                            lower_bound = lower_candidates.max()
+                        else:
+                            lower_bound = lut_grid_points.min()
+
+                        # Get the smallest LUT point >= heuristic_max (or largest LUT point if none)
+                        upper_candidates = lut_grid_points[
+                            lut_grid_points >= heuristic_max
+                        ]
+                        if len(upper_candidates) > 0:
+                            upper_bound = upper_candidates.min()
+                        else:
+                            upper_bound = lut_grid_points.max()
+
+                        # Get all LUT points within [lower_bound, upper_bound]
+                        subset_lut_points = lut_grid_points[
+                            (lut_grid_points >= lower_bound)
+                            & (lut_grid_points <= upper_bound)
                         ]
 
-                        if len(subset_values) == 0:
-                            # No overlap - use closest LUT boundary
-                            if heuristic_min > lut_max:
-                                subset_values = [lut_max]
-                            else:
-                                subset_values = [lut_min]
-
                         logging.warning(
-                            f"Variable '{dim_name}' heuristic range [{heuristic_min}, {heuristic_max}] "
-                            f"exceeds prebuilt LUT range [{lut_min}, {lut_max}]. "
-                            f"Subsetting to {subset_values}"
+                            f"Variable '{dim_name}' heuristic range [{heuristic_min:.4f}, {heuristic_max:.4f}] "
+                            f"adjusted to use prebuilt LUT points that encompass this range: "
+                            f"[{lower_bound:.4f}, {upper_bound:.4f}] ({len(subset_lut_points)} points)"
                         )
-                        lut_grid[dim_name] = subset_values
+                        lut_grid[dim_name] = subset_lut_points.tolist()
 
                 # Apply the subset mechanism (existing logic)
                 if not isinstance(lut_grid[dim_name], dict):

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1574,26 +1574,29 @@ def make_atmosphere_config(
         if modtran_template_path is not None and os.path.exists(modtran_template_path):
             with open(modtran_template_path, "r") as f:
                 template = json.load(f)
+                if "cases" in template:
+                    template = template["cases"][0]
+                template = template["MODTRAN"][0]["MODTRANINPUT"]
+
                 # Extract geometry parameters from first case
-                if "cases" in template and len(template["cases"]) > 0:
-                    geom = template["cases"][0]["MODTRAN"][0].get("GEOMETRY", {})
-                    surf = template["cases"][0]["MODTRAN"][0].get("SURFACE", {})
-                    atm = template["cases"][0]["MODTRAN"][0].get("ATMOSPHERE", {})
+                geom = template.get("GEOMETRY", {})
+                surf = template.get("SURFACE", {})
+                atm = template.get("ATMOSPHERE", {})
 
-                    # Map MODTRAN parameters to isofit dimension names
-                    template_means["solar_zenith"] = geom.get("PARM2")
-                    template_means["observer_zenith"] = (
-                        180 - geom.get("OBSZEN")
-                        if geom.get("OBSZEN") is not None
-                        else None
-                    )  # Convert from MODTRAN convention
-                    template_means["relative_azimuth"] = geom.get("PARM1")
-                    template_means["surface_elevation_km"] = surf.get("GNDALT")
-                    template_means["CO2"] = atm.get("CO2MX")
+                # Map MODTRAN parameters to isofit dimension names
+                template_means["solar_zenith"] = geom.get("PARM2")
+                template_means["observer_zenith"] = (
+                    180 - geom.get("OBSZEN")
+                    if geom.get("OBSZEN") is not None
+                    else None
+                )  # Convert from MODTRAN convention
+                template_means["relative_azimuth"] = geom.get("PARM1")
+                template_means["surface_elevation_km"] = surf.get("GNDALT")
+                template_means["CO2"] = atm.get("CO2MX")
 
-                    logging.debug(
-                        f"Extracted scene means from template: {template_means}"
-                    )
+                logging.debug(
+                    f"Extracted scene means from template: {template_means}"
+                )
 
         # Check for variables in heuristic but not in LUT (fatal error)
         for dim_name, dim_val in lut_grid.items():
@@ -1612,8 +1615,8 @@ def make_atmosphere_config(
 
             vmin, vmax = lut_grid_points.min(), lut_grid_points.max()
 
+            # Dimension in LUT but not in heuristic === interpolate
             if dim_name not in lut_grid or lut_grid[dim_name] is None:
-                # Dimension in LUT but not in heuristic === interpolate
                 # Use scene mean from template if available, otherwise fall back to LUT mean or aerosol formula
                 if dim_name in template_means and template_means[dim_name] is not None:
                     interp_value = template_means[dim_name]
@@ -1631,8 +1634,8 @@ def make_atmosphere_config(
                 )
                 lut_names[dim_name] = {"interp": interp_value}
 
+            # Dimension in both LUT and heuristic === subset
             else:
-                # Dimension in both LUT and heuristic === subset
                 heuristic_val = lut_grid[dim_name]
 
                 # Skip if already formatted as a dict

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1565,10 +1565,8 @@ def make_atmosphere_config(
         # Should only modify H2OSTR and surface_elevation_km
         bounds_check(lut_grid, emulator_base, modify=True)
 
-    ncds = None
     lut_names = {}
     if prebuilt_lut_path is not None:
-        ncds = nc.Dataset(prebuilt_lut_path, "r")
         prebuilt_dimensions = inspect_lut_dimensions(prebuilt_lut_path)
 
         # Check for variables in heuristic but not in LUT (fatal error)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1581,6 +1581,9 @@ def make_atmosphere_config(
 
         # Process each dimension in the prebuilt LUT
         for dim_name, lut_grid_points in prebuilt_dimensions.items():
+            if dim_name == "wl":
+                continue
+
             vmin, vmax = lut_grid_points.min(), lut_grid_points.max()
 
             if dim_name not in lut_grid or lut_grid[dim_name] is None:

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -864,6 +864,21 @@ def build_config(
     return config
 
 
+def get_aerosol_initial_value(range_min: float, range_max: float) -> float:
+    """Calculate the initial/interpolation value for aerosol parameters.
+    Somewhat arbitrary, but puts the starting value away from the lower bound,
+    but still low (assuming clear sky).
+
+    Args:
+        range_min: minimum value of the aerosol parameter range
+        range_max: maximum value of the aerosol parameter range
+
+    Returns:
+        float: the initial/interpolation value (min + 10% of range)
+    """
+    return (range_max - range_min) / 10.0 + range_min
+
+
 def inspect_prebuilt_lut_dimensions(prebuilt_lut_path: str, ncds: nc.Dataset = None):
     """Inspect a prebuilt LUT NetCDF file to determine available dimensions and their ranges.
 
@@ -1073,12 +1088,13 @@ def load_climatology(
         )
 
         if aerosol_lut is not None:
+            init_value = get_aerosol_initial_value(alr[0], alr[1])
             aerosol_state_vector["AERFRAC_{}".format(_a)] = {
                 "bounds": [float(alr[0]), float(alr[1])],
                 "scale": 1,
-                "init": float((alr[1] - alr[0]) / 10.0 + alr[0]),
+                "init": float(init_value),
                 "prior_sigma": 10.0,
-                "prior_mean": float((alr[1] - alr[0]) / 10.0 + alr[0]),
+                "prior_mean": float(init_value),
             }
 
             aerosol_lut_grid["AERFRAC_{}".format(_a)] = aerosol_lut.tolist()
@@ -1093,12 +1109,13 @@ def load_climatology(
     if aot_550_lut is not None:
         aerosol_lut_grid["AOT550"] = aot_550_lut.tolist()
         alr = [aerosol_lut_grid["AOT550"][0], aerosol_lut_grid["AOT550"][-1]]
+        init_value = get_aerosol_initial_value(alr[0], alr[1])
         aerosol_state_vector["AOT550"] = {
             "bounds": [float(alr[0]), float(alr[1])],
             "scale": 1,
-            "init": float((alr[1] - alr[0]) / 10.0 + alr[0]),
+            "init": float(init_value),
             "prior_sigma": 10.0,
-            "prior_mean": float((alr[1] - alr[0]) / 10.0 + alr[0]),
+            "prior_mean": float(init_value),
         }
 
     logging.info("Loading Climatology")
@@ -1603,8 +1620,7 @@ def make_atmosphere_config(
                 # Determine the interpolation point
                 if lut_dim_name.startswith("AOT") or lut_dim_name.startswith("AERFRAC"):
                     # For AOD, use the same initial guess as statevector
-                    # This matches load_climatology logic
-                    interp_value = (lut_range[1] - lut_range[0]) / 10.0 + lut_range[0]
+                    interp_value = get_aerosol_initial_value(lut_range[0], lut_range[1])
                 else:
                     # For other variables, use mean value
                     interp_value = (lut_range[0] + lut_range[1]) / 2.0

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1566,94 +1566,97 @@ def make_atmosphere_config(
         bounds_check(lut_grid, emulator_base, modify=True)
 
     ncds = None
+    lut_names = {}
     if prebuilt_lut_path is not None:
         ncds = nc.Dataset(prebuilt_lut_path, "r")
-        lut_dimensions = inspect_lut_dimensions(prebuilt_lut_path)
+        prebuilt_dimensions = inspect_lut_dimensions(prebuilt_lut_path)
 
         # Check for variables in heuristic but not in LUT (fatal error)
         for dim_name, dim_val in lut_grid.items():
             if dim_val is not None and len(dim_val) > 1:
-                if dim_name not in lut_dimensions:
+                if dim_name not in prebuilt_dimensions:
                     raise ValueError(
                         f"Variable '{dim_name}' is required by the template heuristic but is not "
                         f"present in the prebuilt LUT at {prebuilt_lut_path}. "
-                        f"Available dimensions in LUT: {list(lut_dimensions.keys())}"
+                        f"Available dimensions in LUT: {list(prebuilt_dimensions.keys())}"
                     )
 
-        # Check for variables in LUT but not in heuristic (interpolate to fixed value)
-        for lut_dim_name, lut_grid_points in lut_dimensions.items():
-            if lut_dim_name not in lut_grid or lut_grid[lut_dim_name] is None:
-                # Determine the interpolation point
-                lut_min, lut_max = lut_grid_points.min(), lut_grid_points.max()
-                if lut_dim_name.startswith("AOT") or lut_dim_name.startswith("AERFRAC"):
-                    # For AOD, use the same initial guess as statevector
-                    interp_value = get_aerosol_initial_value(lut_min, lut_max)
+        # Process each dimension in the prebuilt LUT
+        for dim_name, lut_grid_points in prebuilt_dimensions.items():
+            vmin, vmax = lut_grid_points.min(), lut_grid_points.max()
+
+            if dim_name not in lut_grid or lut_grid[dim_name] is None:
+                # Dimension in LUT but not in heuristic === interpolate
+                if dim_name.startswith("AOT") or dim_name.startswith("AERFRAC"):
+                    interp_value = get_aerosol_initial_value(vmin, vmax)
                 else:
-                    # For other variables, use mean value
-                    interp_value = (lut_min + lut_max) / 2.0
+                    interp_value = (vmin + vmax) / 2.0
 
                 logging.info(
-                    f"Variable '{lut_dim_name}' is present in prebuilt LUT but not "
-                    f"in heuristic. Will interpolate to {interp_value}"
+                    f"Variable '{dim_name}' is present in prebuilt LUT but not "
+                    f"in heuristic. Will interpolate to {interp_value:.4f}"
                 )
-                lut_grid[lut_dim_name] = {"interp": interp_value}
+                lut_grid[dim_name] = {"interp": interp_value}
+                lut_names[dim_name] = {"interp": interp_value}
 
-        # Check for range mismatches - use LUT grid points that encompass heuristic range
-        for dim_name, dim_val in lut_grid.items():
-            if dim_name in lut_dimensions and dim_val is not None:
-                lut_grid_points = lut_dimensions[dim_name]
+            else:
+                # Dimension in both LUT and heuristic === subset
+                heuristic_val = lut_grid[dim_name]
 
-                # Handle dict case (already formatted - skip subsetting)
-                if isinstance(dim_val, dict):
+                # Skip if already formatted as a dict
+                if isinstance(heuristic_val, dict):
+                    lut_names[dim_name] = heuristic_val
                     continue
 
-                heuristic_values = (
-                    dim_val if isinstance(dim_val, (list, np.ndarray)) else None
-                )
+                # Get heuristic range
+                if (
+                    isinstance(heuristic_val, (list, np.ndarray))
+                    and len(heuristic_val) > 1
+                ):
+                    heur_min, heur_max = min(heuristic_val), max(heuristic_val)
 
-                if heuristic_values is not None and len(heuristic_values) > 1:
-                    heuristic_min, heuristic_max = min(heuristic_values), max(
-                        heuristic_values
+                    # Constrain heuristic to LUT bounds
+                    constrained_min = max(heur_min, vmin)
+                    constrained_max = min(heur_max, vmax)
+
+                    # Find LUT grid points that encompass the constrained range
+                    lower_candidates = lut_grid_points[
+                        lut_grid_points <= constrained_min
+                    ]
+                    lower_bound = (
+                        lower_candidates.max() if len(lower_candidates) > 0 else vmin
                     )
-                    lut_min, lut_max = lut_grid_points.min(), lut_grid_points.max()
 
-                    # Check if we need to subset to LUT range
-                    if heuristic_min < lut_min or heuristic_max > lut_max:
-                        # Find LUT grid points that fully encompass the heuristic range
-                        # Get the largest LUT point <= heuristic_min (or smallest LUT point if none)
-                        lower_candidates = lut_grid_points[
-                            lut_grid_points <= heuristic_min
-                        ]
-                        if len(lower_candidates) > 0:
-                            lower_bound = lower_candidates.max()
-                        else:
-                            lower_bound = lut_grid_points.min()
+                    upper_candidates = lut_grid_points[
+                        lut_grid_points >= constrained_max
+                    ]
+                    upper_bound = (
+                        upper_candidates.min() if len(upper_candidates) > 0 else vmax
+                    )
 
-                        # Get the smallest LUT point >= heuristic_max (or largest LUT point if none)
-                        upper_candidates = lut_grid_points[
-                            lut_grid_points >= heuristic_max
-                        ]
-                        if len(upper_candidates) > 0:
-                            upper_bound = upper_candidates.min()
-                        else:
-                            upper_bound = lut_grid_points.max()
+                    # Get all LUT points in the encompassing range
+                    subset_points = lut_grid_points[
+                        (lut_grid_points >= lower_bound)
+                        & (lut_grid_points <= upper_bound)
+                    ]
 
-                        # Get all LUT points within [lower_bound, upper_bound]
-                        subset_lut_points = lut_grid_points[
-                            (lut_grid_points >= lower_bound)
-                            & (lut_grid_points <= upper_bound)
-                        ]
-
-                        logging.warning(
-                            f"Variable '{dim_name}' heuristic range [{heuristic_min:.4f}, {heuristic_max:.4f}] "
-                            f"constrained to LUT range [{lut_min:.4f}, {lut_max:.4f}]. "
-                            f"Reader will use LUT points that encompass [{max(heuristic_min, lut_min):.4f}, "
-                            f"{min(heuristic_max, lut_max):.4f}]"
+                    # Heuristic bounds exceed LUT bounds, raise an error
+                    # May choose to relax this to just a warning later.
+                    if heur_min < vmin or heur_max > vmax:
+                        raise ValueError(
+                            f"Variable '{dim_name}' heuristic range [{heur_min:.4f}, {heur_max:.4f}] "
+                            f"constrained to LUT range [{vmin:.4f}, {vmax:.4f}]. "
+                            f"Reader will use LUT points that encompass [{constrained_min:.4f}, {constrained_max:.4f}]"
                         )
-                        # Store all LUT grid points that encompass the heuristic range
-                        lut_grid[dim_name] = subset_lut_points.tolist()
 
-                # Don't convert to dict here - we'll do that separately for lut_names
+                    # Store all encompassing LUT points in lut_grid
+                    lut_grid[dim_name] = subset_points.tolist()
+                    # Set gte and lte.  Also set encompass for completeness
+                    lut_names[dim_name] = {
+                        "gte": constrained_min,
+                        "lte": constrained_max,
+                        "encompass": True,
+                    }
 
     for tr in np.unique(to_remove):
         lut_grid.pop(tr)
@@ -1661,21 +1664,8 @@ def make_atmosphere_config(
     atmosphere_config["lut_grid"].update(lut_grid)
 
     # Set up lut_names for subsetting
-    # For prebuilt LUTs, convert grid definitions to subset strategies
-    # For new LUTs, lut_names should be None (use all points)
     if prebuilt_lut_path is not None:
-        # lut_names controls how to subset the prebuilt LUT
-        # Convert lut_grid values to subset strategies (gte/lte dicts or interp dicts)
-        lut_names = {}
-        for key, val in lut_grid.items():
-            if isinstance(val, dict):
-                # Already a strategy (interp dict)
-                lut_names[key] = val
-            else:
-                # Convert list/array to gte/lte strategy
-                # Reader's sel() with encompass=True will find actual LUT grid points
-                lut_names[key] = get_lut_subset(val)
-
+        # lut_names was already built during reconciliation above
         atmosphere_config["engine"]["lut_names"] = lut_names
     else:
         # For new LUTs being built, lut_names should be None (use all points)

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1597,7 +1597,6 @@ def make_atmosphere_config(
                     f"Variable '{dim_name}' is present in prebuilt LUT but not "
                     f"in heuristic. Will interpolate to {interp_value:.4f}"
                 )
-                lut_grid[dim_name] = {"interp": interp_value}
                 lut_names[dim_name] = {"interp": interp_value}
 
             else:

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1687,10 +1687,10 @@ def make_atmosphere_config(
 
                     # Store all encompassing LUT points in lut_grid
                     lut_grid[dim_name] = subset_points.tolist()
-                    # Set gte and lte.  Also set encompass for completeness
+                    # Set gte and lte to the actual LUT grid boundaries (first and last point)
                     lut_names[dim_name] = {
-                        "gte": constrained_min,
-                        "lte": constrained_max,
+                        "gte": subset_points[0],
+                        "lte": subset_points[-1],
                         "encompass": True,
                     }
                 else:

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -22,6 +22,7 @@ from isofit.core import units
 from isofit.core.common import envi_header, expand_path, json_load_ascii
 from isofit.core.multistate import SurfaceMapping
 from isofit.data import env
+from isofit.luts.reader import inspect_lut_dimensions
 from isofit.utils.surface_model import surface_model
 
 
@@ -879,41 +880,6 @@ def get_aerosol_initial_value(range_min: float, range_max: float) -> float:
     return (range_max - range_min) / 10.0 + range_min
 
 
-def inspect_prebuilt_lut_dimensions(prebuilt_lut_path: str, ncds: nc.Dataset = None):
-    """Inspect a prebuilt LUT NetCDF file to determine available dimensions and their grid points.
-
-    Args:
-        prebuilt_lut_path: path to the prebuilt LUT NetCDF file
-        ncds: optional already-opened NetCDF dataset (to avoid reopening)
-
-    Returns:
-        dict mapping dimension names to numpy arrays of grid points
-    """
-    close_after = False
-    if ncds is None:
-        ncds = nc.Dataset(prebuilt_lut_path, "r")
-        close_after = True
-
-    lut_dimensions = {}
-
-    # Iterate through all variables that could be LUT dimensions
-    # These are typically 1-D coordinate variables
-    for var_name in ncds.variables:
-        var = ncds.variables[var_name]
-
-        # Check if this is a coordinate/dimension variable (1-D)
-        if len(var.dimensions) == 1 and var.dimensions[0] == var_name:
-            # This is a dimension variable - store the actual grid points
-            data = var[:]
-            if len(data) > 0:
-                lut_dimensions[var_name] = np.array(data)
-
-    if close_after:
-        ncds.close()
-
-    return lut_dimensions
-
-
 def get_lut_subset(vals):
     """Populate lut_names for the appropriate style of subsetting
 
@@ -1602,7 +1568,7 @@ def make_atmosphere_config(
     ncds = None
     if prebuilt_lut_path is not None:
         ncds = nc.Dataset(prebuilt_lut_path, "r")
-        lut_dimensions = inspect_prebuilt_lut_dimensions(prebuilt_lut_path, ncds)
+        lut_dimensions = inspect_lut_dimensions(prebuilt_lut_path)
 
         # Check for variables in heuristic but not in LUT (fatal error)
         for dim_name, dim_val in lut_grid.items():

--- a/isofit/utils/wavelength_cal.py
+++ b/isofit/utils/wavelength_cal.py
@@ -324,23 +324,16 @@ def wavelength_cal(
     if emulator_base is not None:
         if emulator_base.endswith(".jld2"):
             multipart_transmittance = False
+
+        elif emulator_base.endswith(".h5"):
+            multipart_transmittance = False
+
+        elif emulator_base.endswith(".6c"):
+            multipart_transmittance = True
+
         else:
-            if emulator_base.endswith(".npz"):
-                emulator_aux_file = emulator_base
-            else:
-                emulator_aux_file = os.path.abspath(
-                    os.path.splitext(emulator_base)[0] + "_aux.npz"
-                )
-            aux = np.load(emulator_aux_file)
-            if (
-                "transm_down_dir"
-                and "transm_down_dif"
-                and "transm_up_dir"
-                and "transm_up_dif" in aux["rt_quantities"]
-            ):
-                multipart_transmittance = True
-            else:
-                multipart_transmittance = False
+            raise ValueError("Invalid emulator_base extension. Use .h5, .6c, or .jld2")
+
     else:
         # This is the MODTRAN case. Do we want to enable the 4c mode by default?
         multipart_transmittance = True


### PR DESCRIPTION
Overtakes #921 with a fresh write to try and handle the grid appropriately (921 got tangled between config parameters).  Highlevel strategy is to:

- Check prebuilt lut dimensions (inspect_prebuilt_lut_dimensions) -> @jammont, should this live in luts instead of template_construction.py?
- If both heuristic and prebuilt LUT have component, but heuristic range is smaller than LUT, subset LUT
- If a variable is in the heuristic and not in the prebuilt LUT throw an error (TBC, providing the LUT config will subset the heuristic before this check)
- If a variable is in the prebuilt LUT and not in the heuristic, interpolate to the mean.

Still needs testing, and verification around boundary conditions.

Boundary condition points update:

Say: 
  - Heuristic range is [0.60, 1.70]
  - LUT has grid points [0.3, 0.5, 0.8, 1.0, 1.3, 1.5, 1.8, 2.0, 2.3]
  - We should subset the LUT to [0.5, 0.8, 1.0, 1.3, 1.5, 1.8]
 
Alternatively we could interpolate to the upper and lower point, but that would cause a computational hit on load.