### PR TITLE
Missing rho_dif_dif resampling for invert_algebraic

### DIFF
--- a/isofit/inversion/inverse_simple.py
+++ b/isofit/inversion/inverse_simple.py
@@ -158,7 +158,11 @@ def invert_algebraic(
     """
     _, rho_init = fm.surface.calc_rfl(x_surface, geom)
 
-    rho_dif_dif = geom.bg_rfl if isinstance(geom.bg_rfl, np.ndarray) else rho_init
+    rho_dif_dif = (
+        fm.upsample(fm.surface.wl, geom.bg_rfl)
+        if isinstance(geom.bg_rfl, np.ndarray)
+        else rho_init
+    )
 
     # Get all radiance terms
     (


### PR DESCRIPTION
This was giving me issues when running the wavelength calibration. This was not hitting the test because it's an issue with the 6c forward model only.