### PR TITLE
Bugfix for lut interpolation on loading

### DIFF
--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -141,6 +141,11 @@ def subsetting(ds, subset):
                 j = i + 1
                 if idx[i] != v:
                     j += 1
+
+                # value falls directly on grid point, don't interpolate
+                if j - i == 1:
+                    continue
+
                 opts["interp"][dim] = v
 
             # Encompassing subset

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -152,7 +152,7 @@ def subsetting(ds, subset):
                     j += 1
                 sel = slice(i, j)
 
-                opts["isel"][dim] = sel
+            opts["isel"][dim] = sel
 
     Logger.debug(f"Operations: {opts}")
 

--- a/isofit/luts/reader.py
+++ b/isofit/luts/reader.py
@@ -138,15 +138,11 @@ def subsetting(ds, subset):
             # Interpolation
             if (v := strat.get("interp")) is not None:
                 i = idx.get_indexer([v], method="ffill")[0]
-                j = i + 1
+                sel = i
+                # Only slice and interpolate if v is not gridpoint
                 if idx[i] != v:
-                    j += 1
-
-                # value falls directly on grid point, don't interpolate
-                if j - i == 1:
-                    continue
-
-                opts["interp"][dim] = v
+                    opts["interp"][dim] = v
+                    sel = slice(i, i + 2)
 
             # Encompassing subset
             else:
@@ -154,8 +150,9 @@ def subsetting(ds, subset):
                 j = idx.get_indexer([strat["lte"]], method="bfill")[0]
                 if idx[j] == strat["lte"]:
                     j += 1
+                sel = slice(i, j)
 
-            opts["isel"][dim] = slice(i, j)
+                opts["isel"][dim] = sel
 
     Logger.debug(f"Operations: {opts}")
 


### PR DESCRIPTION
**Problem:**

If the interpolation value passed into the lut subsetting function falls on a grid point, the interpolation will fail. This is because the resulting `isel` dictionary passes a `slice(0, 1)` into the `ds.isel` call. e.g.:
```
{'isel': {'AOT550': slice(np.int64(1), np.int64(3), None),
  'CO2': slice(np.int64(1), np.int64(3), None),
  'H2OSTR': slice(np.int64(0), np.int64(27), None),
  'observer_zenith': slice(np.int64(0), np.int64(2), None),
  'relative_azimuth': slice(np.int64(0), np.int64(2), None),
  'solar_zenith': slice(np.int64(7), np.int64(9), None),
  'surface_elevation_km': slice(0, 1, None)},
 'interp': {'AOT550': 0.1305,
  'CO2': 420.0,
  'observer_zenith': 8.261426854047528,
  'relative_azimuth': 43.85351152752587,
  'solar_zenith': 58.07854226966155,
  'surface_elevation_km': 0}}
```

The resulting sliced lut holds a `length = 1` dimension. This is the `surface_elevation_km` In the above example. The `ds.interp` call tries to interpolate over this length=1 dimension, and silently returns NaNs.

**Fix:**

Remove slice(0, 1) entries from the `interp` dictionary., and simply select the gridpoint.

With new logic:
```
{'isel': {'AOT550': slice(np.int64(1), np.int64(3), None),
  'CO2': slice(np.int64(1), np.int64(3), None),
  'H2OSTR': slice(np.int64(0), np.int64(27), None),
  'observer_zenith': slice(np.int64(0), np.int64(2), None),
  'relative_azimuth': slice(np.int64(0), np.int64(2), None),
  'solar_zenith': slice(np.int64(7), np.int64(9), None),
  'surface_elevation_km': np.int64(0)},
 'interp': {'AOT550': 0.1305,
  'CO2': 420.0,
  'observer_zenith': 8.261426854047528,
  'relative_azimuth': 43.85351152752587,
  'solar_zenith': 58.07854226966155}}
  ```