### PR TITLE
Rollback to defaulting to Euclidean

### DIFF
--- a/isofit/configs/sections/surface_config.py
+++ b/isofit/configs/sections/surface_config.py
@@ -102,7 +102,7 @@ class SurfaceConfig(BaseConfigSection):
         The state is preserved in the geometry object so that this object stays stateless"""
 
         self._selection_metric_type = str
-        self.selection_metric = "SGA"
+        self.selection_metric = "Euclidean"
 
         self._statevector_type = SurfaceStateVectorConfig
         self.statevector: StateVectorConfig = SurfaceStateVectorConfig({})
@@ -159,7 +159,7 @@ class SurfaceConfig(BaseConfigSection):
                 )
             )
 
-        valid_metrics = ["Euclidean", "SGA", "NormSGA"]
+        valid_metrics = ["Euclidean", "SGA", "SpecAngle"]
         if self.selection_metric not in valid_metrics:
             errors.append(f"surface->selection_metric must be one of: {valid_metrics}")
 

--- a/isofit/surface/surface_multicomp.py
+++ b/isofit/surface/surface_multicomp.py
@@ -154,8 +154,8 @@ class MultiComponentSurface(Surface):
         # Only support euclidean distance comparrison for now
         if self.selection_metric == "SGA":
             mds = self.spectral_gradient_angle(lamb_ref, np.array(self.mus))
-        elif self.selection_metric == "NormSGA":
-            mds = self.normalized_spectral_gradient_angle(lamb_ref, np.array(self.mus))
+        elif self.selection_metric == "SpecAngle":
+            mds = self.spectral_angle_distance(lamb_ref, np.array(self.mus))
         elif self.selection_metric == "Euclidean":
             mds = self.euclidean_distance(
                 lamb_ref,
@@ -437,20 +437,4 @@ class MultiComponentSurface(Surface):
 
         return self.spectral_angle_distance(
             gradient(self.wl[self.idx_ref], lamb_ref), grads
-        )
-
-    def normalized_spectral_gradient_angle(self, lamb_ref, mus):
-        def gradient(wl, val, sigma=2):
-            val = gaussian_filter1d(val, sigma=sigma)
-            return np.gradient(val, wl)
-
-        def gradient_norm(x):
-            return (x - np.min(x)) / (np.max(x) - np.min(x))
-
-        grads = np.array(
-            [gradient_norm(gradient(self.wl[self.idx_ref], mu)) for mu in mus]
-        )
-
-        return self.spectral_angle_distance(
-            gradient_norm(gradient(self.wl[self.idx_ref], lamb_ref)), grads
         )


### PR DESCRIPTION
While the spectral gradient angle had positive impacts for water pixels,mMixed terrestrial pixels tended to be classified as mixed-pixels rather than soil. We empirically noticed negative impacts on solutions in many of these cases.

The idea is a good one, and prior selection needs to be improved, but more time is needed to find the correct solution to the problem.