### PR TITLE
LUT Subsetting

### DIFF
--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -102,6 +102,72 @@ def _inspect_zarr_dimensions(lut_path: Path) -> dict[str, np.ndarray]:
     return lut_dimensions
 
 
+def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):
+    """
+    Subselects an xarray Dataset object using .sel
+
+    Parameters
+    ----------
+    ds: xarray.Dataset
+        LUT dataset
+    dim: str
+        Dimension to work on
+    lt: float, default=None
+        Select along this dim coordinates that are valued less than this
+    lte: float, default=None
+        Select along this dim coordinates that are valued less than or equal to this
+    gt: float, default=None
+        Select along this dim coordinates that are valued greater than this
+    gte: float, default=None
+        Select along this dim coordinates that are valued greater than or equal to this
+    encompass: bool, default=True
+        Change the values of gte/lte such that these values are encompassed using the
+        previous/next valid grid point
+
+    Returns
+    -------
+    ds: xarray.Dataset
+        Subsetted dataset
+    """
+    assert None in (
+        lt,
+        lte,
+    ), f"Subsetting `lt` and `lte` are mutually exclusive, please only set one for dim {dim}"
+    assert None in (
+        gt,
+        gte,
+    ), f"Subsetting `gt` and `gte` are mutually exclusive, please only set one for dim {dim}"
+
+    # Which index in a where to select -- if the dim is in reverse order, this needs to swap
+    g, l = -1, 0
+    if ds[dim][0] > ds[dim][-1]:
+        g, l = 0, -1
+
+    if lt is not None:
+        ds = ds.sel({dim: ds[dim] < lt})
+
+    elif lte is not None:
+        if encompass:
+            where = ds[dim].where(ds[dim] > lte).dropna(dim)
+            lte = where[l] if where.size else ds[dim].max()
+            Logger.debug(f"Encompass changed lte value to {lte}")
+
+        ds = ds.sel({dim: ds[dim] <= lte})
+
+    if gt is not None:
+        ds = ds.sel({dim: gt < ds[dim]})
+
+    elif gte is not None:
+        if encompass:
+            where = ds[dim].where(ds[dim] < gte).dropna(dim)
+            gte = where[g] if where.size else ds[dim].min()
+            Logger.debug(f"Encompass changed gte value to {gte}")
+
+        ds = ds.sel({dim: gte <= ds[dim]})
+
+    return ds
+
+
 def sub(ds: xr.Dataset, dim: str, strat) -> xr.Dataset:
     """
     Subsets a dataset object along a specific dimension in a few supported ways.

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -14,7 +14,7 @@ import xarray as xr
 from netCDF4 import Dataset
 
 from isofit import __version__
-from isofit.core import common, units
+from isofit.core import common
 
 Logger = logging.getLogger(__name__)
 

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -235,10 +235,10 @@ def subsetting(ds, subset):
             opts["interp"][dim] = v
         # Subselect
         else:
-            opts["isel"][dim] = slice(
-                ds.indexes[dim].get_indexer([strat["gte"]], method="ffill")[0],
-                ds.indexes[dim].get_indexer([strat["lte"]], method="bfill")[0] + 1,
+            i, j = ds.indexes[dim].get_indexer(
+                [strat["gte"], strat["lte"]], method="ffill"
             )
+            opts["isel"][dim] = slice(i, j + 1)
 
     if opts["isel"]:
         Logger.debug(f"Selecting")

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -210,7 +210,7 @@ def subsetting(ds, subset):
     """
     Subsets a Dataset
     """
-    Logger.debug(f"Estimated dataset size: {ds.nbytes / 2**30} GB")
+    Logger.debug(f"Estimated dataset size: {ds.nbytes / 2**30:.2f} GB")
 
     # The strategy dict must contain all coordinate keys in the lut file
     missing = set(ds.coords) - ({"wl"} | set(subset))
@@ -228,23 +228,41 @@ def subsetting(ds, subset):
     opts = {"isel": {}, "interp": {}}
 
     for dim, strat in subset.items():
-        # Interpolation
-        if (v := strat.get("interp")) is not None:
-            i = ds.indexes[dim].get_indexer([v], method="ffill")[0]
-            opts["isel"][dim] = slice(i, i + 1)
-            opts["interp"][dim] = v
-        # Subselect
-        else:
-            i, j = ds.indexes[dim].get_indexer(
-                [strat["gte"], strat["lte"]], method="ffill"
-            )
-            opts["isel"][dim] = slice(i, j + 1)
+        idx = ds.indexes[dim]
+
+        # Exact subset
+        if isinstance(strat, list):
+            isel = opts["isel"][dim] = idx.get_indexer(strat)
+            if -1 in isel:
+                msg = f"Lists in the subset must be an exact subset of the dimension. Invalid selection on {dim}: {idx[isel == -1]}"
+                Logger.error(msg)
+                raise ValueError(msg)
+
+        elif isinstance(strat, dict):
+            # Interpolation
+            if (v := strat.get("interp")) is not None:
+                i = idx.get_indexer([v], method="ffill")[0]
+                j = i + 1
+                if idx[i] != v:
+                    j += 1
+                opts["interp"][dim] = v
+
+            # Encompassing subset
+            else:
+                i = idx.get_indexer([strat["gte"]], method="ffill")[0]
+                j = idx.get_indexer([strat["lte"]], method="bfill")[0]
+                if idx[j] == strat["lte"]:
+                    j += 1
+
+            opts["isel"][dim] = slice(i, j)
+
+    Logger.debug(f"Operations: {opts}")
 
     if opts["isel"]:
         Logger.debug(f"Selecting")
         ds = ds.isel(**opts["isel"])
 
-    Logger.debug(f"Estimated isel size: {ds.nbytes / 2**30} GB")
+    Logger.debug(f"Estimated isel size: {ds.nbytes / 2**30:.2f} GB")
 
     if opts["interp"]:
         Logger.debug("Loading for interp")
@@ -253,7 +271,7 @@ def subsetting(ds, subset):
         Logger.debug("Interpolating")
         ds = ds.interp(**opts["interp"])
 
-    Logger.debug(f"Estimated final size: {ds.nbytes / 2**30} GB")
+    Logger.debug(f"Estimated final size: {ds.nbytes / 2**30:.2f} GB")
 
     # Save this subsetting strategy to the attributes for future reference
     ds.attrs["lut_subset"] = str(subset)

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -102,198 +102,12 @@ def _inspect_zarr_dimensions(lut_path: Path) -> dict[str, np.ndarray]:
     return lut_dimensions
 
 
-def findSlice(dim, val):
-    """
-    Creates a slice for selecting along a dimension such that a value is encompassed by
-    the slice.
-
-    Parameters
-    ----------
-    dim: array
-        Dimension array
-    val: float, int
-        Value to be encompassed
-
-    Returns
-    -------
-    slice
-        Index slice to encompass the value
-    """
-    # Increasing is 1, decreasing is -1 for the searchsorted
-    orientation = 1
-    if dim[0] > dim[-1]:
-        orientation = -1
-
-    # Subselect the two points encompassing this interp point
-    b = np.searchsorted(dim * orientation, val * orientation)
-
-    # Handle edge cases when val equals first or last lut dim value
-    if val <= dim[0]:
-        return slice(b, b + 2)
-
-    else:
-        return slice(b - 1, b + 1)
-
-
-def optimizedInterp(ds, strat):
-    """
-    Optimizes the interpolation step by subselecting along dimensions first then
-    interpolating
-
-    Parameters
-    ----------
-    strat: dict
-        Interpolation stategies to perform in the form of {dim: interpolate_values}
-
-    Returns
-    -------
-    xr.Dataset
-        Interpolated dataset
-    """
-    for key, val in strat.items():
-        dim = ds[key]
-
-        if val <= dim[0]:
-            Logger.warning(
-                f"Scene value for key: {key} of {round(val, 2)} "
-                f"is less or equal to minimum LUT value {np.round(dim[0].data, 2)}. "
-                "Solutions will use value interpolated to minimum LUT value"
-            )
-
-        elif val >= dim[-1]:
-            Logger.warning(
-                f"Scene value for key: {key} of {round(val, 2)} "
-                f"is greater or equal to maximum LUT value {np.round(dim[-1].data, 2)}. "
-                "Solutions will use value interpolated to maximum LUT value"
-            )
-
-        if isinstance(val, list):
-            a = findSlice(dim, val[0])
-            b = findSlice(dim, val[-1])
-
-            # Find the correct order
-            if a.start < b.start:
-                sel = slice(a.start, b.stop)
-            else:
-                sel = slice(b.start, a.stop)
-        else:
-            sel = findSlice(dim, val)
-
-        Logger.debug(f"- Subselecting {key}[{sel.start}:{sel.stop}]")
-        ds = ds.isel({key: sel})
-
-    Logger.debug("Calling .interp")
-    return ds.interp(**strat)
-
-
-def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):
-    """
-    Subselects an xarray Dataset object using .sel
-
-    Parameters
-    ----------
-    ds: xarray.Dataset
-        LUT dataset
-    dim: str
-        Dimension to work on
-    lt: float, default=None
-        Select along this dim coordinates that are valued less than this
-    lte: float, default=None
-        Select along this dim coordinates that are valued less than or equal to this
-    gt: float, default=None
-        Select along this dim coordinates that are valued greater than this
-    gte: float, default=None
-        Select along this dim coordinates that are valued greater than or equal to this
-    encompass: bool, default=True
-        Change the values of gte/lte such that these values are encompassed using the
-        previous/next valid grid point
-
-    Returns
-    -------
-    ds: xarray.Dataset
-        Subsetted dataset
-    """
-    assert None in (
-        lt,
-        lte,
-    ), f"Subsetting `lt` and `lte` are mutually exclusive, please only set one for dim {dim}"
-    assert None in (
-        gt,
-        gte,
-    ), f"Subsetting `gt` and `gte` are mutually exclusive, please only set one for dim {dim}"
-
-    # Which index in a where to select -- if the dim is in reverse order, this needs to swap
-    g, l = -1, 0
-    if ds[dim][0] > ds[dim][-1]:
-        g, l = 0, -1
-
-    if lt is not None:
-        ds = ds.sel({dim: ds[dim] < lt})
-
-    elif lte is not None:
-        if encompass:
-            where = ds[dim].where(ds[dim] > lte).dropna(dim)
-            lte = where[l] if where.size else ds[dim].max()
-            Logger.debug(f"Encompass changed lte value to {lte}")
-
-        ds = ds.sel({dim: ds[dim] <= lte})
-
-    if gt is not None:
-        ds = ds.sel({dim: gt < ds[dim]})
-
-    elif gte is not None:
-        if encompass:
-            where = ds[dim].where(ds[dim] < gte).dropna(dim)
-            gte = where[g] if where.size else ds[dim].min()
-            Logger.debug(f"Encompass changed gte value to {gte}")
-
-        ds = ds.sel({dim: gte <= ds[dim]})
-
-    return ds
-
-
-def sub(ds: xr.Dataset, dim: str, strat) -> xr.Dataset:
-    """
-    Subsets a dataset object along a specific dimension in a few supported ways.
-
-    Parameters
-    ----------
-    ds: xr.Dataset
-        Dataset to operate on
-    dim: str
-        Name of the dimension to subset
-    strat: float, int, list, dict, str, None
-        Strategy to subset the given dimension with
-
-    Returns
-    -------
-    xr.Dataset
-        New subset of the input dataset
-    """
-    if isinstance(strat, (float, int, list)):
-        return ds.sel({dim: strat})
-
-    elif isinstance(strat, str):
-        return getattr(ds, strat)(dim)
-
-    elif strat is None:
-        return ds  # Take dimension as-is
-
-    elif isinstance(strat, dict):
-        if "interp" in strat:
-            return ds.interp({dim: strat["interp"]})
-
-        return sel(ds, dim, **strat)
-
-    else:
-        Logger.error(f"Unknown subsetting strategy for type: {type(strat)}")
-        return ds
-
-
 def subsetting(ds, subset):
     """
     Subsets a Dataset
     """
+    Logger.debug(f"Estimated dataset size: {ds.nbytes / 2**30} GB")
+
     # The strategy dict must contain all coordinate keys in the lut file
     missing = set(ds.coords) - ({"wl"} | set(subset))
     if missing:
@@ -306,20 +120,36 @@ def subsetting(ds, subset):
             f"Subset dictionary (engine.lut_names) is missing keys that are present in the LUT dimensions {set(ds.coords)}: {missing=}"
         )
 
-    # Interpolation strategies will be done last for optimization purposes
-    interp = {}
+    # Operations to perform
+    opts = {"isel": {}, "interp": {}}
 
-    # Apply subsetting strategies
     for dim, strat in subset.items():
-        if isinstance(strat, dict) and "interp" in strat:
-            interp[dim] = strat["interp"]
+        # Interpolation
+        if (v := strat.get("interp")) is not None:
+            i = ds.indexes[dim].get_indexer([v], method="ffill")[0]
+            opts["isel"][dim] = slice(i, i + 1)
+            opts["interp"][dim] = v
+        # Subselect
         else:
-            Logger.debug(f"Subsetting {dim} with {strat}")
-            ds = sub(ds, dim, strat)
+            opts["isel"][dim] = slice(
+                ds.indexes[dim].get_indexer([strat["gte"]], method="ffill")[0],
+                ds.indexes[dim].get_indexer([strat["lte"]], method="bfill")[0] + 1,
+            )
 
-    if interp:
+    if opts["isel"]:
+        Logger.debug(f"Selecting")
+        ds = ds.isel(**opts["isel"])
+
+    Logger.debug(f"Estimated isel size: {ds.nbytes / 2**30} GB")
+
+    if opts["interp"]:
+        Logger.debug("Loading for interp")
+        ds = ds.load()
+
         Logger.debug("Interpolating")
-        ds = optimizedInterp(ds, interp)
+        ds = ds.interp(**opts["interp"])
+
+    Logger.debug(f"Estimated final size: {ds.nbytes / 2**30} GB")
 
     # Save this subsetting strategy to the attributes for future reference
     ds.attrs["lut_subset"] = str(subset)

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -202,7 +202,6 @@ def load(
     check: bool = False,
     stack: bool = True,
     load: bool = True,
-    chunks: dict = None,
     **kwargs,
 ):
     """
