### PR TITLE
fixes second apply of viable

### DIFF
--- a/isofit/luts/stores/zarr.py
+++ b/isofit/luts/stores/zarr.py
@@ -165,8 +165,9 @@ def calc_shards(grid, wl, chunk, storage="8gb", target_shards=None, scale=1):
     if target_shards is not None:
         idx = np.abs(files - target_shards).argmin()
     else:
-        # Fall back to the largest shard (fewest files)
-        idx = (cpf * space)[viable].argmax()
+        # Fall back to the largest shard (fewest files). cpf is already
+        # filtered by `viable` above, so index it directly.
+        idx = cpf.argmax()
 
     best = shards[idx]
 


### PR DESCRIPTION
viable is already applied to cpf in line 158.  This causes a break.  Normally target_shards is on, so we don't hit this.