### PR TITLE
Removing H2O_ABSCO form config and Fix ignored lower triangle in the analytical line

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -904,14 +904,17 @@ class ForwardModel:
         when water vapor is not part of the statevector
         (which is very unlikely though).
         """
-        if len(self.bvec) == 0:
-            Kb_atmosphere = np.zeros((0, len(self.atmosphere.wl)))
+        if len(self.atmosphere.bvec) == 0:
+            Kb_atmosphere = np.zeros((len(self.atmosphere.wl), 0))
 
         # ToDo: might require modification in case more unknowns are added
         # The following statement captures the case that H2O is not part
         # of the statevector, but might need to be modified as soon as we
         # add more unknowns
-        elif len(self.bvec) > 0 and "H2OSTR" not in self.atmosphere.statevec_names:
+        elif (
+            len(self.atmosphere.bvec) > 0
+            and "H2OSTR" not in self.atmosphere.statevec_names
+        ):
             Kb_atmosphere = np.zeros((1, len(self.atmosphere.wl)))
         else:
             # unknown parameters modeled as random variables per

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -905,7 +905,7 @@ class ForwardModel:
         (which is very unlikely though).
         """
         if len(self.atmosphere.bvec) == 0:
-            Kb_atmosphere = np.zeros((len(self.atmosphere.wl), 0))
+            Kb_atmosphere = np.zeros(0, (len(self.atmosphere.wl)))
 
         # ToDo: might require modification in case more unknowns are added
         # The following statement captures the case that H2O is not part

--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -905,7 +905,7 @@ class ForwardModel:
         (which is very unlikely though).
         """
         if len(self.atmosphere.bvec) == 0:
-            Kb_atmosphere = np.zeros(0, (len(self.atmosphere.wl)))
+            Kb_atmosphere = np.zeros((0, len(self.atmosphere.wl)))
 
         # ToDo: might require modification in case more unknowns are added
         # The following statement captures the case that H2O is not part

--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -337,7 +337,7 @@ def invert_analytical(
         xk = dsymv(
             1,
             C_rcond,
-            (L.T @ dsymv(1, P, y) + prprod[iv_idx]),
+            (L.T @ dsymv(1, P, y, lower=1) + prprod[iv_idx]),
         )
 
         # Save trajectory step:

--- a/isofit/utils/template_construction.py
+++ b/isofit/utils/template_construction.py
@@ -1509,6 +1509,7 @@ def make_atmosphere_config(
     relative_azimuth_lut_grid: np.array = None,
     to_sensor_zenith_lut_grid: np.array = None,
     to_sun_zenith_lut_grid: np.array = None,
+    unknowns: dict = {},
 ):
     avc = np.sum(
         [
@@ -1547,7 +1548,12 @@ def make_atmosphere_config(
         },
         "statevector": {},
         "lut_grid": {},
-        "unknowns": {"H2O_ABSCO": 0.0},
+        # Previously configured an H2O_ABSCO, but a value effectively turns off
+        # the uncertainty quantification:
+        # "unknowns": {"H2O_ABSCO": 0.0},
+        # We now inherit from the kwargs. Could be hooked up to apply_oe in
+        # the future.
+        "unknowns": unknowns,
     }
 
     atmosphere_rte = {}


### PR DESCRIPTION
This addresses the issue raised in https://github.com/isofit/isofit/issues/1010

Two things to consider here. First, if Seps includes off-diagonal elements, the bug in the issue is as described. The `dsymv` discards the lower triangle, and the result is as if input `P` matrix is purely diagonal. **For now, I've used the lower=1 kwarg within the `dsymv` function.**

For an example Seps matrix with off-diagonal elements, the resulting P is a lower-triangle matrix.

<img width="600" height="400" alt="Screenshot 2026-08-13 at 1 39 54 PM" src="https://github.com/user-attachments/assets/4b0065ef-a525-451c-ad8a-890f9586bf6f" />

The result from the matrix-vector multiplication depends on the call.
<img width="600" height="252" alt="Screenshot 2026-08-13 at 1 40 11 PM" src="https://github.com/user-attachments/assets/1e3aed18-14b1-4c5e-be7d-a60f1baa152e" />


However, this issue does not have an operational impact. 

For nominal run cases that use `apply_oe`, off-diagonal elements in the Seps matrix entirely depend on the `H2O_ABSCO` value passed into the config. Previously, we hard-coded this value to be `{"H2O_ABSCO": 0.0}`. As a result, the `Sb` entry at the corresponding index is `0.0`, and the Seps calculation returns a diagonal matrix.

<img width="600" height="400" alt="Screenshot 2026-08-13 at 1 58 41 PM" src="https://github.com/user-attachments/assets/b549f6e2-9f23-4b50-9bd8-65d282a33bf7" />

<img width="600" height="258" alt="Screenshot 2026-08-13 at 1 58 56 PM" src="https://github.com/user-attachments/assets/d0fe3d7a-a33d-4b6e-863c-0a79a641041e" />

Where it gets a little messy is that we were computing `drdn_datmosphereb` (`Kb`) despite effectively turning off atmospheric unknowns. **This PR resolves that by removing `H2O_ABSCO` from the config, circumventing the numerical derivative calculation.**


TODO:
- Testing