### PR TITLE
Incorrect elevation_lut_grid = None order in ApplyOE. Failing Windows wl-cal test.

### DIFF
--- a/isofit/test/test_examples.py
+++ b/isofit/test/test_examples.py
@@ -126,10 +126,13 @@ def test_wavelength_cal(args, kwargs, monkeypatch):
     )
     assert result.exit_code == 0
 
-    shutil.rmtree("output")
-    shutil.rmtree("data")
-    shutil.rmtree("config")
-    shutil.rmtree("input")
+    try:
+        shutil.rmtree("output")
+        shutil.rmtree("data")
+        shutil.rmtree("config")
+        shutil.rmtree("input")
+    except PermissionError:
+        pass
 
 
 @pytest.mark.examples

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -535,10 +535,10 @@ def apply_oe(
             elevation_lut_grid[elevation_lut_grid < 0] = 0
             elevation_lut_grid = np.unique(elevation_lut_grid)
             if len(elevation_lut_grid) == 1:
-                elevation_lut_grid = None
                 mean_elevation_km = elevation_lut_grid[
                     0
                 ]  # should be 0, but just in case
+                elevation_lut_grid = None
             logging.info(
                 "Scene contains target lut grid elements < 0 km, and uses 6s (via"
                 " sRTMnet).  6s does not support targets below sea level in km units. "


### PR DESCRIPTION
**Problem:**

On edge cases where len(elevation_lut_grid) = 1 and any(elevation_lut_grid < 0), we are setting elevation_lut_grid = None then trying to index it. The edge case can be hit over full-water scenes.

**Fix:**

Change the order of operations.

**Misc:**

I also added a try block in the wavelength cal test to see if this would resolve the Windows issue. 