### PR TITLE
Remove esd factor from Geometry()

### DIFF
--- a/isofit/core/fileio.py
+++ b/isofit/core/fileio.py
@@ -529,7 +529,6 @@ class IO:
         geom = Geometry(
             obs=data["obs_file"],
             loc=data["loc_file"],
-            esd=self.esd,
             bg_rfl=data["background_reflectance_file"],
             svf=data["skyview_factor_file"],
             coszen=self.coszen,

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -35,7 +35,6 @@ class Geometry:
         self,
         obs: np.array = None,
         loc: np.array = None,
-        dt: datetime = None,
         esd: np.array = None,
         bg_rfl: np.array = None,
         svf: float = 1,
@@ -46,7 +45,6 @@ class Geometry:
         Args:
             obs: Observation metadata array.
             loc: Location metadata array.
-            dt: Date time of observation.
             esd: Earth sun distance array.
             bg_rfl: Background reflectance spectrum.
             svf: Sky view factor.
@@ -61,7 +59,6 @@ class Geometry:
         self.observer_altitude_km = None
         self.surface_elevation_km = None
         self.earth_sun_distance = None
-        self.esd_factor = None
 
         if esd is None:
             logging.warning(
@@ -107,9 +104,6 @@ class Geometry:
                 self.surface_elevation_km
                 + self.path_length_km * np.cos(np.deg2rad(self.observer_zenith))
             )
-
-        if dt is not None:
-            self.esd_factor = self.get_esd_factor(dt)
 
         # Determine how to treat coszen
         self.use_universal_coszen = True
@@ -181,15 +175,3 @@ class Geometry:
             logging.warning(
                 "Unable to determine coszen. Proceeding without will cause errors during the inversion."
             )
-
-    def get_esd_factor(self, date_time: datetime):
-        """Get distance ratio from sun based on time of year, relative to day 1
-        Args:
-            date_time: datetime to search
-
-        Returns:
-            float: ratio of earth sun distnace based on datetime.
-        """
-
-        day_of_year = date_time.timetuple().tm_yday
-        return float(self.earth_sun_distance[day_of_year - 1, 1])

--- a/isofit/core/geometry.py
+++ b/isofit/core/geometry.py
@@ -19,7 +19,6 @@
 #
 
 import logging
-from datetime import datetime
 
 import numpy as np
 
@@ -35,7 +34,6 @@ class Geometry:
         self,
         obs: np.array = None,
         loc: np.array = None,
-        esd: np.array = None,
         bg_rfl: np.array = None,
         svf: float = 1,
         coszen: float = None,
@@ -45,11 +43,10 @@ class Geometry:
         Args:
             obs: Observation metadata array.
             loc: Location metadata array.
-            esd: Earth sun distance array.
             bg_rfl: Background reflectance spectrum.
             svf: Sky view factor.
             coszen: Cosine of the solar zenith angle for top of atmosphere.
-            config: isofit config.
+            full_config: isofit config.
         """
         # Set some benign defaults...
         self.observer_zenith = None
@@ -58,15 +55,6 @@ class Geometry:
         self.solar_azimuth = None
         self.observer_altitude_km = None
         self.surface_elevation_km = None
-        self.earth_sun_distance = None
-
-        if esd is None:
-            logging.warning(
-                "Earth sun distance not provided. Proceeding without might cause some inaccuracies down the line"
-            )
-            esd = np.ones((366, 2))
-            esd[:, 0] = np.arange(1, 367, 1)
-        self.earth_sun_distance_reference = esd
 
         self.bg_rfl = bg_rfl
         self.cos_i = None

--- a/isofit/test/test_geometry.py
+++ b/isofit/test/test_geometry.py
@@ -1,6 +1,7 @@
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
-from unittest.mock import MagicMock
 
 from isofit.core.geometry import Geometry
 
@@ -75,7 +76,6 @@ def test_default_behavior():
     assert geom.observer_altitude_km == None
     assert geom.surface_elevation_km == None
     assert geom.earth_sun_distance == None
-    assert geom.esd_factor == None
     assert geom.earth_sun_distance_reference.shape == (366, 2)
     assert np.all(geom.earth_sun_distance_reference[:, 1] == 1.0)
 

--- a/isofit/test/test_geometry.py
+++ b/isofit/test/test_geometry.py
@@ -75,9 +75,6 @@ def test_default_behavior():
     assert geom.solar_azimuth == None
     assert geom.observer_altitude_km == None
     assert geom.surface_elevation_km == None
-    assert geom.earth_sun_distance == None
-    assert geom.earth_sun_distance_reference.shape == (366, 2)
-    assert np.all(geom.earth_sun_distance_reference[:, 1] == 1.0)
 
 
 def test_geom_clipping(input_obs):

--- a/isofit/utils/algebraic_line.py
+++ b/isofit/utils/algebraic_line.py
@@ -30,8 +30,8 @@ from spectral.io import envi
 
 from isofit import ray
 from isofit.configs import configs
-from isofit.core.common import envi_header, load_spectrum
-from isofit.core.fileio import IO, write_bil_chunk
+from isofit.core.common import envi_header, load_esd, load_spectrum
+from isofit.core.fileio import write_bil_chunk
 from isofit.core.forward import ForwardModel
 from isofit.core.geometry import Geometry
 from isofit.inversion.inverse import Inversion
@@ -304,7 +304,7 @@ class Worker(object):
 
         start_line, stop_line = startstop
 
-        esd = IO.load_esd()
+        esd = load_esd()
 
         for r in range(start_line, stop_line):
             output_rfl = (

--- a/isofit/utils/algebraic_line.py
+++ b/isofit/utils/algebraic_line.py
@@ -324,7 +324,6 @@ class Worker(object):
                 geom = Geometry(
                     obs=obs[r, c, :],
                     loc=loc[r, c, :],
-                    esd=esd,
                     coszen=self.coszen,
                     full_config=self.config,
                 )

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -532,7 +532,6 @@ class Worker(object):
             geom = Geometry(
                 obs=self.obs[r, c, :],
                 loc=self.loc[r, c, :],
-                esd=self.esd,
                 svf=self.svf[r, c] if len(self.svf) else 1,
                 bg_rfl=self.bg_rfl[r, c, :] if len(self.bg_rfl) else None,
                 coszen=self.coszen,

--- a/isofit/utils/multicomponent_classification.py
+++ b/isofit/utils/multicomponent_classification.py
@@ -16,7 +16,7 @@ from spectral import envi
 import isofit.utils.template_construction as tmpl
 from isofit import ray
 from isofit.core.common import envi_header, load_esd, resample_spectrum, svd_inv
-from isofit.core.fileio import IO, initialize_output, write_bil_chunk
+from isofit.core.fileio import initialize_output, write_bil_chunk
 from isofit.core.geometry import Geometry
 from isofit.core.multistate import SurfaceMapping
 from isofit.data import env

--- a/isofit/utils/multicomponent_classification.py
+++ b/isofit/utils/multicomponent_classification.py
@@ -130,9 +130,7 @@ class Worker(object):
         for r in range(start_line, stop_line):
             for c in range(output.shape[1]):
                 meas = self.rdn[r, c, :]
-                geom = Geometry(
-                    obs=self.obs[r, c, :], loc=self.loc[r, c, :], esd=self.esd
-                )
+                geom = Geometry(obs=self.obs[r, c, :], loc=self.loc[r, c, :])
                 coszen = np.cos(np.deg2rad(geom.solar_zenith))
 
                 num = meas * np.pi


### PR DESCRIPTION
This is a proposal to remove the `esd_factor` attribute from the `Geometry` object. I'm 99% sure that it's never used anywhere, so we could save some lines of code if folks agree that we don't need it.

Closes #1007.