@@ -221,9 +220,6 @@ def load(
         entirely NaN
     load : bool, default=True
         Loads the final dataset into memory
-    chunks : dict, default={}
-        Chunks parameter for open_dataset, isofit generally wants to have the dataset
-        be chunked by the file's chunks
     **kwargs
         Additional parameters to pass to open_dataset/open_mfdataset
 
@@ -382,11 +378,16 @@ def load(
     """
     path = Path(path)
 
+    # Windows needs to define the engine as the xarray auto-discover breaks
+    engine = None
+    if Path(path).is_dir():
+        engine = "zarr"
+
     xropen = xr.open_dataset
     if mf:
         xropen = xr.mfopen_dataset
 
-    ds = xropen(path, chunks=chunks, **kwargs)
+    ds = xropen(path, engine=engine, **kwargs)
 
     status = ds.attrs.get("ISOFIT status", "<not set>")
     if status != "success":

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -102,6 +102,44 @@ def _inspect_zarr_dimensions(lut_path: Path) -> dict[str, np.ndarray]:
     return lut_dimensions
 
 
+def sub(ds: xr.Dataset, dim: str, strat) -> xr.Dataset:
+    """
+    Subsets a dataset object along a specific dimension in a few supported ways.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+        Dataset to operate on
+    dim: str
+        Name of the dimension to subset
+    strat: float, int, list, dict, str, None
+        Strategy to subset the given dimension with
+
+    Returns
+    -------
+    xr.Dataset
+        New subset of the input dataset
+    """
+    if isinstance(strat, (float, int, list)):
+        return ds.sel({dim: strat})
+
+    elif isinstance(strat, str):
+        return getattr(ds, strat)(dim)
+
+    elif strat is None:
+        return ds  # Take dimension as-is
+
+    elif isinstance(strat, dict):
+        if "interp" in strat:
+            return ds.interp({dim: strat["interp"]})
+
+        return sel(ds, dim, **strat)
+
+    else:
+        Logger.error(f"Unknown subsetting strategy for type: {type(strat)}")
+        return ds
+
+
 def subsetting(ds, subset):
     """
     Subsets a Dataset

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -102,110 +102,6 @@ def _inspect_zarr_dimensions(lut_path: Path) -> dict[str, np.ndarray]:
     return lut_dimensions
 
 
-def sel(ds, dim, lt=None, lte=None, gt=None, gte=None, encompass=True):
-    """
-    Subselects an xarray Dataset object using .sel
-
-    Parameters
-    ----------
-    ds: xarray.Dataset
-        LUT dataset
-    dim: str
-        Dimension to work on
-    lt: float, default=None
-        Select along this dim coordinates that are valued less than this
-    lte: float, default=None
-        Select along this dim coordinates that are valued less than or equal to this
-    gt: float, default=None
-        Select along this dim coordinates that are valued greater than this
-    gte: float, default=None
-        Select along this dim coordinates that are valued greater than or equal to this
-    encompass: bool, default=True
-        Change the values of gte/lte such that these values are encompassed using the
-        previous/next valid grid point
-
-    Returns
-    -------
-    ds: xarray.Dataset
-        Subsetted dataset
-    """
-    assert None in (
-        lt,
-        lte,
-    ), f"Subsetting `lt` and `lte` are mutually exclusive, please only set one for dim {dim}"
-    assert None in (
-        gt,
-        gte,
-    ), f"Subsetting `gt` and `gte` are mutually exclusive, please only set one for dim {dim}"
-
-    # Which index in a where to select -- if the dim is in reverse order, this needs to swap
-    g, l = -1, 0
-    if ds[dim][0] > ds[dim][-1]:
-        g, l = 0, -1
-
-    if lt is not None:
-        ds = ds.sel({dim: ds[dim] < lt})
-
-    elif lte is not None:
-        if encompass:
-            where = ds[dim].where(ds[dim] > lte).dropna(dim)
-            lte = where[l] if where.size else ds[dim].max()
-            Logger.debug(f"Encompass changed lte value to {lte}")
-
-        ds = ds.sel({dim: ds[dim] <= lte})
-
-    if gt is not None:
-        ds = ds.sel({dim: gt < ds[dim]})
-
-    elif gte is not None:
-        if encompass:
-            where = ds[dim].where(ds[dim] < gte).dropna(dim)
-            gte = where[g] if where.size else ds[dim].min()
-            Logger.debug(f"Encompass changed gte value to {gte}")
-
-        ds = ds.sel({dim: gte <= ds[dim]})
-
-    return ds
-
-
-def sub(ds: xr.Dataset, dim: str, strat) -> xr.Dataset:
-    """
-    Subsets a dataset object along a specific dimension in a few supported ways.
-
-    Parameters
-    ----------
-    ds: xr.Dataset
-        Dataset to operate on
-    dim: str
-        Name of the dimension to subset
-    strat: float, int, list, dict, str, None
-        Strategy to subset the given dimension with
-
-    Returns
-    -------
-    xr.Dataset
-        New subset of the input dataset
-    """
-    if isinstance(strat, (float, int, list)):
-        return ds.sel({dim: strat})
-
-    elif isinstance(strat, str):
-        return getattr(ds, strat)(dim)
-
-    elif strat is None:
-        return ds  # Take dimension as-is
-
-    elif isinstance(strat, dict):
-        if "interp" in strat:
-            return ds.interp({dim: strat["interp"]})
-
-        return sel(ds, dim, **strat)
-
-    else:
-        Logger.error(f"Unknown subsetting strategy for type: {type(strat)}")
-        return ds
-
-
 def subsetting(ds, subset):
     """
     Subsets a Dataset
@@ -306,7 +202,7 @@ def load(
     check: bool = False,
     stack: bool = True,
     load: bool = True,
-    chunks: dict = {},
+    chunks: dict = None,
     **kwargs,
 ):
     """
@@ -486,32 +382,9 @@ def load(
     """
     path = Path(path)
 
-    # Windows needs to define the engine as the xarray auto-discover breaks
-    engine = None
-    if Path(path).is_dir():
-        engine = "zarr"
-
     xropen = xr.open_dataset
     if mf:
         xropen = xr.mfopen_dataset
-
-    # Convert dicts of {dim: None, ...} to None
-    if subset and not any(subset.values()):
-        subset = None
-
-    # Special case that doesn't require defining the entire grid subsetting strategy
-    if load:
-        if not subset:
-            Logger.debug(
-                "With no subset defined and load enabled, disabling default chunking for performance"
-            )
-            chunks = None
-
-        elif path.is_file() and path.stat().st_size < units.byte_string_to_float("4gb"):
-            Logger.debug(
-                "LUT store detected less than 4gb and load enabled, disabling default chunking for performance"
-            )
-            chunks = None
 
     ds = xropen(path, chunks=chunks, engine=engine, **kwargs)
 
@@ -743,4 +616,4 @@ class Reader:
             Subselects using rng[0] <= wl <= rng[1]
         """
         Logger.info(f"Subsetting wavelengths to range: {rng}")
-        self.lut = sub(self.lut, "wl", dict(zip(["gte", "lte"], rng)))
+        self.lut = self.lut.sel(wl=slice(*rng))

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -386,7 +386,7 @@ def load(
     if mf:
         xropen = xr.mfopen_dataset
 
-    ds = xropen(path, chunks=chunks, engine=engine, **kwargs)
+    ds = xropen(path, chunks=chunks, **kwargs)
 
     status = ds.attrs.get("ISOFIT status", "<not set>")
     if status != "success":


### PR DESCRIPTION
Attempting to further optimize the LUT subsetting code now that we have a universal lut that's seeing not-ideal load times.

- Greatly simplified the subsetting code by reducing it to one function
  - First calculate the `isel` slicing
    - Previously was done as separate operations for each dim, possibly more than once. I refactored this into one `isel` operation, which is far more efficient
  - Then perform interpolation
    - Loaded the subset before interp, helps some

Tested with strategy:
```
{'AOT550': {'encompass': True, 'gte': 0.045, 'lte': 0.9},
 'CO2': {'encompass': True, 'gte': 380.0, 'lte': 440.0},
 'H2OSTR': {'encompass': True, 'gte': 0.2, 'lte': 3.6},
 'observer_zenith': {'encompass': True, 'gte': 0.0, 'lte': 20.0},
 'relative_azimuth': {'encompass': True, 'gte': 45.0, 'lte': 135.0},
 'solar_zenith': {'interp': 30.93997019852684},
 'surface_elevation_km': {'encompass': True, 'gte': 1.0, 'lte': 3.0}}
```
Using the v4 universal lut took ~5.5mins