### PR TITLE
Altering order of instrument resampling for partial derivatives w.r.t. the atmosphere

### DIFF
--- a/isofit/core/forward.py
+++ b/isofit/core/forward.py
@@ -694,7 +694,7 @@ class ForwardModel:
             L_dif_dif=L_dif_dif,
             r=r,
             geom=geom,
-        )
+        ) + self.eof_offset(x_instrument)
 
         # Call derivative of rfl wrt surface state, upsample
         drfl_dsurface_hi = self.upsample(
@@ -710,6 +710,7 @@ class ForwardModel:
         # To get the derivative w.r.t. atmosphere
         drdn_datmosphere = self.drdn_datmosphere(
             x_atmosphere,
+            x_instrument,
             geom,
             rho_dir_dir=rho_dir_dir_hi,
             rho_dif_dir=rho_dif_dir_hi,
@@ -806,10 +807,11 @@ class ForwardModel:
             L_dif_dif=L_dif_dif,
             r=r,
             geom=geom,
-        )
+        ) + self.eof_offset(x_instrument)
 
         drdn_datmosphereb = self.drdn_datmosphereb(
             x_atmosphere,
+            x_instrument,
             geom=geom,
             rho_dir_dir=rho_dir_dir_hi,
             rho_dif_dir=rho_dif_dir_hi,
@@ -836,6 +838,7 @@ class ForwardModel:
     def drdn_datmosphere(
         self,
         x_atmosphere,
+        x_instrument,
         geom,
         rho_dir_dir,
         rho_dif_dir,
@@ -879,7 +882,7 @@ class ForwardModel:
                 L_dif_dif,
                 r,
                 geom,
-            )
+            ) + self.eof_offset(x_instrument)
             K_atmosphere.append((rdne - rdn) / eps)
 
         K_atmosphere = np.array(K_atmosphere).T
@@ -889,6 +892,7 @@ class ForwardModel:
     def drdn_datmosphereb(
         self,
         x_atmosphere,
+        x_instrument,
         geom,
         rho_dir_dir,
         rho_dif_dir,
@@ -955,7 +959,7 @@ class ForwardModel:
                         L_dif_dif,
                         r,
                         geom,
-                    )
+                    ) + self.eof_offset(x_instrument)
                     Kb_atmosphere.append((rdne - rdn) / eps)
 
         Kb_atmosphere = np.array(Kb_atmosphere).T


### PR DESCRIPTION
For discussion:

What is the correct order of operations to calculate the Jacobian with respect to the atmospheric variables?

(DEV): 
```python 
dmeas/datmosphere = Instrument.sample((L(x + dx) - L(x)) / dx)

```
where `L(x)` is the modeled radiance calculated at the resolution specified in the atmospheric model at statevector, x.

(Alternative):
```python
dmeas/datmosphere = (Instrument.sample(L(x + dx)) - Instrument.sample(L(x))) / dx
```

Tested with the wavelength calibration:

The two orderings give different results:

<img width="1193" height="290" alt="Screenshot 2026-09-14 at 11 30 43 AM" src="https://github.com/user-attachments/assets/d7942b74-755d-455b-9fde-6551ca697af8" />

Driven by differences in the Jacobians (here calculated at the final state)

<img width="977" height="586" alt="Screenshot 2026-09-14 at 11 26 19 AM" src="https://github.com/user-attachments/assets/6cf66687-e57c-4894-bd1c-65f2b6bc9a4b" />
