### PR TITLE
Multisurface mode indexing bug in AOE if instrument statevector elements are present

### DIFF
--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -542,17 +542,12 @@ class Worker(object):
             # atm_interpolated file
             x_atmosphere = self.rt_state[r, c, :]
 
-            # TODO depricate this iv_idx. Abstract the indexing a bit more
-            # s.t. we can smooth any statevector element by specifying idx
-            # iv_idx here is a relic from a version that
-            # achieved this by using atm_band_names in atm_interpolation
-            # need to improve that implementation
-            iv_idx = self.fm.surface.analytical_iv_idx
-
             # Populate the "background" superpixel
             lbl_idx = int(self.lbl[r, c, 0])
             sub_state = np.zeros(self.fm.nstate)
-            sub_state[self.fm.idx_surface] = self.subs_state[lbl_idx, 0, iv_idx]
+            sub_state[self.fm.idx_surface] = self.subs_state[
+                lbl_idx, 0, self.fm.full_idx
+            ]
             sub_state[self.fm.idx_atmosphere] = x_atmosphere
             sub_state[self.fm.idx_instrument] = self.subs_state[
                 lbl_idx, 0, self.fm.idx_instrument

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -542,16 +542,25 @@ class Worker(object):
             # atm_interpolated file
             x_atmosphere = self.rt_state[r, c, :]
 
+            # TODO depricate this iv_idx. Abstract the indexing a bit more
+            # s.t. we can smooth any statevector element by specifying idx
+            # iv_idx here is a relic from a version that
+            # achieved this by using atm_band_names in atm_interpolation
+            # need to improve that implementation
+            iv_idx = self.fm.surface.analytical_iv_idx
+
             # Populate the "background" superpixel
             lbl_idx = int(self.lbl[r, c, 0])
             sub_state = np.zeros(self.fm.nstate)
             sub_state[self.fm.idx_surface] = self.subs_state[
                 lbl_idx, 0, self.fm.full_idx
-            ]
+            ][iv_idx]
+
             sub_state[self.fm.idx_atmosphere] = x_atmosphere
             sub_state[self.fm.idx_instrument] = self.subs_state[
-                lbl_idx, 0, self.fm.idx_instrument
-            ]
+                lbl_idx, 0, self.fm.full_idx
+            ][self.fm.idx_instrument]
+
             # Enforce non-NaN
             sub_state[np.isnan(sub_state)] = self.fm.init[np.isnan(sub_state)]
 


### PR DESCRIPTION
Issue:

**For the multisurface run mode**, if instrument variables are present in the statevector, `fm.unpack(sub_state)` will incorrectly index the vector. 

Fix:
First index the `sub_state` vector by the indexes present for a given forward model. `fm.unpack` can then be called nominally.



