### PR TITLE
Distros Workflow Bugfixes

### DIFF
--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -31,8 +31,9 @@ jobs:
 
       - name: Verify install
         run: |
-          isofit --help | tee help.txt
-          grep -q "usage:" help.txt
+          output="$(isofit --help)"
+          echo "$output"
+          grep -q "usage:" <<< "$output"
 
   uv:
     strategy:
@@ -63,8 +64,9 @@ jobs:
 
       - name: Verify install
         run: |
-          isofit --help | tee help.txt
-          grep -q "usage:" help.txt
+          output="$(isofit --help)"
+          echo "$output"
+          grep -q "usage:" <<< "$output"
 
   conda:
     strategy:
@@ -94,5 +96,6 @@ jobs:
       - name: Verify install
         shell: bash -l {0}
         run: |
-          isofit --help | tee help.txt
-          grep -q "usage:" help.txt
+          output="$(isofit --help)"
+          echo "$output"
+          grep -q "usage:" <<< "$output"

--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -4,11 +4,13 @@ on:
   schedule:
     - cron: "0 14 * * *" # daily at 14:00 UTC / 06:00 PST
   workflow_dispatch:
+  pull_request:
 
 jobs:
   pypi:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.11"
@@ -28,10 +30,37 @@ jobs:
         run: |
           isofit --help
 
+  uv:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.25"
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
+
+      - name: Install from PyPI
+        run: |
+          uv pip install isofit
+
+      - name: Verify install
+        run: |
+          isofit --help
+
   conda:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        fail-fast: false
         python-version:
           - "3.11"
           - "3.12"

--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -30,6 +30,7 @@ jobs:
           pip install isofit
 
       - name: Verify install
+        shell: bash
         run: |
           output="$(isofit --help)"
           echo "$output"
@@ -63,6 +64,7 @@ jobs:
           uv pip install isofit
 
       - name: Verify install
+        shell: bash
         run: |
           output="$(isofit --help)"
           echo "$output"

--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           output="$(isofit --help)"
           echo "$output"
-          grep -q "usage:" <<< "$output"
+          grep -q "Execute ISOFIT core" <<< "$output"
 
   uv:
     strategy:
@@ -68,7 +68,7 @@ jobs:
         run: |
           output="$(isofit --help)"
           echo "$output"
-          grep -q "usage:" <<< "$output"
+          grep -q "Execute ISOFIT core" <<< "$output"
 
   conda:
     strategy:
@@ -100,4 +100,4 @@ jobs:
         run: |
           output="$(isofit --help)"
           echo "$output"
-          grep -q "usage:" <<< "$output"
+          grep -q "Execute ISOFIT core" <<< "$output"

--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  pypi:
+  pip:
     strategy:
       fail-fast: false
       matrix:
@@ -25,13 +25,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install from PyPI
+      - name: Install from PyPI using pip
         run: |
           pip install isofit
 
       - name: Verify install
         run: |
-          isofit --help
+          isofit --help | tee help.txt
+          grep -q "usage:" help.txt
 
   uv:
     strategy:
@@ -53,14 +54,17 @@ jobs:
           version: "0.9.25"
           python-version: ${{ matrix.python-version }}
           activate-environment: true
+          enable-cache: false
+          no-project: true
 
-      - name: Install from PyPI
+      - name: Install from PyPI using uv
         run: |
           uv pip install isofit
 
       - name: Verify install
         run: |
-          isofit --help
+          isofit --help | tee help.txt
+          grep -q "usage:" help.txt
 
   conda:
     strategy:
@@ -90,4 +94,5 @@ jobs:
       - name: Verify install
         shell: bash -l {0}
         run: |
-          isofit --help
+          isofit --help | tee help.txt
+          grep -q "usage:" help.txt

--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -5,8 +5,6 @@ on:
     - cron: "0 14 * * *" # daily at 14:00 UTC / 06:00 PST
   workflow_dispatch:
   pull_request:
-    branches-ignore: ["main", "gh-pages"]
-    paths: ["isofit/**", "recipe/*.yml", "pyproject.toml", ".github/**"]
 
 jobs:
   pypi:
@@ -61,8 +59,8 @@ jobs:
   conda:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         python-version:
           - "3.11"
           - "3.12"

--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 14 * * *" # daily at 14:00 UTC / 06:00 PST
   workflow_dispatch:
   pull_request:
+    branches-ignore: ["main", "gh-pages"]
+    paths: ["isofit/**", "recipe/*.yml", "pyproject.toml", ".github/**"]
 
 jobs:
   pypi:

--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Verify install
         shell: bash
         run: |
-          output="$(isofit --help)"
-          echo "$output"
-          grep -q "Execute ISOFIT core" <<< "$output"
+          isofit --help
 
   uv:
     strategy:
@@ -66,9 +64,7 @@ jobs:
       - name: Verify install
         shell: bash
         run: |
-          output="$(isofit --help)"
-          echo "$output"
-          grep -q "Execute ISOFIT core" <<< "$output"
+          isofit --help
 
   conda:
     strategy:
@@ -98,6 +94,4 @@ jobs:
       - name: Verify install
         shell: bash -l {0}
         run: |
-          output="$(isofit --help)"
-          echo "$output"
-          grep -q "Execute ISOFIT core" <<< "$output"
+          isofit --help

--- a/.github/workflows/check_distros.yml
+++ b/.github/workflows/check_distros.yml
@@ -2,13 +2,12 @@ name: Test Package Distributions
 
 on:
   schedule:
-    - cron: "0 14 * * *" # daily at 14:00 UTC / 06:00 PST
+    - cron: "0 14 * * 0" # Every Sunday at 14:00 UTC / 06:00 PST
   workflow_dispatch:
   pull_request:
 
 jobs:
   pypi:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -17,6 +16,10 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-python@v6
         with:
@@ -31,7 +34,6 @@ jobs:
           isofit --help
 
   uv:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -40,6 +42,10 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -57,7 +63,6 @@ jobs:
           isofit --help
 
   conda:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +71,10 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: conda-incubator/setup-miniconda@v4
         with:


### PR DESCRIPTION
Some bugfixes for the distros test workflow:
- Disabled fail-fast, to ensure each python version gets checked
- Added a uv installation check

Temporarily enabled the workflow on pull_request, for testing