### PR TITLE
Spectral gradient angle to make prior selection more robust

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -99,7 +99,7 @@ class SurfaceConfig(BaseConfigSection):
         The state is preserved in the geometry object so that this object stays stateless"""
 
         self._selection_metric_type = str
-        self.selection_metric = "Euclidean"
+        self.selection_metric = "NormSGA"
 
         self._statevector_type = SurfaceStateVectorConfig
         self.statevector: StateVectorConfig = SurfaceStateVectorConfig({})

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -156,7 +156,7 @@ class SurfaceConfig(BaseConfigSection):
                 )
             )
 
-        valid_metrics = ["Euclidean", "SGA"]
+        valid_metrics = ["Euclidean", "SGA", "NormSGA"]
         if self.selection_metric not in valid_metrics:
             errors.append(f"surface->selection_metric must be one of: {valid_metrics}")
 

--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -99,7 +99,7 @@ class SurfaceConfig(BaseConfigSection):
         The state is preserved in the geometry object so that this object stays stateless"""
 
         self._selection_metric_type = str
-        self.selection_metric = "NormSGA"
+        self.selection_metric = "SGA"
 
         self._statevector_type = SurfaceStateVectorConfig
         self.statevector: StateVectorConfig = SurfaceStateVectorConfig({})

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -148,6 +148,8 @@ class MultiComponentSurface(Surface):
         # Only support euclidean distance comparrison for now
         if self.selection_metric == "SGA":
             mds = self.spectral_gradient_angle(lamb_ref, np.array(self.mus))
+        elif self.selection_metric == "NormSGA":
+            mds = self.normalized_spectral_gradient_angle(lamb_ref, np.array(self.mus))
         elif self.selection_metric == "Euclidean":
             mds = self.euclidean_distance(
                 lamb_ref,
@@ -390,4 +392,20 @@ class MultiComponentSurface(Surface):
 
         return self.spectral_angle_distance(
             gradient(self.wl[self.idx_ref], lamb_ref), grads
+        )
+
+    def normalized_spectral_gradient_angle(self, lamb_ref, mus):
+        def gradient(wl, val, sigma=2):
+            val = gaussian_filter1d(val, sigma=sigma)
+            return np.gradient(val, wl)
+
+        def gradient_norm(x):
+            return (x - np.min(x)) / (np.max(x) - np.min(x))
+
+        grads = np.array(
+            [gradient_norm(gradient(self.wl[self.idx_ref], mu)) for mu in mus]
+        )
+
+        return self.spectral_angle_distance(
+            gradient_norm(gradient(self.wl[self.idx_ref], lamb_ref)), grads
         )

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -66,9 +66,7 @@ class MultiComponentSurface(Surface):
         else:
             raise ValueError("Unrecognized Normalization: %s\n" % self.normalize)
 
-        self.selection_metric = self.model_dict.get(
-            "selection_metric", config.selection_metric
-        )
+        self.selection_metric = config.selection_metric
         self.select_on_init = config.select_on_init
 
         # Reference values are used for normalizing the reflectances.


### PR DESCRIPTION
**Problem**

We are often failing to select the correct prior over some surface types. Here demonstrated over water.

**Proposed fix**

The options implemented here are 1) to use the Spectral Gradient Angle as the default prior selection algorithm. 2) Test a normalized spectral gradient angle, which normalizes gradients before doing the angle comparison.

The figure below directly compares the calculated distances for each prior component **for the superpixels** associated with the full water scene in the figure above. The Euclidean distances offer the worst separability among prior selection algorithms.

<img width="894" height="492" alt="image" src="https://github.com/user-attachments/assets/e2beea60-a2bf-464a-a2b4-f93a2f461a2c" />
