### PR TITLE
apply h2o upper bound check per pixel

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -81,7 +81,9 @@ class ForwardModel:
         modtran_config = json_load_ascii(
             self.full_config.forward_model.atmosphere.template_file
         )["MODTRAN"][0]["MODTRANINPUT"]
-        self.atmosphere_type = modtran_config["ATMOSPHERE"]["M1"]
+        self.atmosphere_type = modtran_config["ATMOSPHERE"].get(
+            "M1", "ATM_MIDLAT_SUMMER"
+        )
         self.h2o_polynomial = ModtranRT.modtran_water_upperbound_polynomials()[
             self.atmosphere_type
         ]

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -78,9 +78,9 @@ class ForwardModel:
             self.atmosphere = Atmosphere(self.full_config)
 
         # Determine atmosphere type to dynamically set h2o bounds with respect to elevation
-        modtran_config = json_load_ascii(self.config.template_file)["MODTRAN"][0][
-            "MODTRANINPUT"
-        ]
+        modtran_config = json_load_ascii(
+            self.full_config.forward_model.atmosphere.template_file
+        )["MODTRAN"][0]["MODTRANINPUT"]
         self.atmosphere_type = modtran_config["ATMOSPHERE"]["M1"]
         self.h2o_polynomial = ModtranRT.modtran_water_upperbound_polynomials()[
             self.atmosphere_type

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -27,8 +27,9 @@ from scipy.interpolate import interp1d
 from scipy.io import loadmat
 from scipy.linalg import block_diag
 
+from isofit.atmosphere.engines.modtran import ModtranRT
 from isofit.atmosphere import Atmosphere
-from isofit.core.common import eps
+from isofit.core.common import eps, json_load_ascii
 from isofit.core.geometry import Geometry
 from isofit.core.instrument import Instrument
 from isofit.core.multistate import match_statevector
@@ -75,6 +76,15 @@ class ForwardModel:
             self.atmosphere = cache_atmosphere
         else:
             self.atmosphere = Atmosphere(self.full_config)
+
+        # Determine atmosphere type to dynamically set h2o bounds with respect to elevation
+        modtran_config = json_load_ascii(self.config.template_file)["MODTRAN"][0][
+            "MODTRANINPUT"
+        ]
+        self.atmosphere_type = modtran_config["ATMOSPHERE"]["M1"]
+        self.h2o_polynomial = ModtranRT.modtran_water_upperbound_polynomials()[
+            self.atmosphere_type
+        ]
 
         # Build the surface model
         self.surface = Surface(full_config)

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -334,6 +334,15 @@ class Inversion:
 
             x0 = x0[self.inds_free]
 
+            # Ensure H2O bounds are physical and update the bounds for the worker
+            self.fm.bounds[1][self.atmosphere.statevec_names.index("H2OSTR")] = (
+                self.fm.max_h2o(geom.surface_elevation_km) - 1e-8
+            )
+            self.least_squares_params["bounds"] = (
+                self.fm.bounds[0][self.inds_free],
+                self.fm.bounds[1][self.inds_free],
+            )
+
             # Catch any state vector elements outside of bounds
             lower_bound_violation = x0 < self.fm.bounds[0][self.inds_free]
             x0[lower_bound_violation] = (

--- a/isofit/inversion/inverse.py
+++ b/isofit/inversion/inverse.py
@@ -335,8 +335,8 @@ class Inversion:
             x0 = x0[self.inds_free]
 
             # Ensure H2O bounds are physical and update the bounds for the worker
-            self.fm.bounds[1][self.atmosphere.statevec_names.index("H2OSTR")] = (
-                self.fm.max_h2o(geom.surface_elevation_km) - 1e-8
+            self.fm.bounds[1][self.fm.atmosphere.statevec_names.index("H2OSTR")] = (
+                self.fm.h2o_polynomial(geom.surface_elevation_km) - 1e-8
             )
             self.least_squares_params["bounds"] = (
                 self.fm.bounds[0][self.inds_free],


### PR DESCRIPTION
@unbohn and I found evidence in v001 data of high (likely erroneous) water vapor occurring in high elevations, `EMIT_L2A_RFL_001_20260422T174438_2611211_011`.  With @pgbrodrick's latest improvements in the 6c emulator, and ensuring training data took into account max physical water vapor, this probably won't be an issue in the future (?). However, for backwards compatibility (1c model) and other LUTs (prebuilt), it may be useful to have a per-pixel physical check to update the h2o upper bound?

If we recall, this idea is related to #689 . Currently we just use this information to inform max water vapor bounds for lut grid creation. We can still have non-physical h2o though image-wide because scene altitude can vary significantly (e.g., in this scene below from 0 - 4.3 km). 

**Update: testing this on dev using 6c emulator, the water vapor values are much lower.** And so, this really would just be an extra safety net, as recent updates have appeared to mostly address this issue. To discuss..

#### EMIT_L2A_RFL_001_20260422T174438_2611211_011
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/3b6fdbb1-44a2-4dd9-8216-0a9fee833cfd" alt="Screenshot 1" width="460"/></td>
    <td><img src="https://github.com/user-attachments/assets/dcbf48bf-547e-4084-b306-710bf60edb39" alt="Screenshot 2" width="400"/></td>
  </tr>
</table>


<img width="3440" height="866" alt="image" src="https://github.com/user-attachments/assets/019d5916-09d3-4657-9a18-13c1d02caf3a" />
